### PR TITLE
Release 0.21.3 — concurrent per-agent tab groups

### DIFF
--- a/.agents/skills/interceptor-browser/SKILL.md
+++ b/.agents/skills/interceptor-browser/SKILL.md
@@ -14,7 +14,8 @@ This installed skill is self-contained. Source checkouts also have `AGENTS.md`, 
 ## Core Rules
 
 - Use compound commands (`open`, `read`, `act`, `inspect`) before low-level verbs.
-- Browser commands operate inside the cyan `interceptor` tab group. Do not use `--any-tab` unless the user explicitly authorizes acting outside that group.
+- Browser commands operate inside managed Interceptor tab groups. Do not use `--any-tab` unless the user explicitly authorizes acting outside those groups.
+- When other agents may share this browser, scope yourself with `--group <label>` on every command (or set `INTERCEPTOR_GROUP` once): your tabs live in their own colored group, resolution never leaves it, and cross-group targets are rejected. Run `interceptor group close <label>` when your job is done; `interceptor group list` shows what's running.
 - `interceptor open <url>` and `interceptor tab new <url>` create background tabs by default. Only `open --activate`, `tab new --activate`, `tab switch <id>`, and `window focus <id>` intentionally move browser focus.
 - If multiple browser profiles are connected, run `interceptor contexts` and pass `--context <id>`.
 - Prefer structured reads (`read`, `tree`, `text`, `inspect`, `scene`) before screenshots. Open `references/screenshot-policy.md` before screenshot-heavy work.

--- a/.agents/skills/interceptor-browser/references/command-catalog.md
+++ b/.agents/skills/interceptor-browser/references/command-catalog.md
@@ -178,6 +178,11 @@ interceptor tab new <url>             # Background tab in the interceptor group
 interceptor tab new <url> --activate  # Explicit foregrounding
 interceptor tab switch <tab-id>
 interceptor tab close <tab-id>
+
+interceptor open <url> --group <label>   # Open into a named per-agent group "<brand>-<label>" (created on first use)
+interceptor read --group <label>         # Any command scopes to that group's tabs; env INTERCEPTOR_GROUP is the fallback
+interceptor group list                   # All live tab groups: label, title, color, tab count
+interceptor group close <label>          # Atomically close every tab in a named group (other groups untouched)
 interceptor window list
 interceptor window new
 interceptor window focus <window-id>                      # Explicit focus move
@@ -187,6 +192,8 @@ interceptor window resize --state maximized               # Don't combine maximi
 ```
 
 Use `--tab <id>` for a specific tab; `--any-tab` only when explicitly authorized.
+
+When several agents share one browser context, give each its own `--group <label>` (or set `INTERCEPTOR_GROUP` once per agent): every command then resolves and acts only within that agent's tab group, `--reuse` reuses only that group's tabs, and cross-group targets are rejected. Labels match `[A-Za-z0-9_-]{1,32}`; pick a color with `--group-color <grey|blue|red|yellow|green|pink|purple|cyan|orange>` on first open. Close your group when the job is done.
 
 ## Cookies / Storage / History / Bookmarks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,7 +100,7 @@ interface AttachmentRecord {
 
 ### Privacy boundary
 
-Focus-follow only attaches to tabs in the cyan **interceptor tab group** (`isTabInInterceptorGroup` in [`extension/src/background/tab-group.ts`](extension/src/background/tab-group.ts)). The user's personal tabs are never auto-attached. This boundary is preserved consistently across `tab new`, `tab switch`, and now focus-follow.
+Focus-follow only attaches to tabs in a **managed tab group** — the default interceptor group or any named per-agent group (`isTabInAnyManagedGroup` in [`extension/src/background/tab-group.ts`](extension/src/background/tab-group.ts)). The user's personal tabs are never auto-attached. This boundary is preserved consistently across `tab new`, `tab switch`, and now focus-follow.
 
 ### Lifecycle events
 
@@ -209,7 +209,17 @@ Framed refs are round-trippable. `parseElementTarget` preserves `frameId` and `r
 
 ### Tab group isolation
 
-[`extension/src/background/tab-group.ts`](extension/src/background/tab-group.ts) maintains the cyan "interceptor" tab group. By default all interceptor commands operate only on tabs in this group; `--any-tab` opts out. Focus-follow respects this boundary.
+[`extension/src/background/tab-group.ts`](extension/src/background/tab-group.ts) maintains the default "interceptor" tab group (runtime-brandable title/color via `interceptor brand tab-group`). By default all interceptor commands operate only on tabs in managed groups; `--any-tab` opts out. Focus-follow respects this boundary.
+
+### Named per-agent tab groups
+
+Multiple agents can share one browser context without touching each other's tabs. `--group <label>` (or the `INTERCEPTOR_GROUP` env var; the flag wins) scopes an invocation to a named group rendered as `<brand>-<label>` on the tab strip with a deterministic per-label color (`--group-color` overrides):
+
+- **Registry** — `tab-group.ts` keeps a `label → groupId` map mirrored to `chrome.storage.session`, whose lifetime exactly matches Chrome's session-scoped group ids. Group creation is serialized per label (concurrent creators join one group instead of minting duplicates), and a `tabGroups.onRemoved` listener purges registry entries when a group is closed — by an agent or by hand.
+- **Scoped dispatch** — each group has its own auto-target key (`activeTabId:<label>`); grouped requests resolve strictly within their group (stored target → most-recent group tab → error) and never fall back to the browser-active tab. The privacy gate requires the target tab to be in the *caller's* group, and the auto-target is persisted only after that gate passes. Ungrouped requests require membership in *any* managed group, preserving single-agent behavior.
+- **Lifecycle** — `interceptor group list` reports every live group (label, title, color, tab count); `interceptor group close <label>` closes exactly that group's tabs in one atomic `tabs.remove`. Closing one group never affects another, so a human can clean up after a dead agent while others keep running.
+- **Group identity travels inside the action payload** (`action.group`), injected at the CLI transport choke point — the daemon relays it untouched, and browsers without the `tabGroups` API (the MV2 Electron bridge, Firefox) degrade gracefully to ungrouped behavior.
+- **Monitor integration** — child tabs inherit their opener's group, and monitor auto-attach accepts any managed group.
 
 ### Transport routing (daemon)
 

--- a/cli/commands/group.ts
+++ b/cli/commands/group.ts
@@ -1,0 +1,33 @@
+/**
+ * cli/commands/group.ts — named per-agent tab groups.
+ *
+ *   interceptor group list             All live tab groups (label, title, color, tab count)
+ *   interceptor group close <label>    Atomically close every tab in a named group
+ *
+ * Scoping day-to-day work into a group is the global `--group <label>` flag
+ * (or $INTERCEPTOR_GROUP), not a subcommand here.
+ */
+
+import { GROUP_LABEL_RE } from "../parse"
+
+type Action = { type: string; [key: string]: unknown }
+
+export function parseGroupCommand(filtered: string[]): Action {
+  const sub = filtered[1]
+
+  if (sub === "list" || sub === undefined) {
+    return { type: "group_list" }
+  }
+
+  if (sub === "close") {
+    const label = filtered[2]
+    if (!label || !GROUP_LABEL_RE.test(label)) {
+      console.error("error: usage: interceptor group close <label>   (label: [A-Za-z0-9_-]{1,32})")
+      process.exit(1)
+    }
+    return { type: "group_close", label }
+  }
+
+  console.error("error: usage: interceptor group list | interceptor group close <label>")
+  process.exit(1)
+}

--- a/cli/global-flags.ts
+++ b/cli/global-flags.ts
@@ -21,6 +21,18 @@ export function buildFilteredArgs(args: string[]): string[] {
     if (args[ctxIdx + 1] !== undefined) skipIndices.add(ctxIdx + 1)
   }
 
