### PR TITLE
build: ad-hoc codesign macOS binaries after compile (fix Killed:9 on Apple Silicon)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -217,6 +217,19 @@ else
   exit 1
 fi
 
+# Ad-hoc sign macOS binaries. Apple Silicon SIGKILLs unsigned Mach-O executables
+# (symptom: `interceptor` exits 137 / "Killed: 9" with empty output, daemon never
+# stays up). `bun build --compile` output can land unsigned or with a malformed
+# signature slot, so remove any existing signature then re-sign ad-hoc.
+if [[ "$(uname -s)" == "Darwin" ]] && command -v codesign >/dev/null 2>&1; then
+  for b in dist/interceptor daemon/interceptor-daemon dist/interceptor-bridge; do
+    if [[ -f "$b" ]]; then
+      codesign --remove-signature "$b" 2>/dev/null || true
+      codesign --force --sign - "$b" && echo "  signed (adhoc): $b"
+    fi
+  done
+fi
+
 echo "Build complete."
 echo "  Extension: extension/dist/"
 echo "  Electron extension: extension/dist-mv2/"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -221,13 +221,23 @@ fi
 # (symptom: `interceptor` exits 137 / "Killed: 9" with empty output, daemon never
 # stays up). `bun build --compile` output can land unsigned or with a malformed
 # signature slot, so remove any existing signature then re-sign ad-hoc.
+# No --entitlements here: entitlement enforcement only applies under the
+# hardened runtime, which ad-hoc signing doesn't enable. Release builds are
+# re-signed (--force) with the real identity + entitlements by release.sh.
 if [[ "$(uname -s)" == "Darwin" ]] && command -v codesign >/dev/null 2>&1; then
   for b in dist/interceptor daemon/interceptor-daemon dist/interceptor-bridge; do
     if [[ -f "$b" ]]; then
       codesign --remove-signature "$b" 2>/dev/null || true
       codesign --force --sign - "$b" && echo "  signed (adhoc): $b"
+      codesign --verify --strict "$b"
     fi
   done
+  # Smoke check: the exact failure this signing step fixes is a silent
+  # Killed:9 at first run, so prove the CLI actually executes.
+  if [[ "$TARGET" != "windows" && -x dist/interceptor ]]; then
+    ./dist/interceptor --version >/dev/null
+    echo "  smoke check: dist/interceptor --version OK"
+  fi
 fi
 
 echo "Build complete."


### PR DESCRIPTION
## Problem

On Apple Silicon, macOS SIGKILLs unsigned Mach-O executables. `bun build --compile` output can land unsigned (or with a malformed signature slot), so the built `dist/interceptor` / `daemon/interceptor-daemon` exit **137 ("Killed: 9")** with no output, and the native-messaging daemon never stays up — every `interceptor` command then returns empty.

## Fix

After the build, remove any existing signature and ad-hoc re-sign the produced binaries:

```sh
codesign --remove-signature "$b"; codesign --force --sign - "$b"
```

for `dist/interceptor`, `daemon/interceptor-daemon`, and `dist/interceptor-bridge`. Guarded to macOS with `codesign` present, so it's a no-op on Linux/Windows or CI hosts without codesign. Windows `.exe` outputs are not matched.

## Testing

- **Before:** a freshly built `interceptor --version` exits 137 with empty output; `codesign -dv dist/interceptor` → *"code object is not signed at all."*
- **After:** `interceptor --version` prints the version (exit 0); `codesign -dv` → `Signature=adhoc`; the daemon starts and `interceptor status` reports `daemon: running`.

Ad-hoc signature only (no Developer ID / notarization) — sufficient to stop the OS kill for locally-built binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the macOS build process by automatically re-signing built binaries (when signing tools are available).
  * Added strict signature verification after re-signing and a quick smoke test to confirm the CLI launches successfully (non-Windows builds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->