### PR TITLE
feat(extension): runtime white-label tab-group identity

### DIFF
--- a/.agents/skills/interceptor-browser/references/command-catalog.md
+++ b/.agents/skills/interceptor-browser/references/command-catalog.md
@@ -243,6 +243,15 @@ interceptor capabilities                            # Available input layers
 interceptor reload                                  # After extension changes during dev
 ```
 
+## Branding (white-label)
+
+```bash
+interceptor brand tab-group --title "Acme"                # Rename the managed tab group at runtime
+interceptor brand tab-group --title "Acme" --color blue   # Title + color (grey|blue|red|yellow|green|pink|purple|cyan|orange)
+```
+
+Runtime-configurable — no rebuild, no options page. Resolved from `chrome.storage` (precedence `managed` > `local` > built-in default `interceptor`/`cyan`) and applied live to the tab-strip group. Settable here, from the toolbar popup, or via an enterprise managed policy.
+
 ## Eval (escape hatch)
 
 ```bash

--- a/cli/commands/brand.ts
+++ b/cli/commands/brand.ts
@@ -1,0 +1,40 @@
+/**
+ * cli/commands/brand.ts — runtime white-label of the Chrome tab-group identity.
+ *
+ *   interceptor brand tab-group --title "Acme" [--color blue]
+ *
+ * Emits a no-tab `brand_set_tab_group` action; the daemon relays it to the extension, which writes
+ * `chrome.storage.local.brandTabGroup` and live-retitles the group. No rebuild, no options page.
+ */
+
+type Action = { type: string; [key: string]: unknown }
+
+// Closed Chrome tabGroups color enum — validated CLI-side (fail fast) as well as in the extension.
+const VALID_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"]
+
+function flagVal(args: string[], name: string): string | undefined {
+  const i = args.indexOf(name)
+  return i >= 0 ? args[i + 1] : undefined
+}
+
+export function parseBrandCommand(filtered: string[]): Action {
+  const sub = filtered[1]
+  if (sub !== "tab-group") {
+    console.error('error: usage: interceptor brand tab-group --title <label> [--color <color>]')
+    process.exit(1)
+  }
+
+  const title = flagVal(filtered, "--title")
+  if (!title || title.startsWith("--")) {
+    console.error("error: interceptor brand tab-group requires --title <label>")
+    process.exit(1)
+  }
+
+  const color = flagVal(filtered, "--color") ?? "cyan"
+  if (!VALID_COLORS.includes(color)) {
+    console.error(`error: invalid --color '${color}' (must be one of: ${VALID_COLORS.join(", ")})`)
+    process.exit(1)
+  }
+
+  return { type: "brand_set_tab_group", title, color }
+}

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -259,6 +259,10 @@ Meta:
   interceptor status --explain               Alias for --verbose with extra rationale per component
   interceptor help                           This help text
 
+Branding:
+  interceptor brand tab-group --title <label> [--color <color>]
+                                             White-label the Chrome tab-group label/color at runtime (no rebuild)
+
 macOS App Internals:
   interceptor macos cdp connect <port> [--host H] [--app NAME] [--url HINT]
                                              Attach to an Electron/Chromium app debug port

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -19,6 +19,7 @@ import { parseDataCommand } from "./commands/data"
 import { parseMetaCommand } from "./commands/meta"
 import { parseEvalCommand } from "./commands/eval"
 import { parseSaveCommand } from "./commands/save"
+import { parseBrandCommand } from "./commands/brand"
 import { parseBatchCommand } from "./commands/batch"
 import { parseMonitorCommand } from "./commands/monitor"
 import { parseSceneCommand } from "./commands/scene"