+  const groupIdx = args.indexOf("--group")
+  if (groupIdx !== -1) {
+    skipIndices.add(groupIdx)
+    if (args[groupIdx + 1] !== undefined) skipIndices.add(groupIdx + 1)
+  }
+
+  const groupColorIdx = args.indexOf("--group-color")
+  if (groupColorIdx !== -1) {
+    skipIndices.add(groupColorIdx)
+    if (args[groupColorIdx + 1] !== undefined) skipIndices.add(groupColorIdx + 1)
+  }
+
   return args.filter((arg, index) => {
     if (skipIndices.has(index)) return false
     if (arg === "--json") return index > 1

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -64,6 +64,8 @@ Flags:
   -V, --version                       Print version, build SHA, and build date
   --json                              Output as JSON
   --context <id>                      Target a specific browser context (see: interceptor contexts)
+  --group <label>                     Scope this command to a named tab group (per-agent isolation; env: INTERCEPTOR_GROUP)
+  --group-color <color>               Color for the group when it is first created (default: auto from label)
 
 Compound (agent-optimized):
   interceptor open <url>                     Open URL in a background tab (default), wait, return tree + text
@@ -309,6 +311,11 @@ Meta:
 Branding:
   interceptor brand tab-group --title <label> [--color <color>]
                                              White-label the Chrome tab-group label/color at runtime (no rebuild)
+
+Tab groups (per-agent isolation):
+  interceptor open <url> --group <label>     Open into the named group "<brand>-<label>" (created on first use)
+  interceptor group list                     All live tab groups: label, title, color, tab count
+  interceptor group close <label>            Atomically close every tab in a named group (other groups untouched)
 
 macOS App Internals:
   interceptor macos cdp connect <port> [--host H] [--app NAME] [--url HINT]

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,7 +1,7 @@
 import { HELP, helpForCommand } from "./help"
-import { parseTabFlag, parseContextFlag } from "./parse"
+import { parseTabFlag, parseContextFlag, parseGroupFlag, parseGroupColorFlag } from "./parse"
 import { formatState, formatTabs, formatCookies, formatResult } from "./format"
-import { sendCommand, sendCommandWs, type DaemonResult, type DaemonResponse } from "./transport"
+import { sendCommand, sendCommandWs, setGlobalGroup, type DaemonResult, type DaemonResponse } from "./transport"
 import { fromPassive, writeExport, type PassiveNetEntry, type ExportFormat } from "../shared/exports"
 import {
   attachMonitorTaskSource,
@@ -20,6 +20,7 @@ import { parseMetaCommand } from "./commands/meta"
 import { parseEvalCommand } from "./commands/eval"
 import { parseSaveCommand } from "./commands/save"
 import { parseBrandCommand } from "./commands/brand"
+import { parseGroupCommand } from "./commands/group"
 import { parseBatchCommand } from "./commands/batch"
 import { parseMonitorCommand } from "./commands/monitor"
 import { parseSceneCommand } from "./commands/scene"
@@ -47,6 +48,7 @@ const META_CMDS = new Set(["status", "reload", "meta", "links", "images", "forms
 const EVAL_CMDS = new Set(["eval"])
 const SAVE_CMDS = new Set(["save"])
 const BRAND_CMDS = new Set(["brand"])
+const GROUP_CMDS = new Set(["group"])
 const BATCH_CMDS = new Set(["batch", "raw"])
 const MONITOR_CMDS = new Set(["monitor"])
 const SCENE_CMDS = new Set(["scene"])
@@ -70,7 +72,7 @@ const NO_DAEMON = new Set(["status", "help", "events", "session", "upgrade", "in
 const ALL_KNOWN_CMDS = new Set<string>([
   ...STATE_CMDS, ...ACTION_CMDS, ...NAV_CMDS, ...TAB_CMDS, ...NET_CMDS,
   ...SS_CMDS, ...DATA_CMDS, ...META_CMDS, ...EVAL_CMDS,
-  ...SAVE_CMDS, ...BRAND_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
+  ...SAVE_CMDS, ...BRAND_CMDS, ...GROUP_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
   ...COMPOUND_CMDS, ...OVERRIDE_CMDS, ...MACOS_CMDS, ...IOS_CMDS,
   ...UPGRADE_CMDS, ...INIT_CMDS, ...RESEARCH_CMDS, ...EXTENSIONS_CMDS,
   "help", "contexts",
@@ -102,6 +104,10 @@ async function main() {
   const anyTab = args.includes("--any-tab")
   const globalTabId = parseTabFlag(args)
   const globalContextId = parseContextFlag(args)
+  // --group / $INTERCEPTOR_GROUP scopes this invocation to a named tab
+  // group. Injected into every outgoing action at the transport choke point, so
+  // simple, compound, and looping command paths are all covered.
+  setGlobalGroup(parseGroupFlag(args), parseGroupColorFlag(args))
 
   // Build filtered args (strip global flags). NB: --json is dual-purpose —
   // it can be a global "emit JSON output" boolean OR a domain-specific
@@ -252,6 +258,7 @@ async function main() {
   else if (EVAL_CMDS.has(cmd))   action = parseEvalCommand(filtered)
   else if (SAVE_CMDS.has(cmd))   action = parseSaveCommand(filtered)
   else if (BRAND_CMDS.has(cmd))  action = parseBrandCommand(filtered)
+  else if (GROUP_CMDS.has(cmd))  action = parseGroupCommand(filtered)
   else if (BATCH_CMDS.has(cmd))  action = parseBatchCommand(filtered)
   else if (MONITOR_CMDS.has(cmd)) action = await parseMonitorCommand(filtered, jsonMode)
   else if (SCENE_CMDS.has(cmd))   action = await parseSceneCommand(filtered, jsonMode)

--- a/cli/parse.ts
+++ b/cli/parse.ts
@@ -41,3 +41,40 @@ export function parseContextFlag(args: string[]): string | undefined {
   }
   return args[idx + 1]
 }
+
+// per-agent named tab groups. Labels become part of a tab-strip title.
+export const GROUP_LABEL_RE = /^[A-Za-z0-9_-]{1,32}$/
+
+/** --group <label>, falling back to $INTERCEPTOR_GROUP (flag wins). */
+export function parseGroupFlag(args: string[], env: Record<string, string | undefined> = process.env): string | undefined {
+  const idx = args.indexOf("--group")
+  let label: string | undefined
+  if (idx !== -1) {
+    if (!args[idx + 1] || args[idx + 1].startsWith("--")) {
+      console.error("error: --group requires a label")
+      process.exit(1)
+    }
+    label = args[idx + 1]
+  } else if (env.INTERCEPTOR_GROUP) {
+    label = env.INTERCEPTOR_GROUP
+  }
+  if (label !== undefined && !GROUP_LABEL_RE.test(label)) {
+    console.error(`error: invalid group label '${label}' — must match [A-Za-z0-9_-]{1,32}`)
+    process.exit(1)
+  }
+  return label
+}
+
+const GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"]
+
+/** --group-color <color>, validated against the closed Chrome tabGroups enum. */
+export function parseGroupColorFlag(args: string[]): string | undefined {
+  const idx = args.indexOf("--group-color")
+  if (idx === -1) return undefined
+  const color = args[idx + 1]
+  if (!color || !GROUP_COLORS.includes(color)) {
+    console.error(`error: invalid --group-color '${color ?? ""}' (must be one of: ${GROUP_COLORS.join(", ")})`)
+    process.exit(1)
+  }
+  return color
+}

--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -72,7 +72,28 @@ export type DaemonResponse = {
   result: DaemonResult
 }
 
-export function sendCommand(action: Action, tabId?: number, contextId?: string): Promise<DaemonResponse> {
+// the per-invocation group scope (--group / $INTERCEPTOR_GROUP), set once
+// by cli/index.ts and injected into every outgoing action here — the single choke
+// point every command path (simple, compound, override, tail loops) funnels
+// through. The group rides INSIDE the action payload because the daemon relays
+// `{id, action, tabId}` verbatim to the extension.
+let globalGroup: string | undefined
+let globalGroupColor: string | undefined
+
+export function setGlobalGroup(group?: string, groupColor?: string): void {
+  globalGroup = group
+  globalGroupColor = groupColor
+}
+
+function withGroup(action: Action): Action {
+  if (!globalGroup || action.group !== undefined) return action
+  const scoped: Action = { ...action, group: globalGroup }
+  if (globalGroupColor && scoped.groupColor === undefined) scoped.groupColor = globalGroupColor
+  return scoped
+}
+
+export function sendCommand(rawAction: Action, tabId?: number, contextId?: string): Promise<DaemonResponse> {
+  const action = withGroup(rawAction)
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID()
     const shortId = id.slice(0, 8)
@@ -141,7 +162,8 @@ export function sendCommand(action: Action, tabId?: number, contextId?: string):
   })
 }
 
-export function sendCommandWs(action: Action, tabId?: number, contextId?: string): Promise<DaemonResponse> {
+export function sendCommandWs(rawAction: Action, tabId?: number, contextId?: string): Promise<DaemonResponse> {
+  const action = withGroup(rawAction)
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID()
     const shortId = id.slice(0, 8)

--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -45,6 +45,136 @@ var interceptorGroupId = null;
 function hasTabGroupApi() {
   return !!chrome.tabGroups && typeof chrome.tabGroups.query === "function";
 }
+var GROUP_LABEL_RE = /^[A-Za-z0-9_-]{1,32}$/;
+var SESSION_NAMED_GROUPS_KEY = "namedTabGroups";
+var namedGroups = new Map;
+var namedGroupsHydrated = false;
+function sessionArea2() {
+  const storage = chrome.storage;
+  return storage.session;
+}
+async function hydrateNamedGroups() {
+  if (namedGroupsHydrated)
+    return;
+  namedGroupsHydrated = true;
+  try {
+    const area = sessionArea2();
+    if (!area)
+      return;
+    const stored = await area.get(SESSION_NAMED_GROUPS_KEY);
+    const raw = stored?.[SESSION_NAMED_GROUPS_KEY];
+    if (raw && typeof raw === "object") {
+      for (const [label, gid] of Object.entries(raw)) {
+        if (GROUP_LABEL_RE.test(label) && typeof gid === "number")
+          namedGroups.set(label, gid);
+      }
+    }
+  } catch {}
+}
+async function persistNamedGroups() {
+  try {
+    const area = sessionArea2();
+    if (!area)
+      return;
+    await area.set({ [SESSION_NAMED_GROUPS_KEY]: Object.fromEntries(namedGroups) });
+  } catch {}
+}
+function groupTitleFor(label) {
+  return `${getTabGroupTitle()}-${label}`;
+}
+function colorForLabel(label) {
+  let h = 0;
+  for (let i = 0;i < label.length; i++)
+    h = h * 31 + label.charCodeAt(i) >>> 0;
+  return VALID_COLORS[h % VALID_COLORS.length];
+}
+async function purgeNamedGroupEntry(label) {
+  namedGroups.delete(label);
+  await persistNamedGroups();
+  try {
+    const area = sessionArea2();
+    if (area)
+      await area.remove(`activeTabId:${label}`);
+  } catch {}
+}
+async function ensureNamedGroup(label) {
+  if (!hasTabGroupApi())
+    return -1;
+  await hydrateNamedGroups();
+  const known = namedGroups.get(label);
+  if (known !== undefined) {
+    try {
+      await chrome.tabGroups.get(known);
+      return known;
+    } catch {
+      await purgeNamedGroupEntry(label);
+    }
+  }
+  const title = groupTitleFor(label);
+  const groups = await chrome.tabGroups.query({});
+  const match = groups.find((g) => g.title === title);
+  if (match) {
+    namedGroups.set(label, match.id);
+    await persistNamedGroups();
+    return match.id;
+  }
+  return -1;
+}
+function addTabToNamedGroup(tabId, label, colorOverride) {
+  return serializeGroupAdd(label, () => addTabToNamedGroupSerialized(tabId, label, colorOverride));
+}
+async function addTabToNamedGroupSerialized(tabId, label, colorOverride) {
+  if (!hasTabGroupApi() || typeof chrome.tabs.group !== "function")
+    return -1;
+  let groupId = await ensureNamedGroup(label);
+  if (groupId === -1) {
+    groupId = await chrome.tabs.group({ tabIds: tabId });
+    const color = typeof colorOverride === "string" && VALID_COLORS.includes(colorOverride) ? normalizeColor(colorOverride) : colorForLabel(label);
+    await chrome.tabGroups.update(groupId, {
+      title: groupTitleFor(label),
+      color
+    });
+    namedGroups.set(label, groupId);
+    await persistNamedGroups();
+  } else {
+    await chrome.tabs.group({ tabIds: tabId, groupId });
+  }
+  return groupId;
+}
+async function isTabInNamedGroup(tabId, label) {
+  if (!hasTabGroupApi())
+    return true;
+  const groupId = await ensureNamedGroup(label);
+  if (groupId === -1)
+    return false;
+  const tab = await chrome.tabs.get(tabId);
+  return tab.groupId === groupId;
+}
+async function isTabInAnyManagedGroup(tabId) {
+  if (!hasTabGroupApi())
+    return true;
+  const tab = await chrome.tabs.get(tabId);
+  if (interceptorGroupId === null)
+    await ensureInterceptorGroup();
+  if (interceptorGroupId !== null && tab.groupId === interceptorGroupId)
+    return true;
+  await hydrateNamedGroups();
+  for (const gid of namedGroups.values()) {
+    if (tab.groupId === gid)
+      return true;
+  }
+  return false;
+}
+function anyManagedGroupKnown() {
+  return interceptorGroupId !== null || namedGroups.size > 0;
+}
+function labelForGroupId(groupId) {
+  for (const [label, gid] of namedGroups) {
+    if (gid === groupId)
+      return label;
+  }
+  return null;
+}
 async function ensureInterceptorGroup() {
   if (!hasTabGroupApi())
     return -1;
@@ -65,7 +195,21 @@ async function ensureInterceptorGroup() {
   }
   return -1;
 }
-async function addTabToInterceptorGroup(tabId) {
+var groupAddChains = new Map;
+function serializeGroupAdd(key, op) {
+  const prev = groupAddChains.get(key) ?? Promise.resolve(-1);
+  const next = prev.then(op, op);
+  groupAddChains.set(key, next);
+  next.finally(() => {
+    if (groupAddChains.get(key) === next)
+      groupAddChains.delete(key);
+  }).catch(() => {});
+  return next;
+}
+function addTabToInterceptorGroup(tabId) {
+  return serializeGroupAdd("", () => addTabToInterceptorGroupSerialized(tabId));
+}
+async function addTabToInterceptorGroupSerialized(tabId) {
   let groupId = await ensureInterceptorGroup();
   if (groupId === -1 && (!hasTabGroupApi() || typeof chrome.tabs.group !== "function"))
     return -1;
@@ -80,14 +224,6 @@ async function addTabToInterceptorGroup(tabId) {
     await chrome.tabs.group({ tabIds: tabId, groupId });
   }
   return groupId;
-}
-async function isTabInInterceptorGroup(tabId) {
-  if (!hasTabGroupApi())
-    return true;
-  const tab = await chrome.tabs.get(tabId);
-  if (interceptorGroupId === null)
-    await ensureInterceptorGroup();
-  return interceptorGroupId !== null && tab.groupId === interceptorGroupId;
 }
 var SENSITIVE_ACTIONS = new Set([
   "evaluate",
@@ -1537,12 +1673,19 @@ async function handleCanvasActions(action, tabId) {
 }
 
 // extension/src/background/capabilities/tabs.ts
+function activeTabKey(group) {
+  return group ? `activeTabId:${group}` : "activeTabId";
+}
 async function handleTabActions(action, tabId) {
   switch (action.type) {
     case "tab_create": {
       const targetUrl = action.url || "about:blank";
+      const group = typeof action.group === "string" && action.group.length > 0 ? action.group : undefined;
+      if (group && !GROUP_LABEL_RE.test(group)) {
+        return { success: false, error: `invalid group label '${group}' — must match [A-Za-z0-9_-]{1,32}` };
+      }
       if (action.reuse) {
-        const groupId = await ensureInterceptorGroup();
+        const groupId = group ? await ensureNamedGroup(group) : await ensureInterceptorGroup();
         if (groupId !== -1) {
           const groupTabs = await chrome.tabs.query({ groupId });
           if (groupTabs.length > 0) {
@@ -1556,10 +1699,10 @@ async function handleTabActions(action, tabId) {
                   updateProps.active = true;
                 const updated = await chrome.tabs.update(candidate.id, updateProps);
                 await waitForTabLoad(candidate.id);
-                await chrome.storage.session.set({ activeTabId: candidate.id });
+                await chrome.storage.session.set({ [activeTabKey(group)]: candidate.id });
                 return {
                   success: true,
-                  data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, reused: true }
+                  data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, group, reused: true }
                 };
               } catch {}
             }
@@ -1569,18 +1712,21 @@ async function handleTabActions(action, tabId) {
       const shouldActivate = action.active === true;
       const newTab = await chrome.tabs.create({ url: targetUrl, active: shouldActivate });
       if (newTab.id) {
-        const groupId = await addTabToInterceptorGroup(newTab.id);
-        await chrome.storage.session.set({ activeTabId: newTab.id });
-        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, reused: false } };
+        const groupId = group ? await addTabToNamedGroup(newTab.id, group, action.groupColor) : await addTabToInterceptorGroup(newTab.id);
+        await chrome.storage.session.set({ [activeTabKey(group)]: newTab.id });
+        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, group, reused: false } };
       }
       return { success: true, data: { tabId: newTab.id, url: newTab.url, reused: false } };
     }
     case "tab_close": {
       const closedId = action.tabId || tabId;
       await chrome.tabs.remove(closedId);
-      const stored = await chrome.storage.session.get("activeTabId");
-      if (stored.activeTabId === closedId)
-        await chrome.storage.session.remove("activeTabId");
+      const keys = ["activeTabId", typeof action.group === "string" ? activeTabKey(action.group) : null].filter((k) => !!k);
+      const stored = await chrome.storage.session.get(keys);
+      for (const key of keys) {
+        if (stored[key] === closedId)
+          await chrome.storage.session.remove(key);
+      }
       return { success: true };
     }
     case "tab_switch": {
@@ -1591,6 +1737,8 @@ async function handleTabActions(action, tabId) {
     case "tab_list": {
       const tabs = await chrome.tabs.query({});
       await ensureInterceptorGroup();
+      await hydrateNamedGroups();
+      const namedIds = new Set(namedGroups.values());
       const tabData = tabs.map((t) => ({
         id: t.id,
         url: t.url,
@@ -1600,9 +1748,55 @@ async function handleTabActions(action, tabId) {
         muted: t.mutedInfo?.muted,
         pinned: t.pinned,
         groupId: t.groupId,
-        managed: interceptorGroupId !== null && t.groupId === interceptorGroupId
+        managed: interceptorGroupId !== null && t.groupId === interceptorGroupId || namedIds.has(t.groupId),
+        group: labelForGroupId(t.groupId)
       }));
       return { success: true, data: tabData };
+    }
+    case "group_list": {
+      if (!chrome.tabGroups || typeof chrome.tabGroups.query !== "function") {
+        return { success: true, data: [] };
+      }
+      await ensureInterceptorGroup();
+      await hydrateNamedGroups();
+      const live = await chrome.tabGroups.query({});
+      const prefix = `${groupTitleFor("")}`;
+      for (const g of live) {
+        if (typeof g.title !== "string" || !g.title.startsWith(prefix))
+          continue;
+        const label = g.title.slice(prefix.length);
+        if (GROUP_LABEL_RE.test(label) && labelForGroupId(g.id) === null && g.id !== interceptorGroupId) {
+          await ensureNamedGroup(label);
+        }
+      }
+      const data = await Promise.all(live.map(async (g) => {
+        const groupTabs = await chrome.tabs.query({ groupId: g.id });
+        return {
+          groupId: g.id,
+          title: g.title,
+          color: g.color,
+          tabCount: groupTabs.length,
+          label: labelForGroupId(g.id),
+          default: interceptorGroupId !== null && g.id === interceptorGroupId,
+          managed: interceptorGroupId !== null && g.id === interceptorGroupId || labelForGroupId(g.id) !== null
+        };
+      }));
+      return { success: true, data };
+    }
+    case "group_close": {
+      const label = action.label;
+      if (!label || !GROUP_LABEL_RE.test(label)) {
+        return { success: false, error: `group_close requires a valid label (got '${label ?? ""}')` };
+      }
+      const groupId = await ensureNamedGroup(label);
+      if (groupId === -1) {
+        return { success: false, error: `group '${label}' not found` };
+      }
+      const groupTabs = await chrome.tabs.query({ groupId });
+      const ids = groupTabs.map((t) => t.id).filter((id) => typeof id === "number");
+      if (ids.length > 0)
+        await chrome.tabs.remove(ids);
+      return { success: true, data: { label, groupId, closedTabs: ids.length } };
     }
     case "tab_duplicate": {
       const dup = await chrome.tabs.duplicate(tabId);
@@ -1715,7 +1909,8 @@ async function handleWindowActions(action, _tabId) {
         const firstTab = win.tabs?.[0];
         let groupId;
         if (firstTab?.id && !action.incognito) {
-          groupId = await addTabToInterceptorGroup(firstTab.id);
+          const group = typeof action.group === "string" && GROUP_LABEL_RE.test(action.group) ? action.group : undefined;
+          groupId = group ? await addTabToNamedGroup(firstTab.id, group, action.groupColor) : await addTabToInterceptorGroup(firstTab.id);
         }
         return {
           success: true,
@@ -3050,6 +3245,18 @@ async function handleCdpNetworkActions(action, tabId) {
 }
 
 // extension/src/background/capabilities/monitor.ts
+async function adoptChildTab(childTabId, openerTabId) {
+  try {
+    if (openerTabId !== undefined && chrome.tabGroups) {
+      const opener = await chrome.tabs.get(openerTabId);
+      if (opener.groupId !== -1 && await isTabInAnyManagedGroup(openerTabId)) {
+        await chrome.tabs.group({ tabIds: childTabId, groupId: opener.groupId });
+        return;
+      }
+    }
+  } catch {}
+  await addTabToInterceptorGroup(childTabId);
+}
 var FOCUS_SWITCH_GUARD_MS = 2000;
 var sessions = new Map;
 var activeSessionByTab = new Map;
@@ -3252,7 +3459,7 @@ function registerWebNavListenersOnce() {
     if (pendingChild) {
       const session2 = sessions.get(pendingChild.sessionId);
       if (session2 && !session2.paused) {
-        addTabToInterceptorGroup(details.tabId).catch(() => {});
+        adoptChildTab(details.tabId, pendingChild.openerTabId).catch(() => {});
         switchToAttachment(session2, createAttachment(details.tabId, details.documentId, details.frameId, details.url, details.documentLifecycle, "child_tab", pendingChild.openerTabId), "child_tab");
         emitMonEvent(session2, "nav", {
           u: details.url,
@@ -3372,7 +3579,7 @@ async function handleFocusActivated(tabId) {
     return;
   let inGroup = false;
   try {
-    inGroup = await isTabInInterceptorGroup(tabId);
+    inGroup = await isTabInAnyManagedGroup(tabId);
   } catch {
     return;
   }
@@ -3543,7 +3750,19 @@ function monitorRuntimeMessageListener(msg, sender, sendResponse) {
   }
   return true;
 }
-async function resolveTabForMonitor() {
+async function resolveTabForMonitor(group) {
+  if (group) {
+    const namedGroupId = await ensureNamedGroup(group);
+    if (namedGroupId !== -1) {
+      const tabs = await chrome.tabs.query({ groupId: namedGroupId });
+      if (tabs.length > 0) {
+        const active = tabs.find((tab) => tab.active) || tabs[0];
+        if (active.id)
+          return { tabId: active.id };
+      }
+    }
+    return { error: `group '${group}' has no tabs — open one with 'interceptor open <url> --group ${group}'` };
+  }
   const groupId = await ensureInterceptorGroup();
   if (groupId !== -1) {
     const tabs = await chrome.tabs.query({ groupId });
@@ -3555,7 +3774,7 @@ async function resolveTabForMonitor() {
   }
   const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (activeTab?.id) {
-    const inGroup = await isTabInInterceptorGroup(activeTab.id);
+    const inGroup = await isTabInAnyManagedGroup(activeTab.id);
     if (inGroup)
       return { tabId: activeTab.id };
   }
@@ -3578,7 +3797,7 @@ async function handleMonitorActions(action, tabId) {
     case "monitor_start": {
       let resolvedTabId = tabId;
       if (!resolvedTabId) {
-        const resolved = await resolveTabForMonitor();
+        const resolved = await resolveTabForMonitor(typeof action.group === "string" && action.group.length > 0 ? action.group : undefined);
         if (resolved.error || !resolved.tabId) {
           return { success: false, error: resolved.error || "no interceptor-managed tab found" };
         }
@@ -3856,7 +4075,9 @@ var TAB_ACTIONS = new Set([
   "tab_group",
   "tab_ungroup",
   "tab_move",
-  "tab_discard"
+  "tab_discard",
+  "group_list",
+  "group_close"
 ]);
 var WINDOW_ACTIONS = new Set([
   "window_create",
@@ -4063,7 +4284,9 @@ var NO_TAB_ACTIONS = new Set([
   "monitor_pause",
   "monitor_resume",
   "monitor_stop",
-  "brand_set_tab_group"
+  "brand_set_tab_group",
+  "group_list",
+  "group_close"
 ]);
 function needsTab(type) {
   return !NO_TAB_ACTIONS.has(type);
@@ -4075,16 +4298,20 @@ var messageQueue = [];
 var EXT_REQUEST_TIMEOUT_MS = 180000;
 var EXT_LONG_REQUEST_TIMEOUT_MS = 600000;
 var pendingRequests = new Map;
-async function getActiveTabId() {
-  const storage = chrome.storage;
-  const area = storage.session ?? chrome.storage.local;
-  const stored = await area.get("activeTabId");
-  return stored.activeTabId;
+function activeTabKey2(group) {
+  return group ? `activeTabId:${group}` : "activeTabId";
 }
-async function setActiveTabId(tabId) {
+async function getActiveTabId(group) {
   const storage = chrome.storage;
   const area = storage.session ?? chrome.storage.local;
-  await area.set({ activeTabId: tabId });
+  const key = activeTabKey2(group);
+  const stored = await area.get(key);
+  return stored[key];
+}
+async function setActiveTabId(tabId, group) {
+  const storage = chrome.storage;
+  const area = storage.session ?? chrome.storage.local;
+  await area.set({ [activeTabKey2(group)]: tabId });
 }
 function drainMessageQueue() {
   while (messageQueue.length > 0) {
@@ -4134,8 +4361,38 @@ async function handleDaemonMessage(msg) {
   });
   const action = msg.action;
   let tabId = msg.tabId;
+  const fail = (error) => {
+    clearTimeout(requestTimer);
+    pendingRequests.delete(msg.id);
+    sendToHost({ id: msg.id, result: { success: false, error } }, respondViaWs);
+  };
+  const groupLabel = typeof action.group === "string" && action.group.length > 0 ? action.group : undefined;
+  if (groupLabel && !GROUP_LABEL_RE.test(groupLabel)) {
+    fail(`invalid group label '${groupLabel}' — must match [A-Za-z0-9_-]{1,32}`);
+    return;
+  }
   if (!tabId && needsTab(action.type)) {
-    tabId = await getActiveTabId();
+    tabId = await getActiveTabId(groupLabel);
+    if (tabId && groupLabel) {
+      let stillInGroup = false;
+      try {
+        stillInGroup = await isTabInNamedGroup(tabId, groupLabel);
+      } catch {}
+      if (!stillInGroup)
+        tabId = undefined;
+    }
+  }
+  if (!tabId && needsTab(action.type) && groupLabel) {
+    const groupId = await ensureNamedGroup(groupLabel);
+    if (groupId !== -1) {
+      const groupTabs = await chrome.tabs.query({ groupId });
+      const candidate = groupTabs.filter((t) => typeof t.id === "number").sort((a, b) => b.id - a.id)[0];
+      tabId = candidate?.id;
+    }
+    if (!tabId) {
+      fail(`group '${groupLabel}' has no tabs — open one with 'interceptor open <url> --group ${groupLabel}'`);
+      return;
+    }
   }
   if (!tabId && needsTab(action.type)) {
     const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -4144,28 +4401,26 @@ async function handleDaemonMessage(msg) {
       setActiveTabId(tabId);
   }
   if (!tabId && needsTab(action.type)) {
-    clearTimeout(requestTimer);
-    pendingRequests.delete(msg.id);
-    sendToHost({ id: msg.id, result: { success: false, error: "no active tab" } }, respondViaWs);
+    fail("no active tab");
     return;
   }
-  if (tabId)
-    setActiveTabId(tabId);
   if (tabId && needsTab(action.type) && !action.anyTab) {
-    const inGroup = await isTabInInterceptorGroup(tabId);
-    if (!inGroup && interceptorGroupId !== null) {
-      clearTimeout(requestTimer);
-      pendingRequests.delete(msg.id);
-      sendToHost({
-        id: msg.id,
-        result: {
-          success: false,
-          error: `tab ${tabId} is not in the interceptor group — use 'interceptor tab new' to create managed tabs`
-        }
-      }, respondViaWs);
-      return;
+    if (groupLabel) {
+      const inNamed = await isTabInNamedGroup(tabId, groupLabel);
+      if (!inNamed) {
+        fail(`tab ${tabId} is not in group '${groupLabel}' — pass the owning group, or --any-tab to bypass`);
+        return;
+      }
+    } else {
+      const inAny = await isTabInAnyManagedGroup(tabId);
+      if (!inAny && anyManagedGroupKnown()) {
+        fail(`tab ${tabId} is not in the interceptor group — use 'interceptor tab new' to create managed tabs`);
+        return;
+      }
     }
   }
+  if (tabId)
+    setActiveTabId(tabId, groupLabel);
   if (SENSITIVE_ACTIONS.has(action.type) && tabId && action.expectedUrl) {
     const urlErr = await verifyTabUrl(tabId, action.expectedUrl);
     if (urlErr) {

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.20.12",
+  "version": "0.21.3",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.20.12",
+  "version": "0.21.3",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background/brand-tab-group.ts
+++ b/extension/src/background/brand-tab-group.ts
@@ -13,10 +13,10 @@
  * `registerBrandTabGroup()` is called ONLY from the MV3 background.ts entry.
  */
 
-import { ensureInterceptorGroup } from "./tab-group"
+import { ensureInterceptorGroup, retitleNamedGroupsForBrand } from "./tab-group"
 
 // Closed Chrome tabGroups color enum (verified against the tabGroups API docs).
-const VALID_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"] as const
+export const VALID_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"] as const
 export type TabGroupColor = (typeof VALID_COLORS)[number]
 
 export const DEFAULT_TAB_GROUP_TITLE = "interceptor"
@@ -156,6 +156,11 @@ async function onBrandChanged(change: chrome.storage.StorageChange): Promise<voi
   // Make the OLD title discoverable BEFORE re-discovery runs, so ensureInterceptorGroup's candidate
   // set can still find a group that currently bears the old label.
   if (prevTitle) await setPreviousTitle(prevTitle)
+
+  // Named per-agent groups follow the brand: retitle each to `${newTitle}-${label}`.
+  // Id-keyed, so this is purely cosmetic and cannot orphan; runs regardless of
+  // whether the DEFAULT group exists.
+  await retitleNamedGroupsForBrand()
 
   // Adopt-then-retitle. ensureInterceptorGroup re-discovers via the candidate set and returns -1 when
   // the tabGroups API is absent (MV2) or no group exists yet.

--- a/extension/src/background/capabilities/monitor.ts
+++ b/extension/src/background/capabilities/monitor.ts
@@ -1,5 +1,23 @@
 import { sendToHost } from "../transport"
-import { addTabToInterceptorGroup, ensureInterceptorGroup, isTabInInterceptorGroup } from "../tab-group"
+import { addTabToInterceptorGroup, ensureInterceptorGroup, isTabInAnyManagedGroup, ensureNamedGroup } from "../tab-group"
+
+// a child tab belongs to its OPENER's group (named or default), so a
+// grouped agent's popups / child navigations stay inside that agent's group
+// instead of always landing in the default group.
+async function adoptChildTab(childTabId: number, openerTabId?: number): Promise<void> {
+  try {
+    if (openerTabId !== undefined && chrome.tabGroups) {
+      const opener = await chrome.tabs.get(openerTabId)
+      if (opener.groupId !== -1 && (await isTabInAnyManagedGroup(openerTabId))) {
+        await chrome.tabs.group({ tabIds: childTabId, groupId: opener.groupId })
+        return
+      }
+    }
+  } catch {
+    // opener vanished — fall through to the default group.
+  }
+  await addTabToInterceptorGroup(childTabId)
+}
 
 const FOCUS_SWITCH_GUARD_MS = 2000
 
@@ -338,7 +356,7 @@ function registerWebNavListenersOnce(): void {
     if (pendingChild) {
       const session = sessions.get(pendingChild.sessionId)
       if (session && !session.paused) {
-        addTabToInterceptorGroup(details.tabId).catch(() => {})
+        adoptChildTab(details.tabId, pendingChild.openerTabId).catch(() => {})
         switchToAttachment(
           session,
           createAttachment(
@@ -485,9 +503,10 @@ async function handleFocusActivated(tabId: number): Promise<void> {
   // reason "child_tab" once the child document commits.
   if (pendingChildTabs.has(tabId)) return
 
-  // Privacy: only auto-attach to tabs the user opted into via the interceptor group.
+  // Privacy: only auto-attach to tabs the user opted into via a managed group
+  // (the default Interceptor group or any named per-agent group).
   let inGroup = false
-  try { inGroup = await isTabInInterceptorGroup(tabId) } catch { return }
+  try { inGroup = await isTabInAnyManagedGroup(tabId) } catch { return }
   if (!inGroup) return
 
   // Recheck — async gap above could have racing onCreated handoff
@@ -665,7 +684,20 @@ function monitorRuntimeMessageListener(
   return true
 }
 
-async function resolveTabForMonitor(): Promise<{ tabId?: number; error?: string }> {
+async function resolveTabForMonitor(group?: string): Promise<{ tabId?: number; error?: string }> {
+  if (group) {
+    // group-scoped resolution — only that group's tabs, never the
+    // browser-active tab (which may be another agent's).
+    const namedGroupId = await ensureNamedGroup(group)
+    if (namedGroupId !== -1) {
+      const tabs = await chrome.tabs.query({ groupId: namedGroupId })
+      if (tabs.length > 0) {
+        const active = tabs.find((tab) => tab.active) || tabs[0]
+        if (active.id) return { tabId: active.id }
+      }
+    }
+    return { error: `group '${group}' has no tabs — open one with 'interceptor open <url> --group ${group}'` }
+  }
   const groupId = await ensureInterceptorGroup()
   if (groupId !== -1) {
     const tabs = await chrome.tabs.query({ groupId })
@@ -676,7 +708,7 @@ async function resolveTabForMonitor(): Promise<{ tabId?: number; error?: string 
   }
   const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true })
   if (activeTab?.id) {
-    const inGroup = await isTabInInterceptorGroup(activeTab.id)
+    const inGroup = await isTabInAnyManagedGroup(activeTab.id)
     if (inGroup) return { tabId: activeTab.id }
   }
   return { error: "no interceptor-managed tab found — use 'interceptor tab new' or pass --tab" }
@@ -703,7 +735,9 @@ export async function handleMonitorActions(
     case "monitor_start": {
       let resolvedTabId = tabId
       if (!resolvedTabId) {
-        const resolved = await resolveTabForMonitor()
+        const resolved = await resolveTabForMonitor(
+          typeof action.group === "string" && action.group.length > 0 ? action.group : undefined
+        )
         if (resolved.error || !resolved.tabId) {
           return { success: false, error: resolved.error || "no interceptor-managed tab found" }
         }

--- a/extension/src/background/capabilities/tabs.ts
+++ b/extension/src/background/capabilities/tabs.ts
@@ -1,7 +1,16 @@
-import { addTabToInterceptorGroup, ensureInterceptorGroup, interceptorGroupId } from "../tab-group"
+import {
+  addTabToInterceptorGroup, ensureInterceptorGroup, interceptorGroupId,
+  GROUP_LABEL_RE, ensureNamedGroup, addTabToNamedGroup, labelForGroupId,
+  namedGroups, hydrateNamedGroups, groupTitleFor
+} from "../tab-group"
 import { waitForTabLoad } from "../content-bridge"
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
+
+// per-group auto-target key (mirrors message-dispatch's activeTabKey).
+function activeTabKey(group?: string): string {
+  return group ? `activeTabId:${group}` : "activeTabId"
+}
 
 export async function handleTabActions(
   action: { type: string; [key: string]: unknown },
@@ -10,13 +19,22 @@ export async function handleTabActions(
   switch (action.type) {
     case "tab_create": {
       const targetUrl = (action.url as string) || "about:blank"
+      const group = typeof action.group === "string" && action.group.length > 0
+        ? action.group
+        : undefined
+      if (group && !GROUP_LABEL_RE.test(group)) {
+        return { success: false, error: `invalid group label '${group}' — must match [A-Za-z0-9_-]{1,32}` }
+      }
       // When `reuse` is set, navigate the most recently created tab inside
-      // the Interceptor group instead of opening a new one. Long-running
-      // automations would otherwise leave a dead tab behind on every call
-      // (dora-cc#5). Falls back to creating a new tab if the group is empty
+      // the caller's group (the named group when action.group is set, the
+      // default Interceptor group otherwise) instead of opening a new one.
+      // Long-running automations would otherwise leave a dead tab behind on
+      // every call (dora-cc#5). Group-scoping the candidate query is what
+      // keeps one agent's --reuse from hijacking another agent's tab
+      // (per-agent isolation). Falls back to creating a new tab if the group is empty
       // or the candidate tab disappeared between query and update.
       if (action.reuse) {
-        const groupId = await ensureInterceptorGroup()
+        const groupId = group ? await ensureNamedGroup(group) : await ensureInterceptorGroup()
         if (groupId !== -1) {
           const groupTabs = await chrome.tabs.query({ groupId })
           if (groupTabs.length > 0) {
@@ -41,13 +59,13 @@ export async function handleTabActions(
                 await waitForTabLoad(candidate.id)
                 // Pin the reused tab as the auto-target for subsequent commands.
                 // Mirrors the new-tab path below: every successful tab_create
-                // — whether new or reused — must update activeTabId so a fresh
-                // CLI invocation (no --tab) routes here instead of a stale id
-                // or the user's foreground tab.
-                await chrome.storage.session.set({ activeTabId: candidate.id })
+                // — whether new or reused — must update the (per-group)
+                // activeTabId so a fresh CLI invocation (no --tab) routes here
+                // instead of a stale id or the user's foreground tab.
+                await chrome.storage.session.set({ [activeTabKey(group)]: candidate.id })
                 return {
                   success: true,
-                  data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, reused: true }
+                  data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, group, reused: true }
                 }
               } catch {
                 // Tab vanished between query and update — fall through to create.
@@ -64,13 +82,15 @@ export async function handleTabActions(
       const shouldActivate = (action.active as boolean | undefined) === true
       const newTab = await chrome.tabs.create({ url: targetUrl, active: shouldActivate })
       if (newTab.id) {
-        const groupId = await addTabToInterceptorGroup(newTab.id)
+        const groupId = group
+          ? await addTabToNamedGroup(newTab.id, group, action.groupColor)
+          : await addTabToInterceptorGroup(newTab.id)
         // Pin the newly-created tab as the auto-target for subsequent commands
         // so a fresh CLI invocation (no --tab) routes to this tab instead of a
         // stale activeTabId or whatever Chrome reports as "active in currentWindow"
         // (which may be the user's foreground tab, not the one we just opened).
-        await chrome.storage.session.set({ activeTabId: newTab.id })
-        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, reused: false } }
+        await chrome.storage.session.set({ [activeTabKey(group)]: newTab.id })
+        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, group, reused: false } }
       }
       return { success: true, data: { tabId: newTab.id, url: newTab.url, reused: false } }
     }
@@ -80,8 +100,13 @@ export async function handleTabActions(
       await chrome.tabs.remove(closedId)
       // If the closed tab was the auto-target, clear it so the next call
       // re-resolves via chrome.tabs.query rather than targeting a dead tab.
-      const stored = await chrome.storage.session.get("activeTabId") as { activeTabId?: number }
-      if (stored.activeTabId === closedId) await chrome.storage.session.remove("activeTabId")
+      // Checks the caller's per-group key too.
+      const keys = ["activeTabId", typeof action.group === "string" ? activeTabKey(action.group) : null]
+        .filter((k): k is string => !!k)
+      const stored = await chrome.storage.session.get(keys) as Record<string, number | undefined>
+      for (const key of keys) {
+        if (stored[key] === closedId) await chrome.storage.session.remove(key)
+      }
       return { success: true }
     }
 
@@ -94,13 +119,70 @@ export async function handleTabActions(
     case "tab_list": {
       const tabs = await chrome.tabs.query({})
       await ensureInterceptorGroup()
+      // Hydrate the named-group registry so labelForGroupId can attribute tabs.
+      await hydrateNamedGroups()
+      const namedIds = new Set(namedGroups.values())
       const tabData = tabs.map(t => ({
         id: t.id, url: t.url, title: t.title, active: t.active,
         windowId: t.windowId, muted: t.mutedInfo?.muted, pinned: t.pinned,
         groupId: t.groupId,
-        managed: interceptorGroupId !== null && t.groupId === interceptorGroupId
+        // managed = default group OR any named group; `group` names the owner.
+        managed: (interceptorGroupId !== null && t.groupId === interceptorGroupId) || namedIds.has(t.groupId),
+        group: labelForGroupId(t.groupId)
       }))
       return { success: true, data: tabData }
+    }
+
+    case "group_list": {
+      if (!chrome.tabGroups || typeof chrome.tabGroups.query !== "function") {
+        return { success: true, data: [] }
+      }
+      await ensureInterceptorGroup()
+      await hydrateNamedGroups()
+      const live = await chrome.tabGroups.query({})
+      // Re-adopt named groups the registry lost (e.g. browser restart restored
+      // the window): exact match on the brand-composed `<brand>-<label>` title.
+      // ponytail: current brand prefix only; a pre-rebrand title is re-adopted on the next brand change
+      const prefix = `${groupTitleFor("")}`
+      for (const g of live) {
+        if (typeof g.title !== "string" || !g.title.startsWith(prefix)) continue
+        const label = g.title.slice(prefix.length)
+        if (GROUP_LABEL_RE.test(label) && labelForGroupId(g.id) === null && g.id !== interceptorGroupId) {
+          await ensureNamedGroup(label)
+        }
+      }
+      const data = await Promise.all(live.map(async g => {
+        const groupTabs = await chrome.tabs.query({ groupId: g.id })
+        return {
+          groupId: g.id,
+          title: g.title,
+          color: g.color,
+          tabCount: groupTabs.length,
+          label: labelForGroupId(g.id),
+          default: interceptorGroupId !== null && g.id === interceptorGroupId,
+          managed: (interceptorGroupId !== null && g.id === interceptorGroupId) || labelForGroupId(g.id) !== null
+        }
+      }))
+      return { success: true, data }
+    }
+
+    case "group_close": {
+      const label = action.label as string | undefined
+      if (!label || !GROUP_LABEL_RE.test(label)) {
+        return { success: false, error: `group_close requires a valid label (got '${label ?? ""}')` }
+      }
+      const groupId = await ensureNamedGroup(label)
+      if (groupId === -1) {
+        return { success: false, error: `group '${label}' not found` }
+      }
+      const groupTabs = await chrome.tabs.query({ groupId })
+      const ids = groupTabs.map(t => t.id).filter((id): id is number => typeof id === "number")
+      // Atomic: ONE tabs.remove over exactly this group's tab ids — the group
+      // object auto-deletes at zero tabs, and the tabGroups.onRemoved listener
+      // purges the registry entry + per-group auto-target. Nothing outside this
+      // id list is touched (issue #124's "3a" isolation guarantee).
+      if (ids.length > 0) await chrome.tabs.remove(ids)
+      return { success: true, data: { label, groupId, closedTabs: ids.length } }
     }
 
     case "tab_duplicate": {

--- a/extension/src/background/capabilities/windows.ts
+++ b/extension/src/background/capabilities/windows.ts
@@ -1,4 +1,4 @@
-import { addTabToInterceptorGroup } from "../tab-group"
+import { addTabToInterceptorGroup, addTabToNamedGroup, GROUP_LABEL_RE } from "../tab-group"
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
 
@@ -79,7 +79,13 @@ export async function handleWindowActions(
         const firstTab = win.tabs?.[0]
         let groupId: number | undefined
         if (firstTab?.id && !action.incognito) {
-          groupId = await addTabToInterceptorGroup(firstTab.id)
+          // honor the caller's named group; default group otherwise.
+          const group = typeof action.group === "string" && GROUP_LABEL_RE.test(action.group)
+            ? action.group
+            : undefined
+          groupId = group
+            ? await addTabToNamedGroup(firstTab.id, group, action.groupColor)
+            : await addTabToInterceptorGroup(firstTab.id)
         }
         return {
           success: true,

--- a/extension/src/background/message-dispatch.ts
+++ b/extension/src/background/message-dispatch.ts
@@ -1,5 +1,8 @@
 import { sendToHost, activeTransport, connectToHost, connectWsChannel } from "./transport"
-import { isTabInInterceptorGroup, interceptorGroupId, ensureInterceptorGroup, SENSITIVE_ACTIONS, verifyTabUrl } from "./tab-group"
+import {
+  SENSITIVE_ACTIONS, verifyTabUrl,
+  GROUP_LABEL_RE, ensureNamedGroup, isTabInNamedGroup, isTabInAnyManagedGroup, anyManagedGroupKnown
+} from "./tab-group"
 import { routeAction } from "./router"
 import { needsTab } from "./no-tab-actions"
 
@@ -20,17 +23,25 @@ export const pendingRequests = new Map<string, {
   viaWs?: boolean
 }>()
 
-async function getActiveTabId(): Promise<number | undefined> {
-  const storage = chrome.storage as typeof chrome.storage & { session?: chrome.storage.StorageArea }
-  const area = storage.session ?? chrome.storage.local
-  const stored = await area.get("activeTabId") as { activeTabId?: number }
-  return stored.activeTabId
+// the auto-target is per-group. Grouped requests use "activeTabId:<label>"
+// so concurrent agents on one context never clobber each other's target; the bare
+// "activeTabId" key keeps serving ungrouped requests exactly as before.
+function activeTabKey(group?: string): string {
+  return group ? `activeTabId:${group}` : "activeTabId"
 }
 
-async function setActiveTabId(tabId: number): Promise<void> {
+async function getActiveTabId(group?: string): Promise<number | undefined> {
   const storage = chrome.storage as typeof chrome.storage & { session?: chrome.storage.StorageArea }
   const area = storage.session ?? chrome.storage.local
-  await area.set({ activeTabId: tabId })
+  const key = activeTabKey(group)
+  const stored = await area.get(key) as Record<string, number | undefined>
+  return stored[key]
+}
+
+async function setActiveTabId(tabId: number, group?: string): Promise<void> {
+  const storage = chrome.storage as typeof chrome.storage & { session?: chrome.storage.StorageArea }
+  const area = storage.session ?? chrome.storage.local
+  await area.set({ [activeTabKey(group)]: tabId })
 }
 
 export function drainMessageQueue(): void {
@@ -94,8 +105,50 @@ export async function handleDaemonMessage(msg: {
   const action = msg.action
   let tabId = msg.tabId
 
+  const fail = (error: string): void => {
+    clearTimeout(requestTimer)
+    pendingRequests.delete(msg.id!)
+    sendToHost({ id: msg.id, result: { success: false, error } }, respondViaWs)
+  }
+
+  // per-request group scope rides inside the action payload.
+  const groupLabel = typeof action.group === "string" && action.group.length > 0
+    ? action.group
+    : undefined
+  if (groupLabel && !GROUP_LABEL_RE.test(groupLabel)) {
+    fail(`invalid group label '${groupLabel}' — must match [A-Za-z0-9_-]{1,32}`)
+    return
+  }
+
   if (!tabId && needsTab(action.type)) {
-    tabId = await getActiveTabId()
+    tabId = await getActiveTabId(groupLabel)
+    if (tabId && groupLabel) {
+      // Stored per-group target may be dead (tab closed outside group_close) or
+      // no longer a member of the group; validate MEMBERSHIP (not mere existence)
+      // and fall through to the group's own tabs otherwise — this also self-heals
+      // a stale key.
+      let stillInGroup = false
+      try { stillInGroup = await isTabInNamedGroup(tabId, groupLabel) } catch {}
+      if (!stillInGroup) tabId = undefined
+    }
+  }
+
+  if (!tabId && needsTab(action.type) && groupLabel) {
+    // Grouped requests resolve ONLY within their group — never the browser-active
+    // tab, which is frequently another agent's (the cross-agent bleed this feature
+    // exists to prevent).
+    const groupId = await ensureNamedGroup(groupLabel)
+    if (groupId !== -1) {
+      const groupTabs = await chrome.tabs.query({ groupId })
+      const candidate = groupTabs
+        .filter(t => typeof t.id === "number")
+        .sort((a, b) => (b.id as number) - (a.id as number))[0]
+      tabId = candidate?.id
+    }
+    if (!tabId) {
+      fail(`group '${groupLabel}' has no tabs — open one with 'interceptor open <url> --group ${groupLabel}'`)
+      return
+    }
   }
 
   if (!tabId && needsTab(action.type)) {
@@ -105,29 +158,30 @@ export async function handleDaemonMessage(msg: {
   }
 
   if (!tabId && needsTab(action.type)) {
-    clearTimeout(requestTimer)
-    pendingRequests.delete(msg.id)
-    sendToHost({ id: msg.id, result: { success: false, error: "no active tab" } }, respondViaWs)
+    fail("no active tab")
     return
   }
 
-  if (tabId) setActiveTabId(tabId)
-
   if (tabId && needsTab(action.type) && !action.anyTab) {
-    const inGroup = await isTabInInterceptorGroup(tabId)
-    if (!inGroup && interceptorGroupId !== null) {
-      clearTimeout(requestTimer)
-      pendingRequests.delete(msg.id)
-      sendToHost({
-        id: msg.id,
-        result: {
-          success: false,
-          error: `tab ${tabId} is not in the interceptor group — use 'interceptor tab new' to create managed tabs`
-        }
-      }, respondViaWs)
-      return
+    if (groupLabel) {
+      const inNamed = await isTabInNamedGroup(tabId, groupLabel)
+      if (!inNamed) {
+        fail(`tab ${tabId} is not in group '${groupLabel}' — pass the owning group, or --any-tab to bypass`)
+        return
+      }
+    } else {
+      const inAny = await isTabInAnyManagedGroup(tabId)
+      if (!inAny && anyManagedGroupKnown()) {
+        fail(`tab ${tabId} is not in the interceptor group — use 'interceptor tab new' to create managed tabs`)
+        return
+      }
     }
   }
+
+  // Persist the auto-target only AFTER the group gate has passed — a rejected
+  // cross-group request must never poison another group's (or the global)
+  // auto-target key.
+  if (tabId) setActiveTabId(tabId, groupLabel)
 
   if (SENSITIVE_ACTIONS.has(action.type) && tabId && action.expectedUrl) {
     const urlErr = await verifyTabUrl(tabId, action.expectedUrl as string)

--- a/extension/src/background/no-tab-actions.ts
+++ b/extension/src/background/no-tab-actions.ts
@@ -5,7 +5,7 @@ export const NO_TAB_ACTIONS = new Set([
   "bookmark_create", "downloads_search", "browsing_data_remove",
   "session_list", "session_restore", "notification_create", "notification_clear",
   "search_query", "monitor_status", "monitor_start", "monitor_pause", "monitor_resume",
-  "monitor_stop", "brand_set_tab_group"
+  "monitor_stop", "brand_set_tab_group", "group_list", "group_close"
 ])
 
 export function needsTab(type: string): boolean {

--- a/extension/src/background/router.ts
+++ b/extension/src/background/router.ts
@@ -46,7 +46,8 @@ const CANVAS_ACTIONS = new Set([
 const TAB_ACTIONS = new Set([
   "tab_create", "tab_close", "tab_switch", "tab_list", "tab_duplicate",
   "tab_reload", "tab_mute", "tab_pin", "tab_zoom_get", "tab_zoom_set",
-  "tab_group", "tab_ungroup", "tab_move", "tab_discard"
+  "tab_group", "tab_ungroup", "tab_move", "tab_discard",
+  "group_list", "group_close"
 ])
 const WINDOW_ACTIONS = new Set([
   "window_create", "window_close", "window_focus", "window_resize", "window_list", "window_get_all"

--- a/extension/src/background/tab-group.ts
+++ b/extension/src/background/tab-group.ts
@@ -1,9 +1,187 @@
-import { getTabGroupTitle, getTabGroupColor, getCandidateTitles } from "./brand-tab-group"
+import { getTabGroupTitle, getTabGroupColor, getCandidateTitles, normalizeColor, VALID_COLORS, type TabGroupColor } from "./brand-tab-group"
 
 export let interceptorGroupId: number | null = null
 
 function hasTabGroupApi(): boolean {
   return !!chrome.tabGroups && typeof chrome.tabGroups.query === "function"
+}
+
+// --- Named per-agent groups ------------------------------------------------
+// Registry of label -> live groupId, mirrored to chrome.storage.session
+// ("namedTabGroups"). session lifetime matches tab-group-id lifetime exactly:
+// both survive SW restarts and both die on browser restart, so the registry
+// can never resurrect a stale-but-valid-looking id.
+
+export const GROUP_LABEL_RE = /^[A-Za-z0-9_-]{1,32}$/
+const SESSION_NAMED_GROUPS_KEY = "namedTabGroups"
+
+export const namedGroups = new Map<string, number>()
+let namedGroupsHydrated = false
+
+function sessionArea(): chrome.storage.StorageArea | undefined {
+  const storage = chrome.storage as typeof chrome.storage & { session?: chrome.storage.StorageArea }
+  return storage.session
+}
+
+export async function hydrateNamedGroups(): Promise<void> {
+  if (namedGroupsHydrated) return
+  namedGroupsHydrated = true
+  try {
+    const area = sessionArea()
+    if (!area) return
+    const stored = (await area.get(SESSION_NAMED_GROUPS_KEY)) as Record<string, unknown>
+    const raw = stored?.[SESSION_NAMED_GROUPS_KEY]
+    if (raw && typeof raw === "object") {
+      for (const [label, gid] of Object.entries(raw as Record<string, unknown>)) {
+        if (GROUP_LABEL_RE.test(label) && typeof gid === "number") namedGroups.set(label, gid)
+      }
+    }
+  } catch {}
+}
+
+async function persistNamedGroups(): Promise<void> {
+  try {
+    const area = sessionArea()
+    if (!area) return
+    await area.set({ [SESSION_NAMED_GROUPS_KEY]: Object.fromEntries(namedGroups) })
+  } catch {}
+}
+
+/** Tab-strip title for a named group, composed with the runtime brand title. */
+export function groupTitleFor(label: string): string {
+  return `${getTabGroupTitle()}-${label}`
+}
+
+/**
+ * Deterministic color for a label: stable across restarts so an agent's group
+ * keeps its color. Plain string hash into the closed Chrome color enum.
+ */
+// ponytail: label-hash can collide with the brand color; acceptable — groupColor overrides
+export function colorForLabel(label: string): TabGroupColor {
+  let h = 0
+  for (let i = 0; i < label.length; i++) h = (h * 31 + label.charCodeAt(i)) >>> 0
+  return VALID_COLORS[h % VALID_COLORS.length]
+}
+
+async function purgeNamedGroupEntry(label: string): Promise<void> {
+  namedGroups.delete(label)
+  await persistNamedGroups()
+  try {
+    const area = sessionArea()
+    if (area) await area.remove(`activeTabId:${label}`)
+  } catch {}
+}
+
+/**
+ * Resolve a named group's live id: registry id (validated) first, then exact-title
+ * re-discovery over query({}) — NEVER query({title}) which is pattern-matching per
+ * the tabGroups docs and would collide "…-ai1" with "…-ai134". Returns -1 when the
+ * group does not exist (creation happens in addTabToNamedGroup — Chrome cannot
+ * create an empty group).
+ */
+export async function ensureNamedGroup(label: string): Promise<number> {
+  if (!hasTabGroupApi()) return -1
+  await hydrateNamedGroups()
+  const known = namedGroups.get(label)
+  if (known !== undefined) {
+    try {
+      await chrome.tabGroups.get(known)
+      return known
+    } catch {
+      await purgeNamedGroupEntry(label)
+    }
+  }
+  const title = groupTitleFor(label)
+  const groups = await chrome.tabGroups.query({})
+  const match = groups.find((g) => g.title === title)
+  if (match) {
+    namedGroups.set(label, match.id)
+    await persistNamedGroups()
+    return match.id
+  }
+  return -1
+}
+
+export function addTabToNamedGroup(
+  tabId: number,
+  label: string,
+  colorOverride?: unknown
+): Promise<number> {
+  return serializeGroupAdd(label, () => addTabToNamedGroupSerialized(tabId, label, colorOverride))
+}
+
+async function addTabToNamedGroupSerialized(
+  tabId: number,
+  label: string,
+  colorOverride?: unknown
+): Promise<number> {
+  if (!hasTabGroupApi() || typeof chrome.tabs.group !== "function") return -1
+  let groupId = await ensureNamedGroup(label)
+  if (groupId === -1) {
+    groupId = await chrome.tabs.group({ tabIds: tabId })
+    const color = typeof colorOverride === "string" && (VALID_COLORS as readonly string[]).includes(colorOverride)
+      ? normalizeColor(colorOverride)
+      : colorForLabel(label)
+    await chrome.tabGroups.update(groupId, {
+      title: groupTitleFor(label),
+      color: color as `${chrome.tabGroups.Color}`,
+    })
+    namedGroups.set(label, groupId)
+    await persistNamedGroups()
+  } else {
+    await chrome.tabs.group({ tabIds: tabId, groupId })
+  }
+  return groupId
+}
+
+export async function isTabInNamedGroup(tabId: number, label: string): Promise<boolean> {
+  if (!hasTabGroupApi()) return true
+  const groupId = await ensureNamedGroup(label)
+  if (groupId === -1) return false
+  const tab = await chrome.tabs.get(tabId)
+  return tab.groupId === groupId
+}
+
+/** Membership in the default brand group OR any registered named group. */
+export async function isTabInAnyManagedGroup(tabId: number): Promise<boolean> {
+  if (!hasTabGroupApi()) return true
+  const tab = await chrome.tabs.get(tabId)
+  if (interceptorGroupId === null) await ensureInterceptorGroup()
+  if (interceptorGroupId !== null && tab.groupId === interceptorGroupId) return true
+  await hydrateNamedGroups()
+  for (const gid of namedGroups.values()) {
+    if (tab.groupId === gid) return true
+  }
+  return false
+}
+
+/** True when at least one managed group (default or named) is known to exist. */
+export function anyManagedGroupKnown(): boolean {
+  return interceptorGroupId !== null || namedGroups.size > 0
+}
+
+/**
+ * Retitle every named group to `${newBrandTitle}-${label}` after a brand change.
+ * Ids never change, so a brand retitle cannot orphan a named group.
+ */
+export async function retitleNamedGroupsForBrand(): Promise<void> {
+  if (!hasTabGroupApi()) return
+  await hydrateNamedGroups()
+  for (const [label, gid] of namedGroups) {
+    try {
+      await chrome.tabGroups.update(gid, { title: groupTitleFor(label) })
+    } catch {
+      // group vanished — onRemoved listener purges it; never break the brand change.
+    }
+  }
+}
+
+/** Reverse lookup: the label owning a live groupId, or null (default/unmanaged). */
+export function labelForGroupId(groupId: number): string | null {
+  for (const [label, gid] of namedGroups) {
+    if (gid === groupId) return label
+  }
+  return null
 }
 
 export async function ensureInterceptorGroup(): Promise<number> {
@@ -29,7 +207,28 @@ export async function ensureInterceptorGroup(): Promise<number> {
   return -1
 }
 
-export async function addTabToInterceptorGroup(tabId: number): Promise<number> {
+// Group creation is check-then-act (miss the registry -> chrome.tabs.group mints a
+// NEW group): N concurrent adds for the same group each miss and create N duplicate
+// groups (found by stress testing — 9 parallel opens over 3 labels produced
+// 9 groups). Serialize adds per group key ("" = the default group); the first
+// creates, the rest join it via the registry.
+const groupAddChains = new Map<string, Promise<number>>()
+
+export function serializeGroupAdd(key: string, op: () => Promise<number>): Promise<number> {
+  const prev = groupAddChains.get(key) ?? Promise.resolve(-1)
+  const next = prev.then(op, op)
+  groupAddChains.set(key, next)
+  void next.finally(() => {
+    if (groupAddChains.get(key) === next) groupAddChains.delete(key)
+  }).catch(() => {})
+  return next
+}
+
+export function addTabToInterceptorGroup(tabId: number): Promise<number> {
+  return serializeGroupAdd("", () => addTabToInterceptorGroupSerialized(tabId))
+}
+
+async function addTabToInterceptorGroupSerialized(tabId: number): Promise<number> {
   let groupId = await ensureInterceptorGroup()
   if (groupId === -1 && (!hasTabGroupApi() || typeof chrome.tabs.group !== "function")) return -1
   if (groupId === -1) {
@@ -77,4 +276,15 @@ export function registerTabGroupListeners(): void {
       interceptorGroupId = null
     }
   })
+  // A group closed in the tab strip (user-closed, or auto-closed at zero tabs)
+  // must not leave a stale registry entry or per-group auto-target behind —
+  // that is the "human closes a leftover group" guarantee (issue #124).
+  if (chrome.tabGroups.onRemoved) {
+    chrome.tabGroups.onRemoved.addListener(async (group) => {
+      if (interceptorGroupId === group.id) interceptorGroupId = null
+      await hydrateNamedGroups()
+      const label = labelForGroupId(group.id)
+      if (label !== null) await purgeNamedGroupEntry(label)
+    })
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.20.12",
+  "version": "0.21.3",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/test/tab-groups.test.ts
+++ b/test/tab-groups.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { GROUP_LABEL_RE, groupTitleFor, colorForLabel, serializeGroupAdd } from "../extension/src/background/tab-group"
+import { VALID_COLORS } from "../extension/src/background/brand-tab-group"
+import { GROUP_LABEL_RE as CLI_GROUP_LABEL_RE, parseGroupFlag } from "../cli/parse"
+import { buildFilteredArgs } from "../cli/global-flags"
+
+// tab-group.ts is module-load side-effect-free (no `chrome.*` at import time — the
+// MV2 transitive-bundle constraint), so its pure helpers are unit-testable here.
+
+describe("tab groups: group label validation", () => {
+  test("valid labels pass", () => {
+    for (const l of ["ai134", "a", "A-b_c", "x".repeat(32)]) {
+      expect(GROUP_LABEL_RE.test(l)).toBe(true)
+    }
+  })
+
+  test("invalid labels fail", () => {
+    for (const l of ["", "has space", "x".repeat(33), "emoji🙂", "a/b", "a.b"]) {
+      expect(GROUP_LABEL_RE.test(l)).toBe(false)
+    }
+  })
+
+  test("extension and CLI enforce the identical label grammar", () => {
+    expect(CLI_GROUP_LABEL_RE.source).toBe(GROUP_LABEL_RE.source)
+  })
+})
+
+describe("tab groups: group title composition + color", () => {
+  test("title composes brand + label (default brand is 'interceptor')", () => {
+    expect(groupTitleFor("ai134")).toBe("interceptor-ai134")
+  })
+
+  test("colorForLabel is deterministic and always a valid Chrome color", () => {
+    for (const l of ["ai134", "ai7", "research", "zz"]) {
+      const c1 = colorForLabel(l)
+      const c2 = colorForLabel(l)
+      expect(c1).toBe(c2)
+      expect(VALID_COLORS as readonly string[]).toContain(c1)
+    }
+  })
+})
+
+describe("tab groups: concurrent group creation is serialized per label (stress-test regression)", () => {
+  test("N concurrent adds for one label run strictly sequentially", async () => {
+    // Without serialization, 9 parallel opens over 3 labels minted 9 duplicate
+    // groups in the live stress test. The op chain must never interleave.
+    let running = 0
+    let maxRunning = 0
+    const op = async () => {
+      running++
+      maxRunning = Math.max(maxRunning, running)
+      await new Promise(r => setTimeout(r, 5))
+      running--
+      return 42
+    }
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => serializeGroupAdd("stress-label", op))
+    )
+    expect(maxRunning).toBe(1)
+    expect(results).toEqual([42, 42, 42, 42, 42, 42])
+  })
+
+  test("different labels do not serialize against each other", async () => {
+    let running = 0
+    let maxRunning = 0
+    const op = async () => {
+      running++
+      maxRunning = Math.max(maxRunning, running)
+      await new Promise(r => setTimeout(r, 5))
+      running--
+      return 1
+    }
+    await Promise.all([serializeGroupAdd("l1", op), serializeGroupAdd("l2", op)])
+    expect(maxRunning).toBe(2)
+  })
+
+  test("a rejected op does not wedge the chain", async () => {
+    const boom = () => Promise.reject(new Error("boom"))
+    await expect(serializeGroupAdd("l3", boom)).rejects.toThrow("boom")
+    await expect(serializeGroupAdd("l3", async () => 7)).resolves.toBe(7)
+  })
+})
+
+describe("tab groups: CLI global flags", () => {
+  test("--group and --group-color (with values) are stripped from filtered args", () => {
+    expect(buildFilteredArgs(["open", "https://x", "--group", "ai1"])).toEqual(["open", "https://x"])
+    expect(buildFilteredArgs(["open", "https://x", "--group-color", "purple"])).toEqual(["open", "https://x"])
+    expect(buildFilteredArgs(["group", "close", "ai1"])).toEqual(["group", "close", "ai1"])
+  })
+
+  test("parseGroupFlag: flag wins over INTERCEPTOR_GROUP env; env is the fallback", () => {
+    expect(parseGroupFlag(["open", "--group", "flagged"], { INTERCEPTOR_GROUP: "fromenv" })).toBe("flagged")
+    expect(parseGroupFlag(["open"], { INTERCEPTOR_GROUP: "fromenv" })).toBe("fromenv")
+    expect(parseGroupFlag(["open"], {})).toBeUndefined()
+  })
+})
+
+// Source assertions (the brand-tab-group.test.ts precedent): lock in the
+// structural guarantees the feature's acceptance criteria depend on.
+
+const root = join(import.meta.dir, "..")
+const dispatchSrc = readFileSync(join(root, "extension", "src", "background", "message-dispatch.ts"), "utf-8")
+const tabsSrc = readFileSync(join(root, "extension", "src", "background", "capabilities", "tabs.ts"), "utf-8")
+const routerSrc = readFileSync(join(root, "extension", "src", "background", "router.ts"), "utf-8")
+const noTabSrc = readFileSync(join(root, "extension", "src", "background", "no-tab-actions.ts"), "utf-8")
+
+describe("tab groups: dispatch never falls back to the browser-active tab for grouped requests", () => {
+  test("grouped resolution errors out instead of reaching the active-tab query", () => {
+    // The grouped branch must terminate (fail + return) before the ungrouped
+    // active-tab fallback runs — the fallback is the cross-agent bleed.
+    const groupedBlock = dispatchSrc.indexOf("needsTab(action.type) && groupLabel")
+    const activeFallback = dispatchSrc.indexOf("query({ active: true, currentWindow: true })")
+    expect(groupedBlock).toBeGreaterThan(-1)
+    expect(activeFallback).toBeGreaterThan(groupedBlock)
+    expect(dispatchSrc).toContain("has no tabs — open one with")
+  })
+
+  test("per-group auto-target key derives from the label", () => {
+    expect(dispatchSrc).toContain('group ? `activeTabId:${group}` : "activeTabId"')
+  })
+
+  test("gate scopes to the caller's group when a label is present", () => {
+    expect(dispatchSrc).toContain("isTabInNamedGroup(tabId, groupLabel)")
+    expect(dispatchSrc).toContain("isTabInAnyManagedGroup(tabId)")
+  })
+
+  test("auto-target persists only AFTER the gate — a rejected cross-group request must not poison the key", () => {
+    const gateIdx = dispatchSrc.indexOf("is not in group")
+    const setIdx = dispatchSrc.lastIndexOf("setActiveTabId(tabId, groupLabel)")
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(setIdx).toBeGreaterThan(gateIdx)
+  })
+
+  test("stored per-group target is validated for MEMBERSHIP, not mere existence", () => {
+    expect(dispatchSrc).toContain("stillInGroup = await isTabInNamedGroup(tabId, groupLabel)")
+  })
+})
+
+describe("tab groups: group_close is one atomic tabs.remove over the group's own ids", () => {
+  test("handler exists and uses a single chrome.tabs.remove(ids)", () => {
+    const closeCase = tabsSrc.slice(tabsSrc.indexOf('case "group_close"'))
+    expect(closeCase.length).toBeGreaterThan(10)
+    const body = closeCase.slice(0, closeCase.indexOf("case ", 10))
+    expect(body).toContain("chrome.tabs.remove(ids)")
+    expect((body.match(/chrome\.tabs\.remove/g) || []).length).toBe(1)
+    expect(body).not.toContain("chrome.windows.remove")
+  })
+})
+
+describe("tab groups: new actions are registered everywhere they must be", () => {
+  test("router TAB_ACTIONS", () => {
+    expect(routerSrc).toContain('"group_list"')
+    expect(routerSrc).toContain('"group_close"')
+  })
+
+  test("NO_TAB_ACTIONS (a tabless verb dies with 'no active tab' otherwise)", () => {
+    expect(noTabSrc).toContain('"group_list"')
+    expect(noTabSrc).toContain('"group_close"')
+  })
+
+  test("reuse path is group-scoped in tab_create", () => {
+    expect(tabsSrc).toContain("group ? await ensureNamedGroup(group) : await ensureInterceptorGroup()")
+  })
+})


### PR DESCRIPTION
## Summary

Prepares Interceptor `0.21.3` and closes #124: **concurrent per-agent tab groups**. Multiple AI agents can drive the same browser context at the same time, each penned into its own named, colored tab group — no cross-agent tab grabs, no shared-target clobbering, atomic per-job cleanup.

## What Changed

**Named per-agent groups (extension)**
- Registry of `label → groupId` in `chrome.storage.session`, lifetime-matched to Chrome's session-scoped group ids; exact-title rediscovery (never pattern-matched `query({title})`).
- Group creation serialized per label — N concurrent opens for one label join a single group instead of minting N duplicates.
- Per-group auto-target keys (`activeTabId:<label>`). Grouped resolution never falls back to the browser-active tab; the ownership gate runs **before** the auto-target persists, and stored targets are membership-validated (self-healing).
- `group_list` / `group_close` actions — close is one atomic `tabs.remove` over exactly that group's ids; a `tabGroups.onRemoved` listener keeps the registry honest when a human closes a group by hand.
- Brand retitles (`interceptor brand tab-group`) propagate to named groups (`<brand>-<label>`).
- Monitor: child tabs inherit their opener's group; auto-attach accepts any managed group.
- Graceful degradation where `tabGroups` is unavailable (MV2 Electron bridge, Firefox).

**CLI**
- Global `--group <label>` / `--group-color <color>` flags with `INTERCEPTOR_GROUP` env fallback (flag wins), injected at the transport choke point so simple, compound, and looping paths are all scoped.
- New `interceptor group list` / `interceptor group close <label>`.

**Docs**
- `ARCHITECTURE.md` named-groups section; `interceptor-browser` agent skill updated with multi-agent scoping guidance.

## Testing

- 19 new unit + source-assertion tests (626 total, 0 fail).
- Live: two-agent isolation, cross-group rejection, group-scoped `--reuse`, staggered teardown.
- Stress: **100 tabs / 10 groups / 3 browser contexts** (two Chromium profiles + Firefox) opened, scrolled, and torn down fully concurrently — 100/100 opens, 100/100 scrolls, zero duplicate groups, zero cross-group bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named tab groups for isolating browser actions per session.
  * Introduced commands to list groups, close a group, and open tabs/windows into a specific group.
  * Added support for choosing a group color when creating a group.

* **Bug Fixes**
  * Improved tab targeting so actions stay within the correct group.
  * Made child tabs inherit their parent’s group more reliably.
  * Updated group handling to survive restarts more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->