@@ -44,6 +45,7 @@ const DATA_CMDS = new Set(["cookies", "storage", "history", "bookmarks", "downlo
 const META_CMDS = new Set(["status", "reload", "meta", "links", "images", "forms", "info", "page_info", "query", "exists", "count", "table", "attr", "style", "events", "search", "notify", "sessions", "capabilities", "modals", "panels"])
 const EVAL_CMDS = new Set(["eval"])
 const SAVE_CMDS = new Set(["save"])
+const BRAND_CMDS = new Set(["brand"])
 const BATCH_CMDS = new Set(["batch", "raw"])
 const MONITOR_CMDS = new Set(["monitor"])
 const SCENE_CMDS = new Set(["scene"])
@@ -66,7 +68,7 @@ const NO_DAEMON = new Set(["status", "help", "events", "session", "upgrade", "in
 const ALL_KNOWN_CMDS = new Set<string>([
   ...STATE_CMDS, ...ACTION_CMDS, ...NAV_CMDS, ...TAB_CMDS, ...NET_CMDS,
   ...SS_CMDS, ...DATA_CMDS, ...META_CMDS, ...EVAL_CMDS,
-  ...SAVE_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
+  ...SAVE_CMDS, ...BRAND_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
   ...COMPOUND_CMDS, ...OVERRIDE_CMDS, ...MACOS_CMDS,
   ...UPGRADE_CMDS, ...INIT_CMDS, ...RESEARCH_CMDS, ...EXTENSIONS_CMDS,
   "help", "contexts",
@@ -238,6 +240,7 @@ async function main() {
   else if (META_CMDS.has(cmd))   action = await parseMetaCommand(filtered, jsonMode)
   else if (EVAL_CMDS.has(cmd))   action = parseEvalCommand(filtered)
   else if (SAVE_CMDS.has(cmd))   action = parseSaveCommand(filtered)
+  else if (BRAND_CMDS.has(cmd))  action = parseBrandCommand(filtered)
   else if (BATCH_CMDS.has(cmd))  action = parseBatchCommand(filtered)
   else if (MONITOR_CMDS.has(cmd)) action = await parseMonitorCommand(filtered, jsonMode)
   else if (SCENE_CMDS.has(cmd))   action = await parseSceneCommand(filtered, jsonMode)

--- a/cli/version.ts
+++ b/cli/version.ts
@@ -1,6 +1,6 @@
 // Sentinel values used when running from source (`bun run cli`).
 // scripts/build.sh stamps real build values into this file just before
 // each `bun build --compile` and restores it afterwards via `git checkout`.
-export const VERSION = "0.19.0"
+export const VERSION = "0.19.1"
 export const BUILD_SHA = "dev"
 export const BUILD_DATE = "dev"

--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -1,3 +1,45 @@
+// extension/src/background/brand-tab-group.ts
+var VALID_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
+var DEFAULT_TAB_GROUP_TITLE = "interceptor";
+var DEFAULT_TAB_GROUP_COLOR = "cyan";
+var SESSION_PREV_TITLE_KEY = "brandTabGroupPrevTitle";
+var cachedTitle = DEFAULT_TAB_GROUP_TITLE;
+var cachedColor = DEFAULT_TAB_GROUP_COLOR;
+function normalizeColor(color) {
+  return typeof color === "string" && VALID_COLORS.includes(color) ? color : DEFAULT_TAB_GROUP_COLOR;
+}
+function getTabGroupTitle() {
+  return cachedTitle;
+}
+function getTabGroupColor() {
+  return normalizeColor(cachedColor);
+}
+function sessionArea() {
+  const storage = chrome.storage;
+  return storage.session;
+}
+async function getPreviousTitle() {
+  try {
+    const area = sessionArea();
+    if (!area)
+      return;
+    const stored = await area.get(SESSION_PREV_TITLE_KEY);
+    const v = stored?.[SESSION_PREV_TITLE_KEY];
+    return typeof v === "string" ? v : undefined;
+  } catch {
+    return;
+  }
+}
+async function getCandidateTitles() {
+  const titles = new Set;
+  titles.add(cachedTitle);
+  const prev = await getPreviousTitle();
+  if (prev)
+    titles.add(prev);
+  titles.add(DEFAULT_TAB_GROUP_TITLE);
+  return [...titles];
+}
+
 // extension/src/background/tab-group.ts
 var interceptorGroupId = null;
 function hasTabGroupApi() {
@@ -14,9 +56,11 @@ async function ensureInterceptorGroup() {
       interceptorGroupId = null;
     }
   }
-  const groups = await chrome.tabGroups.query({ title: "interceptor" });
-  if (groups.length > 0) {
-    interceptorGroupId = groups[0].id;
+  const candidates = await getCandidateTitles();
+  const groups = await chrome.tabGroups.query({});
+  const match = groups.find((g) => typeof g.title === "string" && candidates.includes(g.title));
+  if (match) {
+    interceptorGroupId = match.id;
     return interceptorGroupId;
   }
   return -1;
@@ -27,7 +71,10 @@ async function addTabToInterceptorGroup(tabId) {
     return -1;
   if (groupId === -1) {
     groupId = await chrome.tabs.group({ tabIds: tabId });
-    await chrome.tabGroups.update(groupId, { title: "interceptor", color: "cyan" });
+    await chrome.tabGroups.update(groupId, {
+      title: getTabGroupTitle(),
+      color: getTabGroupColor()
+    });
     interceptorGroupId = groupId;
   } else {
     await chrome.tabs.group({ tabIds: tabId, groupId });
@@ -2732,6 +2779,14 @@ async function handleMetaActions(action, tabId) {
 `);
       return { success: true, data: formatted || "empty tree" };
     }
+    case "brand_set_tab_group": {
+      const title = typeof action.title === "string" ? action.title.trim() : "";
+      if (!title)
+        return { success: false, error: "brand_set_tab_group requires a non-empty title" };
+      const color = typeof action.color === "string" ? action.color : "cyan";
+      await chrome.storage.local.set({ brandTabGroup: { title, color } });
+      return { success: true, data: { brandTabGroup: { title, color } } };
+    }
   }
   return { success: false, error: `unknown meta action: ${action.type}` };
 }
@@ -3795,7 +3850,7 @@ var EVALUATE_ACTIONS = new Set(["evaluate"]);
 var BINARY_SINK_ACTIONS = new Set(["binary_sink_save"]);
 var STYLE_ACTIONS = new Set(["style_inject", "style_remove"]);
 var FRAME_ACTIONS = new Set(["frames_list", "frames_read_tree"]);
-var META_ACTIONS = new Set(["status", "reload_extension", "capabilities", "cdp_tree"]);
+var META_ACTIONS = new Set(["status", "reload_extension", "capabilities", "cdp_tree", "brand_set_tab_group"]);
 var PASSIVE_NET_ACTIONS = new Set([
   "net_log",
   "net_clear",
@@ -3980,7 +4035,8 @@ function needsTab(type) {
     "monitor_start",
     "monitor_pause",
     "monitor_resume",
-    "monitor_stop"
+    "monitor_stop",
+    "brand_set_tab_group"
   ]);
   return !noTabActions.has(type);
 }

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,7 @@
 import { connectToHost, connectWsChannel, registerAlarmListener, registerSwKeepaliveListener, registerStorageContextListener } from "./background/transport"
 import { registerCdpListeners } from "./background/cdp"
 import { registerTabGroupListeners, ensureInterceptorGroup } from "./background/tab-group"
+import { registerBrandTabGroup } from "./background/brand-tab-group"
 
 // Register all event listeners
 registerCdpListeners()
@@ -8,6 +9,7 @@ registerTabGroupListeners()
 registerAlarmListener()
 registerSwKeepaliveListener()
 registerStorageContextListener()
+registerBrandTabGroup()
 
 // Startup connections
 chrome.runtime.onInstalled.addListener(() => {

--- a/extension/src/background/brand-tab-group.ts
+++ b/extension/src/background/brand-tab-group.ts
@@ -1,0 +1,196 @@
+/**
+ * extension/src/background/brand-tab-group.ts — runtime-configurable Chrome tab-group identity
+ * (the visible tab-strip group `title` + `color`).
+ *
+ * The label/color is resolved at RUNTIME from chrome.storage with precedence
+ * `managed` > `local` > built-in default `{ title: "interceptor", color: "cyan" }`, mirroring the
+ * existing `contextId` storage pattern (see transport.ts). No rebuild, no options page.
+ *
+ * This module is module-load SIDE-EFFECT-FREE. It is transitively bundled into the MV2
+ * `background-electron.js` (background-electron.ts -> transport.ts -> message-dispatch.ts ->
+ * tab-group.ts -> here), so it must NOT touch `chrome.*` at import time. ALL chrome.storage access and
+ * listener registration happens inside `registerBrandTabGroup()` / the accessors, and
+ * `registerBrandTabGroup()` is called ONLY from the MV3 background.ts entry.
+ */
+
+import { ensureInterceptorGroup } from "./tab-group"
+
+// Closed Chrome tabGroups color enum (verified against the tabGroups API docs).
+const VALID_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"] as const
+export type TabGroupColor = (typeof VALID_COLORS)[number]
+
+export const DEFAULT_TAB_GROUP_TITLE = "interceptor"
+export const DEFAULT_TAB_GROUP_COLOR: TabGroupColor = "cyan"
+
+const STORAGE_KEY = "brandTabGroup"
+// "previous" title persisted across an onChanged-woken / restarted service worker so the
+// candidate-title-set re-discovery can find a group that still bears the old label.
+const SESSION_PREV_TITLE_KEY = "brandTabGroupPrevTitle"
+
+export type BrandTabGroup = { title: string; color: TabGroupColor }
+
+// Module-level cache, pre-seeded to the default so the very first SYNC read is never
+// wrong-by-undefined (this literal is the only module-load state; no `chrome.*` here).
+let cachedTitle: string = DEFAULT_TAB_GROUP_TITLE
+let cachedColor: TabGroupColor = DEFAULT_TAB_GROUP_COLOR
+
+/** Validate a color against the closed Chrome enum; invalid -> default `cyan` (never throws). */
+export function normalizeColor(color: unknown): TabGroupColor {
+  return typeof color === "string" && (VALID_COLORS as readonly string[]).includes(color)
+    ? (color as TabGroupColor)
+    : DEFAULT_TAB_GROUP_COLOR
+}
+
+/** Normalize a raw stored value into a complete, valid BrandTabGroup. */
+export function normalizeBrandTabGroup(raw: unknown): BrandTabGroup {
+  const obj = raw && typeof raw === "object" ? (raw as { title?: unknown; color?: unknown }) : {}
+  const title =
+    typeof obj.title === "string" && obj.title.trim().length > 0 ? obj.title : DEFAULT_TAB_GROUP_TITLE
+  return { title, color: normalizeColor(obj.color) }
+}
+
+/** Sync, cache-backed accessor for the resolved tab-group title. */
+export function getTabGroupTitle(): string {
+  return cachedTitle
+}
+
+/** Sync, cache-backed (and re-validated) accessor for the resolved tab-group color. */
+export function getTabGroupColor(): TabGroupColor {
+  return normalizeColor(cachedColor)
+}
+
+// --- storage helpers (ALL chrome.* access lives below, never at module load) ---
+
+/**
+ * Defensive read of a storage area. In some Chromium builds `chrome.storage.managed` is undefined or
+ * its `.get()` rejects when no managed_schema/policy exists; any miss/throw returns undefined so the
+ * resolver falls through `managed` -> `local` -> default and NEVER throws.
+ */
+async function readArea(area: "managed" | "local"): Promise<BrandTabGroup | undefined> {
+  try {
+    const storageArea = (chrome.storage as unknown as Record<string, chrome.storage.StorageArea | undefined>)[area]
+    if (!storageArea || typeof storageArea.get !== "function") return undefined
+    const stored = (await storageArea.get(STORAGE_KEY)) as Record<string, unknown>
+    const raw = stored?.[STORAGE_KEY]
+    if (raw === undefined || raw === null) return undefined
+    return normalizeBrandTabGroup(raw)
+  } catch {
+    return undefined
+  }
+}
+
+/** Resolve the brand with precedence managed > local > default. Never throws. */
+async function resolveBrand(): Promise<BrandTabGroup> {
+  const managed = await readArea("managed")
+  if (managed) return managed
+  const local = await readArea("local")
+  if (local) return local
+  return { title: DEFAULT_TAB_GROUP_TITLE, color: DEFAULT_TAB_GROUP_COLOR }
+}
+
+function sessionArea(): chrome.storage.StorageArea | undefined {
+  const storage = chrome.storage as typeof chrome.storage & { session?: chrome.storage.StorageArea }
+  return storage.session
+}
+
+async function getPreviousTitle(): Promise<string | undefined> {
+  try {
+    const area = sessionArea()
+    if (!area) return undefined
+    const stored = (await area.get(SESSION_PREV_TITLE_KEY)) as Record<string, unknown>
+    const v = stored?.[SESSION_PREV_TITLE_KEY]
+    return typeof v === "string" ? v : undefined
+  } catch {
+    return undefined
+  }
+}
+
+async function setPreviousTitle(title: string): Promise<void> {
+  try {
+    const area = sessionArea()
+    if (!area) return
+    await area.set({ [SESSION_PREV_TITLE_KEY]: title })
+  } catch {}
+}
+
+/**
+ * The candidate title set used by the cross-restart re-discovery path:
+ * { resolved (current cache), previous (from session), default "interceptor" }. Querying this set lets
+ * the adopt path re-adopt a group created under the default or a prior brand, rather than orphaning it
+ * after a retitle + service-worker restart.
+ */
+export async function getCandidateTitles(): Promise<string[]> {
+  const titles = new Set<string>()
+  titles.add(cachedTitle)
+  const prev = await getPreviousTitle()
+  if (prev) titles.add(prev)
+  titles.add(DEFAULT_TAB_GROUP_TITLE)
+  return [...titles]
+}
+
+async function seedCache(): Promise<void> {
+  const resolved = await resolveBrand()
+  cachedTitle = resolved.title
+  cachedColor = resolved.color
+  await setPreviousTitle(cachedTitle)
+}
+
+/**
+ * SW-restart-safe live re-title. On a `brandTabGroup` change: re-resolve the cache, then
+ * ADOPT-THEN-RETITLE — re-discover the existing group via the candidate title set (which now includes
+ * the OLD title) and adopt it into `interceptorGroupId`, then update its title+color in lockstep. A naive
+ * `if (interceptorGroupId !== null) update(...)` guard would skip the retitle on an onChanged-woken SW
+ * and orphan the group.
+ */
+async function onBrandChanged(change: chrome.storage.StorageChange): Promise<void> {
+  const oldVal = change.oldValue
+  const prevTitle =
+    oldVal && typeof oldVal === "object" && typeof (oldVal as { title?: unknown }).title === "string"
+      ? (oldVal as { title: string }).title
+      : cachedTitle
+
+  const resolved = await resolveBrand()
+  cachedTitle = resolved.title
+  cachedColor = resolved.color
+
+  // Make the OLD title discoverable BEFORE re-discovery runs, so ensureInterceptorGroup's candidate
+  // set can still find a group that currently bears the old label.
+  if (prevTitle) await setPreviousTitle(prevTitle)
+
+  // Adopt-then-retitle. ensureInterceptorGroup re-discovers via the candidate set and returns -1 when
+  // the tabGroups API is absent (MV2) or no group exists yet.
+  const gid = await ensureInterceptorGroup()
+  if (gid === -1) {
+    // No group yet — nothing to retitle; the next created group uses the fresh cache. Reset the
+    // session "previous" to the new title so it doesn't linger as a stale candidate.
+    await setPreviousTitle(cachedTitle)
+    return
+  }
+  try {
+    await chrome.tabGroups.update(gid, {
+      title: cachedTitle,
+      color: getTabGroupColor() as `${chrome.tabGroups.Color}`,
+    })
+    // The group now bears the new title; record it as the steady-state "previous".
+    await setPreviousTitle(cachedTitle)
+  } catch {
+    // color/title rejected — already validated, but never let a retitle break grouping.
+  }
+}
+
+/**
+ * Seed the cache on service-worker startup and register the live-update listener. Called ONLY from the
+ * MV3 background.ts entry (never background-electron.ts). Without this call the cache never seeds from
+ * storage and onChanged never fires.
+ */
+export function registerBrandTabGroup(): void {
+  void seedCache()
+  chrome.storage.onChanged.addListener((changes, area) => {
+    // The existing `contextId` listener ignores `managed`; this one handles BOTH `local` and `managed`
+    // so an enterprise policy (deferred) or a local write both drive a live re-title.
+    if (area !== "local" && area !== "managed") return
+    const change = changes[STORAGE_KEY]
+    if (!change) return
+    void onBrandChanged(change)
+  })
+}

--- a/extension/src/background/capabilities/meta.ts
+++ b/extension/src/background/capabilities/meta.ts
@@ -68,6 +68,16 @@ export async function handleMetaActions(
       }).join("\n")
       return { success: true, data: formatted || "empty tree" }
     }
+
+    case "brand_set_tab_group": {
+      // No-tab storage write that drives the runtime tab-group identity. The background
+      // brand-tab-group `onChanged` listener picks this up and live-retitles the group.
+      const title = typeof action.title === "string" ? action.title.trim() : ""
+      if (!title) return { success: false, error: "brand_set_tab_group requires a non-empty title" }
+      const color = typeof action.color === "string" ? action.color : "cyan"
+      await chrome.storage.local.set({ brandTabGroup: { title, color } })
+      return { success: true, data: { brandTabGroup: { title, color } } }
+    }
   }
   return { success: false, error: `unknown meta action: ${action.type}` }
 }

--- a/extension/src/background/message-dispatch.ts
+++ b/extension/src/background/message-dispatch.ts
@@ -46,7 +46,7 @@ export function needsTab(type: string): boolean {
     "bookmark_create", "downloads_search", "browsing_data_remove",
     "session_list", "session_restore", "notification_create", "notification_clear",
     "search_query", "monitor_status", "monitor_start", "monitor_pause", "monitor_resume",
-    "monitor_stop"
+    "monitor_stop", "brand_set_tab_group"
   ])
   return !noTabActions.has(type)
 }

--- a/extension/src/background/router.ts
+++ b/extension/src/background/router.ts
@@ -70,7 +70,7 @@ const EVALUATE_ACTIONS = new Set(["evaluate"])
 const BINARY_SINK_ACTIONS = new Set(["binary_sink_save"])
 const STYLE_ACTIONS = new Set(["style_inject", "style_remove"])
 const FRAME_ACTIONS = new Set(["frames_list", "frames_read_tree"])
-const META_ACTIONS = new Set(["status", "reload_extension", "capabilities", "cdp_tree"])
+const META_ACTIONS = new Set(["status", "reload_extension", "capabilities", "cdp_tree", "brand_set_tab_group"])
 const PASSIVE_NET_ACTIONS = new Set([
   "net_log", "net_clear", "net_headers", "sse_log", "sse_streams", "sse_chunk",
   "set_net_overrides", "clear_net_overrides",

--- a/extension/src/background/tab-group.ts
+++ b/extension/src/background/tab-group.ts
@@ -1,3 +1,5 @@
+import { getTabGroupTitle, getTabGroupColor, getCandidateTitles } from "./brand-tab-group"
+
 export let interceptorGroupId: number | null = null
 
 function hasTabGroupApi(): boolean {
@@ -14,9 +16,14 @@ export async function ensureInterceptorGroup(): Promise<number> {
       interceptorGroupId = null
     }
   }
-  const groups = await chrome.tabGroups.query({ title: "interceptor" })
-  if (groups.length > 0) {
-    interceptorGroupId = groups[0].id
+  // Re-discover by the CANDIDATE TITLE SET (resolved brand + previous + default "interceptor"),
+  // not a single hardcoded title, so a group created under the default or a prior brand is re-adopted
+  // rather than orphaned after a retitle + SW restart.
+  const candidates = await getCandidateTitles()
+  const groups = await chrome.tabGroups.query({})
+  const match = groups.find((g) => typeof g.title === "string" && candidates.includes(g.title))
+  if (match) {
+    interceptorGroupId = match.id
     return interceptorGroupId
   }
   return -1
@@ -27,7 +34,10 @@ export async function addTabToInterceptorGroup(tabId: number): Promise<number> {
   if (groupId === -1 && (!hasTabGroupApi() || typeof chrome.tabs.group !== "function")) return -1
   if (groupId === -1) {
     groupId = await chrome.tabs.group({ tabIds: tabId })
-    await chrome.tabGroups.update(groupId, { title: "interceptor", color: "cyan" })
+    await chrome.tabGroups.update(groupId, {
+      title: getTabGroupTitle(),
+      color: getTabGroupColor() as `${chrome.tabGroups.Color}`,
+    })
     interceptorGroupId = groupId
   } else {
     await chrome.tabs.group({ tabIds: tabId, groupId })

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -25,3 +25,65 @@ resetBtn.addEventListener("click", async () => {
   input.value = ""
   showStatus("Reset — new ID assigned on next connect.")
 })
+
+// --- runtime tab-group label/color (white-label) ---
+// This field is INJECTED dynamically and gated on `chrome.tabGroups`. It is NOT static
+// `popup.html` markup, because `popup.js` is not copied to `dist-mv2/` — a static field would render
+// as an ungated dead control in the shared MV2 Electron-bridge popup. Injecting from here means the
+// field simply does not exist where `popup.js` does not run (MV2) or where tab groups are unavailable.
+const hasTabGroups = !!(chrome as typeof chrome & { tabGroups?: unknown }).tabGroups
+if (hasTabGroups) {
+  const COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"]
+
+  const wrap = document.createElement("div")
+  wrap.style.marginTop = "14px"
+
+  const brandLabel = document.createElement("label")
+  brandLabel.textContent = "Tab group label"
+  brandLabel.htmlFor = "brandTitle"
+  wrap.appendChild(brandLabel)
+
+  const titleInput = document.createElement("input")
+  titleInput.id = "brandTitle"
+  titleInput.type = "text"
+  titleInput.placeholder = "e.g. interceptor"
+  titleInput.spellcheck = false
+  wrap.appendChild(titleInput)
+
+  const colorSelect = document.createElement("select")
+  colorSelect.id = "brandColor"
+  colorSelect.style.cssText =
+    "width:100%;margin-top:6px;padding:6px 8px;border:1px solid #ccc;border-radius:6px;font-size:13px;"
+  for (const c of COLORS) {
+    const opt = document.createElement("option")
+    opt.value = c
+    opt.textContent = c
+    colorSelect.appendChild(opt)
+  }
+  colorSelect.value = "cyan"
+  wrap.appendChild(colorSelect)
+
+  const brandRow = document.createElement("div")
+  brandRow.className = "row"
+  const brandSave = document.createElement("button")
+  brandSave.id = "brandSave"
+  brandSave.textContent = "Save label"
+  brandSave.style.cssText = "background:#0071e3;color:#fff;"
+  brandRow.appendChild(brandSave)
+  wrap.appendChild(brandRow)
+
+  statusEl.parentElement?.insertBefore(wrap, statusEl)
+
+  void chrome.storage.local.get("brandTabGroup").then((stored) => {
+    const b = (stored as { brandTabGroup?: { title?: unknown; color?: unknown } }).brandTabGroup
+    if (b && typeof b.title === "string") titleInput.value = b.title
+    if (b && typeof b.color === "string" && COLORS.includes(b.color)) colorSelect.value = b.color
+  })
+
+  brandSave.addEventListener("click", async () => {
+    const title = titleInput.value.trim()
+    if (!title) { showStatus("Tab group label cannot be empty."); return }
+    await chrome.storage.local.set({ brandTabGroup: { title, color: colorSelect.value } })
+    showStatus("Tab group label saved.")
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/test/brand-tab-group.test.ts
+++ b/test/brand-tab-group.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import {
+  normalizeColor,
+  normalizeBrandTabGroup,
+  DEFAULT_TAB_GROUP_TITLE,
+  DEFAULT_TAB_GROUP_COLOR,
+} from "../extension/src/background/brand-tab-group"
+
+// The accessor module is module-load side-effect-free, so it imports cleanly under bun (no `chrome`
+// global needed) and its pure validators are unit-testable here.
+
+describe("brand-tab-group: color validation", () => {
+  test("every valid Chrome tabGroups color passes through", () => {
+    for (const c of ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"]) {
+      expect(normalizeColor(c)).toBe(c)
+    }
+  })
+
+  test("an invalid color falls back to cyan (never throws)", () => {
+    expect(normalizeColor("teal")).toBe("cyan")
+    expect(normalizeColor("")).toBe("cyan")
+    expect(normalizeColor(undefined)).toBe("cyan")
+    expect(normalizeColor(null)).toBe("cyan")
+    expect(normalizeColor(123)).toBe("cyan")
+  })
+})
+
+describe("brand-tab-group: value normalization + default fallback", () => {
+  test("empty / missing / blank raw resolves to the built-in default", () => {
+    expect(normalizeBrandTabGroup(undefined)).toEqual({
+      title: DEFAULT_TAB_GROUP_TITLE,
+      color: DEFAULT_TAB_GROUP_COLOR,
+    })
+    expect(normalizeBrandTabGroup({})).toEqual({ title: "interceptor", color: "cyan" })
+    expect(normalizeBrandTabGroup({ title: "   " })).toEqual({ title: "interceptor", color: "cyan" })
+  })
+
+  test("valid raw passes through; an invalid color clamps to cyan", () => {
+    expect(normalizeBrandTabGroup({ title: "Acme", color: "blue" })).toEqual({ title: "Acme", color: "blue" })
+    expect(normalizeBrandTabGroup({ title: "Acme", color: "teal" })).toEqual({ title: "Acme", color: "cyan" })
+  })
+
+  test("the default is exactly today's behavior (interceptor / cyan)", () => {
+    expect(DEFAULT_TAB_GROUP_TITLE).toBe("interceptor")
+    expect(DEFAULT_TAB_GROUP_COLOR).toBe("cyan")
+  })
+})
+
+describe("tab-group.ts uses the runtime accessors (not frozen literals)", () => {
+  const src = readFileSync(
+    join(import.meta.dir, "..", "extension", "src", "background", "tab-group.ts"),
+    "utf-8",
+  )
+
+  test("the group create path calls getTabGroupTitle()/getTabGroupColor()", () => {
+    expect(src).toContain("getTabGroupTitle()")
+    expect(src).toContain("getTabGroupColor()")
+  })
+
+  test('the hardcoded { title: "interceptor", color: "cyan" } update literal is gone', () => {
+    expect(src).not.toMatch(/title:\s*"interceptor"\s*,\s*color:\s*"cyan"/)
+  })
+
+  test("the re-discovery query uses the candidate title set, not a single hardcoded title", () => {
+    expect(src).toContain("getCandidateTitles()")
+    expect(src).not.toContain('chrome.tabGroups.query({ title: "interceptor" })')
+  })
+})


### PR DESCRIPTION
Adds `interceptor brand tab-group` — a runtime-configurable white-label of the Chrome tab-strip group identity (the visible group label + color) — and bumps the version surfaces to 0.19.1. No rebuild, no options page.

## `interceptor brand tab-group` — runtime tab-group white-label
`interceptor brand tab-group --title "Acme" [--color blue]` sets the label (and one of the nine Chrome tab-group colors) the extension stamps on every managed tab group. The value resolves at runtime from `chrome.storage` with precedence `managed` > `local` > the built-in default `interceptor`/`cyan`, read through a cached, service-worker-startup-seeded accessor so the hot path never blocks on async storage. With nothing set, behavior is identical to before.

Three set channels, no dedicated settings page:
- the new CLI verb (a no-tab action: CLI → daemon → extension storage write),
- a "Tab group label" field injected into the existing toolbar popup (MV3 only; gated on `chrome.tabGroups` so it never renders as a dead control in the MV2 Electron-bridge popup),
- an enterprise `chrome.storage.managed` policy (read-only, deployer-locked) — the resolver already reads it, so this path is additive.

## Live retitle, restart-safe
A `chrome.storage.onChanged` listener (handling both `local` and `managed`) retitles the existing group immediately. Because the change can wake an idle MV3 service worker, the handler re-discovers the group via a candidate-title set (resolved + previous + default) and adopts-then-retitles in lockstep, so a rename never orphans the old group or spawns a duplicate — including across a service-worker restart. Invalid colors fall back to `cyan` instead of throwing and breaking grouping.

## Safety / scope
- The accessor module is module-load side-effect-free, so it is inert where it is transitively bundled into the MV2 Electron bridge; registration runs only from the MV3 entry.
- No new permissions; the value is purely runtime (no build-time dependency).
- Version bumped to 0.19.1 across `package.json`, `cli/version.ts`, and the extension manifests.

## Tests
New unit coverage for the color validator and value normalization (valid/invalid colors, default fallback), plus a source-assertion that the group create + re-discovery paths use the runtime accessors. Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab group title and color are now customizable at runtime without requiring a rebuild
  * Added CLI command to configure tab group label and color
  * Added UI controls in the popup to manage tab group label and color selection

* **Chores**
  * Version bumped to 0.19.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->