### PR TITLE
Release 0.22.1 — CLI contract overhaul & skills adoption

### DIFF
--- a/.agents/skills/interceptor-ios/SKILL.md
+++ b/.agents/skills/interceptor-ios/SKILL.md
@@ -34,7 +34,7 @@ Treat `eN` refs as short-lived. The UI changes between calls; **re-read with `in
 - **The device dials in.** A verb on a not-yet-connected phone auto-launches the runner; it connects back over WiFi and the verb runs. There is no manual "enable" step.
 - **Unlocked + foreground matters.** A locked phone refuses app launches. If launches stall, the phone is likely locked — unlock it. The runner drops on idle and re-dials per verb, so between calls the phone may return to the Home screen; chain a launch and its follow-up verbs closely.
 - **UI only.** Interceptor drives the touchscreen and buttons. It cannot pass Face ID / passcode / Apple Pay or unlock the phone.
-- **Setup is one-time.** `interceptor ios setup` (Xcode signed in) or `interceptor ios login` (no-Xcode, the user's own Apple ID) installs + signs the runner. A background timer re-signs before the free-tier certificate expires.
+- **Setup is one-time.** `interceptor ios setup` (Xcode signed in) or `interceptor ios login` (no-Xcode, the user's own Apple ID) installs + signs the runner. A background timer renews the runner signature before the free-tier certificate expires.
 
 ## Workflows
 

--- a/cli/commands/ios.ts
+++ b/cli/commands/ios.ts
@@ -113,7 +113,22 @@ Drive a phone (add --on <name>, or it uses your only phone):
   apps                                       installed apps
   app     launch|activate|terminate <id>     app lifecycle
 
-Phones connect automatically — no enable, no plugging in required once paired over WiFi.
+Connection model (how the runner reaches the phone):
+  • The phone runs an on-device XCUITest runner (InterceptorRunner) that DIALS IN
+    to the daemon over WiFi. There is no persistent socket held open while idle.
+  • 'devices' shows "connected: false" whenever the runner isn't actively dialed in.
+    That is the NORMAL idle state for a correctly-installed phone — it means
+    "installed, will auto-connect on the next verb", NOT "broken" or "offline".
+  • You do NOT need to connect manually. Just run a verb — e.g.
+    'interceptor ios tree --on <name>' — and the daemon launches the runner and
+    the phone dials in. 'connected' flips to true for the life of that session.
+  • Keep the phone UNLOCKED and AWAKE while driving. Auto-lock / sleep tears the
+    runner down (you'll see connected:false again and the next verb re-launches).
+  • If a verb hangs or times out: confirm the phone is unlocked, on the same
+    network, and reachable — 'interceptor ios status' shows the live context and
+    'xcrun devicectl list devices' shows whether macOS sees it as "available".
+
+Phones connect automatically — no enable, no cable required once paired over WiFi.
 Drives UI only: can't pass Face ID/passcode/Apple Pay or unlock the phone.`
 
 export async function runIosCommand(

--- a/cli/commands/skills.ts
+++ b/cli/commands/skills.ts
@@ -1,0 +1,382 @@
+/**
+ * cli/commands/skills.ts — interceptor skills list|status|show|adopt
+ *
+ *
+ * Links the skill packs shipped with the pkg into the skills directories of
+ * the AI runtimes present on this machine. Symlinks (junctions on Windows —
+ * they need neither Developer Mode nor elevation) keep adopted skills current
+ * across package updates; a physical copy would silently go stale (observed
+ * in the wild: a ~/.codex/skills/interceptor copy six weeks behind the pkg).
+ *
+ * Per-skill selection, whole-folder links: one symlink per skill directory.
+ * A real directory at the destination is NEVER replaced without --force.
+ */
+
+import {
+  existsSync, lstatSync, mkdirSync, readFileSync, readdirSync,
+  readlinkSync, realpathSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync,
+} from "node:fs"
+import { join, dirname, resolve } from "node:path"
+import { homedir, tmpdir } from "node:os"
+
+const PKG_SKILLS_DIR_DARWIN = "/Library/Application Support/Interceptor/skills"
+const SKILLS_REFRESH_MARKER_DARWIN = "/Library/Application Support/Interceptor/.skills-refresh"
+const HINT_FLAG_FILE = join(tmpdir(), "interceptor-skills-hint.flag")
+const HINT_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export type LinkState = "linked" | "stale-copy" | "foreign" | "missing"
+
+export type SkillTarget = {
+  id: string
+  label: string
+  dir: string      // skills dir links are created in
+  parent: string   // runtime home whose existence means "this runtime is installed"
+}
+
+export type SkillInfo = { name: string; description: string; dir: string }
+
+// ── pack discovery ────────────────────────────────────────────────────────────
+
+/** Installed skill-pack directory: pkg locations first, dev checkout fallback. */
+export function resolvePackDir(): string | null {
+  if (process.platform === "darwin" && existsSync(PKG_SKILLS_DIR_DARWIN)) {
+    return PKG_SKILLS_DIR_DARWIN
+  }
+  // Windows: Inno lays skills down next to the CLI at {app}\skills
+  const besideBinary = join(dirname(process.execPath), "skills")
+  if (existsSync(join(besideBinary, "interceptor-browser"))) return besideBinary
+  // Dev checkout: walk up from the binary / cwd looking for .agents/skills
+  const starts = [dirname(process.execPath), process.cwd()]
+  for (const start of starts) {
+    let cur = start
+    for (let hop = 0; hop < 6; hop++) {
+      const candidate = resolve(cur, ".agents/skills")
+      if (existsSync(join(candidate, "interceptor-browser"))) return candidate
+      const parent = dirname(cur)
+      if (parent === cur) break
+      cur = parent
+    }
+  }
+  return null
+}
+
+function skillDescription(dir: string): string {
+  try {
+    const raw = readFileSync(join(dir, "SKILL.md"), "utf-8")
+    const m = /^description:\s*(.+)$/m.exec(raw)
+    if (m) return m[1].trim().replace(/^["']|["']$/g, "")
+  } catch {}
+  return ""
+}
+
+export function discoverSkills(packDir: string): SkillInfo[] {
+  try {
+    return readdirSync(packDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && existsSync(join(packDir, e.name, "SKILL.md")))
+      .map(e => ({
+        name: e.name,
+        description: skillDescription(join(packDir, e.name)),
+        dir: join(packDir, e.name),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  } catch {
+    return []
+  }
+}
+
+// ── runtime targets ───────────────────────────────────────────────────────────
+
+/**
+ * Candidate runtimes. Codex's home is $CODEX_HOME (default ~/.codex) — its
+ * documented USER-scope skills dir is ~/.agents/skills, but curated installs
+ * land in $CODEX_HOME/skills and both are scanned; we link into the Codex
+ * home so `codex` means Codex regardless of the shared-.agents convention.
+ */
+export function allTargets(home = homedir(), env: Record<string, string | undefined> = process.env): SkillTarget[] {
+  const codexHome = env.CODEX_HOME || join(home, ".codex")
+  return [
+    { id: "claude", label: "Claude Code", parent: join(home, ".claude"), dir: join(home, ".claude", "skills") },
+    { id: "codex", label: "Codex", parent: codexHome, dir: join(codexHome, "skills") },
+    { id: "agents", label: "~/.agents consumers", parent: join(home, ".agents"), dir: join(home, ".agents", "skills") },
+    { id: "openclaw", label: "OpenClaw", parent: join(home, ".openclaw"), dir: join(home, ".openclaw", "skills") },
+    { id: "opencode", label: "OpenCode", parent: join(home, ".config", "opencode"), dir: join(home, ".config", "opencode", "skills") },
+  ]
+}
+
+export function detectedTargets(home = homedir(), env: Record<string, string | undefined> = process.env): SkillTarget[] {
+  return allTargets(home, env).filter(t => existsSync(t.parent))
+}
+
+// ── classification ────────────────────────────────────────────────────────────
+
+export function classifyLink(targetDir: string, skillName: string, srcDir: string): LinkState {
+  const dst = join(targetDir, skillName)
+  let st
+  try { st = lstatSync(dst) } catch { return "missing" }
+  if (st.isSymbolicLink()) {
+    try {
+      if (realpathSync(dst) === realpathSync(srcDir)) return "linked"
+    } catch { return "foreign" } // dangling link
+    return "foreign"
+  }
+  if (st.isDirectory()) return "stale-copy"
+  return "foreign"
+}
+
+// ── adopt ─────────────────────────────────────────────────────────────────────
+
+export type AdoptResult = {
+  target: string
+  skill: string
+  action: "linked" | "already-linked" | "skipped" | "replaced-copy" | "error"
+  detail?: string
+}
+
+export function adoptSkill(target: SkillTarget, skill: SkillInfo, force: boolean): AdoptResult {
+  const dst = join(target.dir, skill.name)
+  const state = classifyLink(target.dir, skill.name, skill.dir)
+  try {
+    mkdirSync(target.dir, { recursive: true })
+    if (state === "linked") return { target: target.id, skill: skill.name, action: "already-linked" }
+    if (state === "foreign") {
+      // ln -sfn semantics: replacing a symlink (even one pointing elsewhere)
+      // destroys no data — the target directory is untouched.
+      unlinkSync(dst)
+    } else if (state === "stale-copy") {
+      if (!force) {
+        return {
+          target: target.id, skill: skill.name, action: "skipped",
+          detail: `${dst} is a real directory (stale copy?) — re-run with --force to replace it with a link`,
+        }
+      }
+      rmSync(dst, { recursive: true })
+    }
+    symlinkSync(skill.dir, dst, process.platform === "win32" ? "junction" : undefined)
+    // verify the link resolves before reporting success
+    if (!existsSync(dst)) {
+      return { target: target.id, skill: skill.name, action: "error", detail: `link created at ${dst} but does not resolve` }
+    }
+    return { target: target.id, skill: skill.name, action: state === "stale-copy" ? "replaced-copy" : "linked" }
+  } catch (err) {
+    return { target: target.id, skill: skill.name, action: "error", detail: (err as Error).message }
+  }
+}
+
+// ── status summary (shared with `interceptor status` and the manifest) ────────
+
+export type SkillsStatusSummary = {
+  packDir: string | null
+  skills: string[]
+  targets: Array<{ id: string; dir: string; linked: number; total: number; states: Record<string, LinkState> }>
+}
+
+export function skillsStatusSummary(): SkillsStatusSummary {
+  const packDir = resolvePackDir()
+  if (!packDir) return { packDir: null, skills: [], targets: [] }
+  const skills = discoverSkills(packDir)
+  const targets = detectedTargets().map(t => {
+    const states: Record<string, LinkState> = {}
+    let linked = 0
+    for (const s of skills) {
+      const st = classifyLink(t.dir, s.name, s.dir)
+      states[s.name] = st
+      if (st === "linked") linked++
+    }
+    return { id: t.id, dir: t.dir, linked, total: skills.length, states }
+  })
+  return { packDir, skills: skills.map(s => s.name), targets }
+}
+
+// ── update-time hint ────────────
+
+/**
+ * One rate-limited stderr line when installed skills are not (or no longer)
+ * linked into a detected runtime. Information, not coercion: changes nothing
+ * about the command's behavior or stdout. Opt out with --no-skills-hint or
+ * INTERCEPTOR_NO_SKILLS_HINT=1.
+ */
+export function maybeEmitSkillsHint(argv: string[], env: Record<string, string | undefined> = process.env): void {
+  if (argv.includes("--no-skills-hint") || env.INTERCEPTOR_NO_SKILLS_HINT) return
+  try {
+    if (existsSync(HINT_FLAG_FILE)) {
+      const age = Date.now() - statSync(HINT_FLAG_FILE).mtimeMs
+      if (age < HINT_WINDOW_MS) return
+    }
+    const summary = skillsStatusSummary()
+    if (!summary.packDir || summary.targets.length === 0) return
+    const gaps: string[] = []
+    for (const t of summary.targets) {
+      const unlinked = Object.entries(t.states).filter(([, st]) => st !== "linked")
+      if (unlinked.length > 0) {
+        gaps.push(`${t.id}: ${unlinked.length} of ${t.total} not linked`)
+      }
+    }
+    if (gaps.length === 0) return
+    writeFileSync(HINT_FLAG_FILE, String(Date.now()))
+    process.stderr.write(
+      `hint: Interceptor skill packs are not fully linked into your AI runtimes (${gaps.join("; ")}). ` +
+      `Run 'interceptor skills adopt'. (--no-skills-hint to silence)\n`,
+    )
+  } catch {
+    // never let the hint break a real command
+  }
+}
+
+// ── CLI entry ─────────────────────────────────────────────────────────────────
+
+function parseInto(filtered: string[]): string[] | null {
+  const idx = filtered.indexOf("--into")
+  if (idx === -1) return null
+  const val = filtered[idx + 1]
+  if (!val || val.startsWith("--")) {
+    console.error("error: --into requires a comma-separated target list (claude,codex,agents,openclaw,opencode)")
+    process.exit(1)
+  }
+  return val.split(",").map(s => s.trim()).filter(Boolean)
+}
+
+export function runSkillsCommand(filtered: string[], jsonMode: boolean): null {
+  const sub = filtered[1] && !filtered[1].startsWith("--") ? filtered[1] : "list"
+  const packDir = resolvePackDir()
+
+  if (!packDir) {
+    const msg = "no installed skill packs found (looked in the pkg location and for a dev checkout)"
+    if (jsonMode) console.log(JSON.stringify({ success: false, error: msg }))
+    else console.error(`error: ${msg}`)
+    process.exit(1)
+  }
+
+  const skills = discoverSkills(packDir)
+
+  if (sub === "list") {
+    const summary = skillsStatusSummary()
+    if (jsonMode) {
+      console.log(JSON.stringify({ packDir, skills: discoverSkills(packDir), targets: summary.targets }, null, 2))
+      return null
+    }
+    console.log(`skill packs at ${packDir}:\n`)
+    for (const s of skills) {
+      console.log(`  ${s.name}`)
+      if (s.description) console.log(`      ${s.description.slice(0, 120)}${s.description.length > 120 ? "…" : ""}`)
+    }
+    console.log("")
+    if (summary.targets.length === 0) {
+      console.log("no AI runtimes detected (~/.claude, ~/.codex, ~/.agents, ~/.openclaw, ~/.config/opencode)")
+    } else {
+      for (const t of summary.targets) console.log(`  ${t.id}: ${t.linked}/${t.total} linked (${t.dir})`)
+      console.log("\nRun 'interceptor skills adopt' to link, 'interceptor skills status' for detail, 'interceptor skills show <name>' for one skill.")
+    }
+    return null
+  }
+
+  if (sub === "status") {
+    const summary = skillsStatusSummary()
+    if (jsonMode) {
+      console.log(JSON.stringify(summary, null, 2))
+      return null
+    }
+    if (summary.targets.length === 0) {
+      console.log("no AI runtimes detected")
+      return null
+    }
+    for (const t of summary.targets) {
+      console.log(`${t.id} (${t.dir}): ${t.linked}/${t.total} linked`)
+      for (const [name, st] of Object.entries(t.states)) {
+        console.log(`  ${st === "linked" ? "✓" : st === "missing" ? "·" : "!"} ${name}: ${st}`)
+      }
+    }
+    return null
+  }
+
+  if (sub === "show") {
+    const name = filtered[2]
+    const skill = skills.find(s => s.name === name)
+    if (!skill) {
+      console.error(`error: unknown skill '${name || ""}'. Installed: ${skills.map(s => s.name).join(", ")}`)
+      process.exit(1)
+    }
+    const summary = skillsStatusSummary()
+    if (jsonMode) {
+      console.log(JSON.stringify({
+        ...skill,
+        adoption: summary.targets.map(t => ({ target: t.id, state: t.states[skill.name] })),
+      }, null, 2))
+      return null
+    }
+    console.log(`${skill.name} — ${skill.description}`)
+    console.log(`pack: ${skill.dir}`)
+    for (const t of summary.targets) console.log(`  ${t.id}: ${t.states[skill.name]}`)
+    if (skill.name === "interceptor-browser" || skill.name === "interceptor") {
+      console.log("\nPicking the right text verb (what each actually returns):")
+      console.log("  read --text-only / text     visible rendered text (innerText); 8K cap, --full → 200K")
+      console.log("  read --markdown             text WITH structure — headings/bold/lists/tables preserved")
+      console.log("  text e<ref>                 one element's textContent (includes display:none text)")
+      console.log("  html e<ref>                 raw outerHTML markup")
+      console.log("  read --tree-only / tree     a11y tree of interactive elements + refs for act")
+      console.log("  find \"<term>\"               locate elements by accessible name (returns refs, NOT text search)")
+      console.log("  search <query>              in-page text search")
+      console.log("  table/links/forms/query     structured JSON extraction")
+      console.log("\nFull machine-readable semantics: interceptor manifest")
+    }
+    return null
+  }
+
+  if (sub === "adopt") {
+    const force = filtered.includes("--force")
+    const all = filtered.includes("--all")
+    const intoIds = parseInto(filtered)
+    const detected = detectedTargets()
+    const targets = intoIds
+      ? allTargets().filter(t => intoIds.includes(t.id))
+      : detected
+    if (intoIds) {
+      const known = new Set(allTargets().map(t => t.id))
+      const bad = intoIds.filter(id => !known.has(id))
+      if (bad.length) {
+        console.error(`error: unknown target(s) ${bad.join(", ")} (valid: claude, codex, agents, openclaw, opencode)`)
+        process.exit(1)
+      }
+    }
+    if (targets.length === 0) {
+      console.error("error: no AI runtimes detected and no --into given. Try: interceptor skills adopt --into claude")
+      process.exit(1)
+    }
+    // positional skill names: argv is normalized, so positionals run from
+    // index 2 until the first flag token
+    const nameArgs: string[] = []
+    for (let i = 2; i < filtered.length; i++) {
+      if (filtered[i].startsWith("--")) break
+      nameArgs.push(filtered[i])
+    }
+    const unknown = nameArgs.filter(n => !skills.some(s => s.name === n))
+    if (unknown.length > 0) {
+      console.error(`error: unknown skill(s) ${unknown.join(", ")}. Installed: ${skills.map(s => s.name).join(", ")}`)
+      process.exit(1)
+    }
+    const requested = all || nameArgs.length === 0
+      ? skills
+      : skills.filter(s => nameArgs.includes(s.name))
+
+    const results: AdoptResult[] = []
+    for (const t of targets) {
+      for (const s of requested) {
+        results.push(adoptSkill(t, s, force))
+      }
+    }
+    if (jsonMode) {
+      console.log(JSON.stringify({ success: results.every(r => r.action !== "error"), results }, null, 2))
+    } else {
+      for (const r of results) {
+        const mark = r.action === "error" ? "✗" : r.action === "skipped" ? "!" : "✓"
+        console.log(`${mark} ${r.target}/${r.skill}: ${r.action}${r.detail ? ` — ${r.detail}` : ""}`)
+      }
+      const skipped = results.filter(r => r.action === "skipped").length
+      if (skipped) console.log(`\n${skipped} destination(s) were real directories — re-run with --force to replace them with links.`)
+    }
+    if (results.some(r => r.action === "error")) process.exit(1)
+    return null
+  }
+
+  console.error(`error: unknown skills subcommand '${sub}'. Usage: interceptor skills [list|status|show <name>|adopt [names…] [--into t1,t2] [--all] [--force]]`)
+  process.exit(1)
+}

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -3,6 +3,8 @@
 // runs `interceptor <cmd> --help` mid-task — often without the skill reference
 // loaded — so this block carries everything needed to form a correct invocation
 // in one shot (flags, accepted inputs, response shape, an example).
+import { COMMAND_SPECS } from "./manifest"
+
 const COMMAND_HELP: Record<string, string> = {
   save: [
     "interceptor save — write page-produced bytes to disk (no downloads shelf, Save dialog, clipboard, or CDP)",
@@ -35,10 +37,18 @@ const COMMAND_HELP: Record<string, string> = {
 // "  interceptor <cmd> ". User types `interceptor <cmd> --help` (or `-h`) and
 // gets exactly the slice for that command.
 export function helpForCommand(cmd: string): string | null {
-  const footer = `Run 'interceptor help' for the full command list, or 'interceptor ${cmd} -h' is an alias for --help.`
+  const footer = `Run 'interceptor help --all' for the full command list, or 'interceptor ${cmd} -h' is an alias for --help.`
+  // per-verb returns semantics from the manifest spec, so an
+  // agent forming an invocation also learns exactly what comes back.
+  const spec = COMMAND_SPECS.find(s => s.name === cmd)
+  const semantics: string[] = []
+  if (spec) {
+    semantics.push("", `Returns: ${spec.returns}`)
+    if (spec.example) semantics.push(`Example: ${spec.example}`)
+  }
   const curated = COMMAND_HELP[cmd]
   if (curated) {
-    return [curated, "", footer].join("\n")
+    return [curated, ...semantics, "", footer].join("\n")
   }
   const lines = HELP.split("\n")
   const matched: string[] = []
@@ -53,12 +63,96 @@ export function helpForCommand(cmd: string): string | null {
     `interceptor ${cmd} — usage`,
     "",
     ...matched,
+    ...semantics,
     "",
     footer,
   ].join("\n")
 }
 
-export const HELP = `interceptor — browser control CLI
+// ── progressive disclosure ─────────────────────────────────────
+// Tier 0 (shortHelp): bare `interceptor`, `interceptor --help`, `interceptor help`.
+//   A CAPABILITY MAP, not a teaser — EVERY verb on every installed surface, one
+//   line each, so an AI agent with no skill pack loaded learns the full
+//   out-of-box surface in a single read. Flags/response-shapes live one level
+//   down (`help <cmd>` / `manifest`) so the map stays scannable but hides nothing.
+// Tier 1: `interceptor help <cmd>` / `interceptor <cmd> --help` (helpForCommand).
+// Tier 2 (`help --all`): the exhaustive per-flag dump, filtered to installed surfaces.
+
+const MAP_HEADER = `interceptor — drive a real browser, macOS, and iPhone from one CLI (built for AI agents)
+
+You operate a signed-in browser session — and, on the full install, native macOS
+apps and a physical iPhone — by reading accessibility trees + text and acting on
+element refs (not blind pixel taps). Everything below works now; no skill pack
+needed. Go deeper on any verb:
+  interceptor help <command>     One command's full contract: flags, inputs, what it returns
+  interceptor manifest           Machine-readable JSON — every verb + its exact return shape
+  interceptor help --all         Exhaustive per-flag reference for every installed surface
+  interceptor skills adopt       Install the deep skill-pack playbooks into your AI runtime`
+
+const MAP_BROWSER = `BROWSER — a signed-in Chrome/Brave profile, background tabs by default:
+  Compound   open <url> · read [ref] · act <ref> ["text"] · inspect     one-call open / read / act / debug
+  Read text  text (visible innerText) · text --markdown (keeps headings/tables) · html <ref> (raw markup)
+  Structure  tree (a11y refs to act on) · find "<name>" (elements by name) · search "<q>" (full-text) · state · diff
+  Extract    table · links · images · forms · query <css> · exists · count · attr · style      structured JSON
+  Act        act <ref> · click · type · select · focus · hover · drag · dblclick · rightclick · check · keys · scroll
+  Navigate   navigate <url> · back · forward · scroll · wait <ms> · wait-stable
+  Tabs       tabs · tab new|close|switch · window · frames · session · group (per-agent isolation) · contexts
+  Network    net (passive log → HAR/pcapng) · headers · override (rewrite requests) · sse
+  Capture    screenshot [ref] · canvas · ocr · save --out <path> <expr>  (page bytes straight to disk) · eval <js> (CSP-proof)
+  Data       cookies · storage · history · bookmarks · downloads · clipboard · clear
+  Record     monitor (record → replay) · scene (canvas / rich editors) · batch (many actions, one call) · brand`
+
+const MAP_MACOS = `MACOS — native apps via the accessibility tree, background-first (no focus steal unless you pass --activate):
+  Compound   macos open <app> · macos read · macos act <ref> ["text"] · macos inspect
+  AX+input   macos tree · find · value · action · focused · windows · move · resize · click · type · keys · scroll · drag
+  Apps       macos apps · app activate|hide|quit|launch · frontmost · menu "<path>"
+  Capture    macos screenshot (occluded/minimized windows too) · capture · stream · display
+  Scripts    macos script run --jxa|--jsc|--script · intent dispatch (Apple Events, no foregrounding)
+  System     macos clipboard · notifications · files · fs read|write|search · url · log query
+  Media/AI   macos vision (OCR any window) · listen (speech-to-text) · nlp · ai prompt · audio · sounds
+  Docs/data  macos pdf · detect · translate · thumbnail · calendar · reminders · contacts · photos · location · music · maps · share
+  Electron   macos cdp discover|connect|app attach     drive an Electron/Chromium app's web contents
+  Runtime    macos runtime enable|tree|read|eval|mutate     in-process control of a running native app
+  Trust      macos trust     permission status + Accessibility/Screen/Microphone prompts`
+
+const MAP_IOS = `iOS — automate a physical iPhone over WiFi (on-device XCUITest runner, no cable once paired):
+  Drive      ios tree · find · inspect       on-screen elements + refs (auto-connects on first verb)
+  Input      ios click · type · keys · scroll · drag · press       trusted XCUITest input
+  Apps       ios screenshot · apps · app launch|activate|terminate · devices · name
+  Setup      ios install | login | setup     one-time: put the InterceptorRunner on the phone
+  Connection model (read this before you panic about 'connected: false'):
+    • Phone must be owned, unlocked, in Developer Mode, and WiFi-paired to this Mac.
+    • 'ios devices' showing "connected: false" is NORMAL when idle — it means "installed,
+      auto-connects on the next verb", NOT "broken". Just run a verb (e.g. 'ios tree --on <name>').
+    • Keep the phone unlocked and awake while driving — auto-lock drops the runner.
+    • 'interceptor help ios' / 'ios help' has the full setup + troubleshooting flow.`
+
+const MAP_UPGRADE = `macOS + iPhone control are NOT enabled on this browser-only install:
+  interceptor upgrade --full     Add native macOS + iPhone control (macOS host only)`
+
+const MAP_FOOTER = `LOCAL (no browser needed):
+  status · init · skills (adopt packs into Claude Code / Codex / ~/.agents) · manifest · research · upgrade · help
+
+GLOBAL FLAGS (any command, any position — flag order never changes meaning):
+  --json  --context <id>  --tab <id>  --group <label>  --frame <id>  --all-surfaces
+  e.g. 'open --text-only <url>' ≡ 'open <url> --text-only'
+
+Docs & issues: https://github.com/Hacker-Valley-Media/Interceptor`
+
+/** Tier-0 capability map, gated to the surfaces this install actually has. */
+export function shortHelp(surfaces: { macos: boolean; ios: boolean }): string {
+  const parts = [MAP_HEADER, MAP_BROWSER]
+  if (surfaces.macos) parts.push(MAP_MACOS)
+  if (surfaces.ios) parts.push(MAP_IOS)
+  if (!surfaces.macos && !surfaces.ios) parts.push(MAP_UPGRADE)
+  parts.push(MAP_FOOTER)
+  return parts.join("\n\n")
+}
+
+// Static all-surfaces fallback for callers/tests that don't detect surfaces.
+export const SHORT_HELP = shortHelp({ macos: true, ios: true })
+
+const HELP_BROWSER = `interceptor — browser control CLI
 
 Flags:
   -V, --version                       Print version, build SHA, and build date
@@ -72,7 +166,7 @@ Compound (agent-optimized):
   interceptor open <url> --activate          Foreground the new tab (explicit opt-in; background-first contract)
   interceptor open <url> --tree-only         Skip text, return only tree
   interceptor open <url> --text-only         Skip tree, return only text
-  interceptor open <url> --full              Full text instead of 2000-char summary
+  interceptor open <url> --full              Full text (200K cap) instead of the 8000-char summary
   interceptor open <url> --timeout <ms>      Override wait-stable timeout (default 5000)
   interceptor open <url> --no-wait           Return immediately after tab creation
   interceptor open <url> --reuse             Navigate the most recent Interceptor-group tab instead of opening a new one (cleans up long automation runs)
@@ -306,7 +400,13 @@ Meta:
   interceptor status                         Check daemon status (local — no connection needed)
   interceptor status --verbose               Daemon + bridge + extension probe with per-component diagnostics
   interceptor status --explain               Alias for --verbose with extra rationale per component
-  interceptor help                           This help text
+  interceptor help [<command>|--all]         Concise help / one command's contract / the full reference
+  interceptor manifest                       Machine-readable capability manifest (verbs, flags, returns, skills)
+  interceptor skills list                    Skill packs shipped with this install + adoption state
+  interceptor skills status                  Per-runtime link state (linked / stale-copy / foreign / missing)
+  interceptor skills show <name>             One skill's purpose + which text verb returns what
+  interceptor skills adopt [names…] [--into claude,codex,agents] [--all] [--force]
+                                             Symlink skill packs into AI runtimes (junctions on Windows)
 
 Branding:
   interceptor brand tab-group --title <label> [--color <color>]
@@ -315,9 +415,9 @@ Branding:
 Tab groups (per-agent isolation):
   interceptor open <url> --group <label>     Open into the named group "<brand>-<label>" (created on first use)
   interceptor group list                     All live tab groups: label, title, color, tab count
-  interceptor group close <label>            Atomically close every tab in a named group (other groups untouched)
+  interceptor group close <label>            Atomically close every tab in a named group (other groups untouched)`
 
-macOS App Internals:
+const HELP_MACOS = `macOS App Internals:
   interceptor macos cdp connect <port> [--host H] [--app NAME] [--url HINT]
                                              Attach to an Electron/Chromium app debug port
   interceptor macos cdp discover             List running Electron/Chromium apps + CDP/debug-port status
@@ -522,9 +622,9 @@ macOS Bridge (full install only):
   Notifications (UN extension to existing notifications domain):
   interceptor macos notifications status|request|settings|post|schedule-after|schedule-at|schedule-cron|cancel|cancel-all|pending|delivered|dismiss|dismiss-all
   interceptor macos notifications post --title "..." --body "..." [--sound default] [--badge N] [--category <id>]
-  interceptor macos notifications categories list|register|clear
+  interceptor macos notifications categories list|register|clear`
 
-  iOS — automate your iPhone (pre-built agent, no signing/env):
+const HELP_IOS = `  iOS — automate your iPhone (pre-built agent, no signing/env):
   interceptor ios install [<device>]         Push the agent to a phone (plugged in + unlocked)
   interceptor ios devices                     Phones with the agent (+ names)
   interceptor ios name <device> <alias>       Rename a phone (then use --on <alias>)
@@ -532,3 +632,18 @@ macOS Bridge (full install only):
   interceptor ios click|type|keys|scroll|drag|press [--on <name>]   Trusted XCUITest input
   interceptor ios screenshot | apps | app launch|activate|terminate <id> [--on <name>]
   Run 'interceptor ios help' for the full iOS surface.`
+
+// Back-compat: the complete dump (all surfaces), used by helpForCommand's
+// line-grep and by `help --all` on full installs.
+export const HELP = [HELP_BROWSER, HELP_MACOS, HELP_IOS].join("\n\n")
+
+/** Tier-2 help filtered to the surfaces present on this install. */
+export function fullHelp(surfaces: { macos: boolean; ios: boolean }): string {
+  const parts = [HELP_BROWSER]
+  if (surfaces.macos) parts.push(HELP_MACOS)
+  if (surfaces.ios) parts.push(HELP_IOS)
+  if (!surfaces.macos || !surfaces.ios) {
+    parts.push("macos/ios: not available in this install — 'interceptor upgrade --full' adds computer-use mode (macOS only).")
+  }
+  return parts.join("\n\n")
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,7 @@
-import { HELP, helpForCommand } from "./help"
+import { HELP, shortHelp, fullHelp, helpForCommand } from "./help"
+import { detectSurfaces, SURFACE_UPGRADE_HINT } from "./lib/surfaces"
+import { runSkillsCommand, maybeEmitSkillsHint } from "./commands/skills"
+import { runManifestCommand } from "./manifest"
 import { parseTabFlag, parseContextFlag, parseGroupFlag, parseGroupColorFlag } from "./parse"
 import { formatState, formatTabs, formatCookies, formatResult } from "./format"
 import { sendCommand, sendCommandWs, setGlobalGroup, type DaemonResult, type DaemonResponse } from "./transport"
@@ -35,6 +38,7 @@ import { runResearchCommand } from "./commands/research"
 import { runExtensionsCommand } from "./commands/extensions"
 import { VERSION, BUILD_SHA, BUILD_DATE } from "./version"
 import { buildFilteredArgs } from "./global-flags"
+import { normalizeArgs } from "./normalize"
 
 // Command → module routing
 const STATE_CMDS = new Set(["state", "tree", "diff", "find", "text", "html"])
@@ -61,11 +65,13 @@ const UPGRADE_CMDS = new Set(["upgrade"])
 const INIT_CMDS = new Set(["init"])
 const RESEARCH_CMDS = new Set(["research"])
 const EXTENSIONS_CMDS = new Set(["extensions"])
+const SKILLS_CMDS = new Set(["skills"])
+const MANIFEST_CMDS = new Set(["manifest"])
 
 // Commands that don't require a daemon connection (or, in init's case,
 // bootstrap it themselves rather than relying on the pre-dispatch auto-spawn).
 // `research` prints guidance / manages an on-disk ledger — no browser, no daemon.
-const NO_DAEMON = new Set(["status", "help", "events", "session", "upgrade", "init", "research", "extensions"])
+const NO_DAEMON = new Set(["status", "help", "events", "session", "upgrade", "init", "research", "extensions", "skills", "manifest"])
 
 // Every command the CLI dispatches. Used to reject unknown commands
 // before any daemon-spawning side effect runs.
@@ -75,6 +81,7 @@ const ALL_KNOWN_CMDS = new Set<string>([
   ...SAVE_CMDS, ...BRAND_CMDS, ...GROUP_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
   ...COMPOUND_CMDS, ...OVERRIDE_CMDS, ...MACOS_CMDS, ...IOS_CMDS,
   ...UPGRADE_CMDS, ...INIT_CMDS, ...RESEARCH_CMDS, ...EXTENSIONS_CMDS,
+  ...SKILLS_CMDS, ...MANIFEST_CMDS,
   "help", "contexts",
 ])
 
@@ -115,10 +122,26 @@ async function main() {
   // by position: `--json` at index 0 or 1 is the global boolean (it's
   // always near the front, like `interceptor --json status`); deeper
   // occurrences are always domain value flags consumed by the parser.
-  const filtered = buildFilteredArgs(args)
+  let filtered = buildFilteredArgs(args)
 
+  // progressive disclosure. Bare invocation and `help` print the
+  // concise tier-0 card; `help <cmd>` prints one command's contract; `help
+  // --all` prints the exhaustive reference filtered to installed surfaces.
   if (filtered.length === 0 || filtered[0] === "help") {
-    console.log(HELP)
+    const helpArg = filtered[1]
+    if (helpArg && !helpArg.startsWith("-")) {
+      const sub = helpForCommand(helpArg)
+      if (sub) {
+        console.log(sub)
+      } else {
+        console.error(`error: no help for '${helpArg}'. Run 'interceptor help --all' for the full reference.`)
+        process.exit(1)
+      }
+    } else if (filtered.includes("--all")) {
+      console.log(fullHelp(detectSurfaces(args)))
+    } else {
+      console.log(shortHelp(detectSurfaces(args)))
+    }
     return
   }
 
@@ -139,10 +162,21 @@ async function main() {
 
   const cmd = filtered[0]
 
+  // rewrite argv to [cmd, ...positionals, ...flags] so flag
+  // position never changes meaning (e.g. `open --text-only <url>` used to
+  // create a tab whose URL was literally "--text-only"). macos/ios pass
+  // through untouched — see cli/normalize.ts.
+  filtered = normalizeArgs(filtered)
+
   // Per-command --help / -h short-circuit. `interceptor open --help` prints
   // the open-specific help block; `interceptor --help` (no command) falls
   // back to the full HELP. Runs before any daemon-spawn side effect.
   if (filtered.includes("--help") || filtered.includes("-h")) {
+    // Bare `interceptor --help` (no command) prints the tier-0 card.
+    if (cmd.startsWith("-")) {
+      console.log(shortHelp(detectSurfaces(args)))
+      return
+    }
     if (cmd === "macos" && (filtered[1] === "cdp" || filtered[1] === "runtime")) {
       await runMacosCommand(filtered, { jsonMode, useWs, globalTabId, contextId: globalContextId })
       return
@@ -159,7 +193,7 @@ async function main() {
     if (sub) {
       console.log(sub)
     } else {
-      console.log(HELP)
+      console.log(shortHelp(detectSurfaces(args)))
     }
     return
   }
@@ -168,6 +202,21 @@ async function main() {
     console.error(`error: unknown command '${cmd}'. Run 'interceptor help' for usage.`)
     process.exit(1)
   }
+
+  // fail fast (before any daemon spawn) when a surface is not
+  // part of this install. Override with --all-surfaces / INTERCEPTOR_ALL_SURFACES.
+  if (MACOS_CMDS.has(cmd) || IOS_CMDS.has(cmd)) {
+    const surfaces = detectSurfaces(args)
+    const available = MACOS_CMDS.has(cmd) ? surfaces.macos : surfaces.ios
+    if (!available) {
+      console.error(`error: ${SURFACE_UPGRADE_HINT}`)
+      process.exit(1)
+    }
+  }
+
+  // one rate-limited stderr hint when installed skill packs are
+  // not linked into detected AI runtimes (fires after installs and updates).
+  if (cmd !== "skills" && cmd !== "manifest") maybeEmitSkillsHint(args)
 
   let needsDaemon = !NO_DAEMON.has(cmd)
   if (cmd === "monitor" && filtered[1] && MONITOR_LOCAL_SUBCOMMANDS.has(filtered[1])) {
@@ -211,6 +260,16 @@ async function main() {
 
   if (EXTENSIONS_CMDS.has(cmd)) {
     runExtensionsCommand(filtered, jsonMode)
+    return
+  }
+
+  if (SKILLS_CMDS.has(cmd)) {
+    runSkillsCommand(filtered, jsonMode)
+    return
+  }
+
+  if (MANIFEST_CMDS.has(cmd)) {
+    runManifestCommand(args)
     return
   }
 

--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs"
 import { spawnSync } from "node:child_process"
 import { IS_WIN, SOCKET_PATH, PID_PATH, transportLabel } from "../../shared/platform"
+import { skillsStatusSummary } from "../commands/skills"
 
 export type StatusSnapshot = {
   mode: "browser-only" | "full" | "unknown"
@@ -38,6 +39,11 @@ export type StatusSnapshot = {
     probed: boolean
     reachable: boolean
     reason?: string
+  }
+  // skills-adoption block — pack presence + per-runtime link counts
+  skills?: {
+    packDir: string | null
+    targets: Array<{ id: string; linked: number; total: number }>
   }
 }
 
@@ -121,6 +127,19 @@ export function readStatusSnapshot(): StatusSnapshot {
     mode = "browser-only"
   }
 
+  let skills: StatusSnapshot["skills"]
+  try {
+    const summary = skillsStatusSummary()
+    if (summary.packDir) {
+      skills = {
+        packDir: summary.packDir,
+        targets: summary.targets.map(t => ({ id: t.id, linked: t.linked, total: t.total })),
+      }
+    }
+  } catch {
+    // status must never fail because of skills probing
+  }
+
   return {
     mode,
     daemon: daemonAlive,
@@ -133,6 +152,7 @@ export function readStatusSnapshot(): StatusSnapshot {
     launchAgentInstalled,
     launchAgentPath,
     launchAgentLoaded,
+    skills,
   }
 }
 
@@ -320,6 +340,23 @@ export function formatStatus(snap: StatusSnapshot, opts: { verbose?: boolean }):
     }
   }
 
+  // skills adoption block — pack presence + per-runtime link counts
+  if (snap.skills && snap.skills.targets.length > 0) {
+    lines.push("")
+    if (v) {
+      lines.push("skills (Interceptor skill packs linked into AI runtimes — see 'interceptor skills status'):")
+    } else {
+      lines.push("skills:")
+    }
+    for (const t of snap.skills.targets) {
+      const mark = t.linked === t.total ? "✓" : "⚠"
+      lines.push(`  ${mark} ${t.id}: ${t.linked}/${t.total} linked`)
+    }
+    if (snap.skills.targets.some(t => t.linked < t.total)) {
+      lines.push("  hint: interceptor skills adopt")
+    }
+  }
+
   if (!snap.daemon) {
     lines.push("")
     lines.push("hint: run any interceptor command and the daemon will auto-start.")
@@ -346,5 +383,6 @@ export function snapshotToJson(snap: StatusSnapshot): Record<string, unknown> {
   }
   if (snap.browser) base.browser = snap.browser
   if (snap.extension) base.extension = snap.extension
+  if (snap.skills) base.skills = snap.skills
   return base
 }

--- a/cli/lib/surfaces.ts
+++ b/cli/lib/surfaces.ts
@@ -1,0 +1,37 @@
+/**
+ * cli/lib/surfaces.ts — which Interceptor surfaces exist on this install
+ *
+ *
+ * Both pkgs ship the same CLI binary; the Full pkg additionally lays down the
+ * bridge LaunchAgent. Surface presence is therefore detected, not compiled in:
+ *   browser  — always (it IS the product)
+ *   macos    — darwin + bridge LaunchAgent plist present (Full install),
+ *              or a dev checkout running the bridge directly
+ *   ios      — rides the Full daemon (same detection as macos)
+ *
+ * INTERCEPTOR_ALL_SURFACES=1 or --all-surfaces overrides detection — used by
+ * docs tooling and by agents deciding whether to suggest `upgrade --full`.
+ */
+
+import { existsSync } from "node:fs"
+
+export type Surfaces = { browser: true; macos: boolean; ios: boolean }
+
+const LAUNCH_AGENT_SYSTEM = "/Library/LaunchAgents/com.interceptor.bridge.plist"
+
+function launchAgentUser(): string {
+  return `${process.env.HOME || ""}/Library/LaunchAgents/com.interceptor.bridge.plist`
+}
+
+export function detectSurfaces(argv: string[] = [], env: Record<string, string | undefined> = process.env): Surfaces {
+  if (argv.includes("--all-surfaces") || env.INTERCEPTOR_ALL_SURFACES) {
+    return { browser: true, macos: true, ios: true }
+  }
+  const full = process.platform === "darwin" &&
+    (existsSync(LAUNCH_AGENT_SYSTEM) || existsSync(launchAgentUser()) ||
+     existsSync("/tmp/interceptor-bridge.sock"))
+  return { browser: true, macos: full, ios: full }
+}
+
+export const SURFACE_UPGRADE_HINT =
+  "macos/ios: not available in this install — 'interceptor upgrade --full' adds computer-use mode (macOS only)."

--- a/cli/manifest.ts
+++ b/cli/manifest.ts
@@ -1,0 +1,198 @@
+/**
+ * cli/manifest.ts — interceptor manifest
+ *
+ * Machine-readable capability discovery for AI agents: what each verb does,
+ * what it RETURNS (the load-bearing part — innerText vs textContent vs
+ * markdown vs a11y tree are different answers to "get me the text"), which
+ * surfaces exist on this install, and skill-pack adoption state. An agent
+ * that never loaded a skill can ask the binary itself in one structured call
+ * instead of grepping a 33KB help dump.
+ *
+ * The returns: strings are verified against the extension implementation
+ * (extension/src/content/data/extract.ts, cli/commands/*.ts) — keep them in
+ * lockstep when extraction semantics change.
+ */
+
+import { VERSION, BUILD_SHA } from "./version"
+import { detectSurfaces } from "./lib/surfaces"
+import { skillsStatusSummary } from "./commands/skills"
+
+export type FlagSpec = { name: string; value?: string; description: string }
+export type CommandSpec = {
+  name: string
+  surface: "browser" | "macos" | "ios" | "local"
+  usage: string
+  summary: string
+  returns: string
+  flags?: FlagSpec[]
+  example?: string
+}
+
+export const COMMAND_SPECS: CommandSpec[] = [
+  // ── compound (agent-optimized) ──────────────────────────────────────────────
+  {
+    name: "open", surface: "browser",
+    usage: "interceptor open <url> [--tree-only|--text-only] [--markdown] [--full] [--reuse] [--activate] [--no-wait] [--timeout <ms>]",
+    summary: "Open URL in a background tab, wait for stability, return a11y tree + page text",
+    returns: "tree: a11y tree (interactive elements + e<n> refs). text: document.body.innerText (visible rendered text), capped at 8,000 chars unless --full (200K). --markdown swaps text for a structure-preserving markdown render.",
+    flags: [
+      { name: "--tree-only", description: "skip text" },
+      { name: "--text-only", description: "skip tree" },
+      { name: "--markdown", description: "render text as markdown (headings/bold/lists/tables preserved)" },
+      { name: "--full", description: "lift the 8K text cap (up to 200K)" },
+      { name: "--reuse", description: "navigate the most recent managed tab instead of opening a new one" },
+      { name: "--activate", description: "foreground the tab (default is background-first)" },
+      { name: "--no-wait", description: "return immediately after tab creation" },
+      { name: "--timeout", value: "<ms>", description: "wait-stable timeout (default 5000)" },
+    ],
+    example: "interceptor open https://example.com --text-only",
+  },
+  {
+    name: "read", surface: "browser",
+    usage: "interceptor read [e<ref>] [--tree-only|--text-only] [--markdown] [--full] [--filter <mode>] [--tree-format compact|verbose] [--include-style] [--include-frames]",
+    summary: "Tree + text for the active tab (or an element subtree)",
+    returns: "Same shapes as open. With e<ref>: element-scoped — element text uses textContent (INCLUDES display:none text, unlike page-level innerText).",
+    flags: [
+      { name: "--tree-only", description: "a11y tree only (the way to find refs for act)" },
+      { name: "--text-only", description: "visible text only (innerText; flattens headings into prose)" },
+      { name: "--markdown", description: "text with structure: use when headings/tables matter" },
+      { name: "--full", description: "lift the 8K text cap" },
+      { name: "--filter", value: "interactive|all", description: "tree filter (default interactive)" },
+      { name: "--tree-format", value: "compact|verbose", description: "compact saves agent context" },
+      { name: "--include-frames", description: "walk all reachable frames (refs become e<frameId>_<n>)" },
+    ],
+    example: "interceptor read --markdown --full",
+  },
+  {
+    name: "act", surface: "browser",
+    usage: "interceptor act <ref> [value…] [--keys <combo>] [--trusted] [--append] [--no-read] [--timeout <ms>]",
+    summary: "Click (no value) or type (with value) on a ref, wait, return updated tree + diff",
+    returns: "Updated a11y tree + '--- diff ---' of what changed. 'ok (page navigated…)' when the action triggered navigation.",
+    flags: [
+      { name: "--keys", value: "<combo>", description: "send a keyboard shortcut instead (e.g. Enter, cmd+shift+p)" },
+      { name: "--trusted", description: "HID-sourced input — page sees isTrusted: true" },
+      { name: "--append", description: "type without clearing the field first" },
+      { name: "--no-read", description: "skip the post-action tree read" },
+    ],
+    example: "interceptor act e5 \"hello world\"",
+  },
+  {
+    name: "inspect", surface: "browser",
+    usage: "interceptor inspect [--net-only] [--limit <n>] [--filter <pattern>]",
+    summary: "Tree + text + network log + request headers in one call",
+    returns: "a11y tree, 2,000-char text summary, recent network entries, request headers.",
+    example: "interceptor inspect --net-only --filter api",
+  },
+  // ── reading & finding ───────────────────────────────────────────────────────
+  {
+    name: "text", surface: "browser",
+    usage: "interceptor text [e<ref>] [--markdown]",
+    summary: "Page or element text",
+    returns: "Page: document.body.innerText (visible only). Element: textContent (includes hidden text). --markdown preserves headings/lists/tables — 'get the headings' means --markdown or tree, NOT plain text.",
+  },
+  {
+    name: "html", surface: "browser",
+    usage: "interceptor html e<ref>",
+    summary: "Raw markup for an element",
+    returns: "outerHTML of the element subtree (raw markup — harder for agents to parse than rendered text; prefer text/read unless you need attributes).",
+  },
+  {
+    name: "tree", surface: "browser",
+    usage: "interceptor tree [--filter interactive|all] [--depth <n>] [--max-chars <n>] [--native]",
+    summary: "Accessibility tree with e<n> refs",
+    returns: "Indented a11y tree; refs are the input to act/click/type. filter=all includes headings and static text — use it to see document structure.",
+  },
+  {
+    name: "find", surface: "browser",
+    usage: "interceptor find \"<term>\" [--role <role>] [--limit <n>]",
+    summary: "Locate elements by accessible name",
+    returns: "Matching elements with refs. This matches element NAMES (buttons, links, fields) — it is NOT a full-text page search; use 'search' for that.",
+  },
+  {
+    name: "search", surface: "browser",
+    usage: "interceptor search <query…>",
+    summary: "Full-text search within the rendered page",
+    returns: "Text matches with surrounding context.",
+  },
+  {
+    name: "state", surface: "browser",
+    usage: "interceptor state [--full]",
+    summary: "Current page URL/title/status snapshot",
+    returns: "Structured page state (url, title, readyState, counts).",
+  },
+  { name: "diff", surface: "browser", usage: "interceptor diff", summary: "What changed since the last tree read", returns: "Added/removed/changed tree entries." },
+  // ── structured extraction ───────────────────────────────────────────────────
+  { name: "table", surface: "browser", usage: "interceptor table [selector]", summary: "Extract table data", returns: "Structured rows/columns as JSON — prefer over scraping markdown for tabular data." },
+  { name: "links", surface: "browser", usage: "interceptor links", summary: "All links on the page", returns: "Array of {text, href}." },
+  { name: "images", surface: "browser", usage: "interceptor images", summary: "All images", returns: "Array of {alt, src}." },
+  { name: "forms", surface: "browser", usage: "interceptor forms", summary: "All forms and fields", returns: "Form structure with field names/types/values." },
+  { name: "query", surface: "browser", usage: "interceptor query <css-selector>", summary: "Query elements by CSS selector", returns: "Matching elements with attributes." },
+  { name: "exists", surface: "browser", usage: "interceptor exists <css-selector>", summary: "Does a selector match?", returns: "Boolean." },
+  { name: "count", surface: "browser", usage: "interceptor count <css-selector>", summary: "How many elements match", returns: "Number." },
+  { name: "attr", surface: "browser", usage: "interceptor attr e<ref> <name> | attr set e<ref> <name> <value>", summary: "Get/set an attribute", returns: "Attribute value." },
+  { name: "style", surface: "browser", usage: "interceptor style e<ref> <property> | style inject --css \"<rules>\" | style remove <handle>", summary: "Computed style / stylesheet injection", returns: "Computed value, or an injection handle." },
+  // ── actions ─────────────────────────────────────────────────────────────────
+  { name: "click", surface: "browser", usage: "interceptor click e<ref>", summary: "Click an element", returns: "ok / error." },
+  { name: "type", surface: "browser", usage: "interceptor type e<ref> <text…>", summary: "Type into a field", returns: "ok / error." },
+  { name: "select", surface: "browser", usage: "interceptor select e<ref> <value>", summary: "Select an option", returns: "ok / error." },
+  { name: "keys", surface: "browser", usage: "interceptor keys <combo>", summary: "Send a keyboard shortcut", returns: "ok / error." },
+  { name: "scroll", surface: "browser", usage: "interceptor scroll up|down|top|bottom [--amount <px>]", summary: "Scroll the page", returns: "ok." },
+  { name: "hover", surface: "browser", usage: "interceptor hover e<ref>", summary: "Hover an element", returns: "ok." },
+  { name: "drag", surface: "browser", usage: "interceptor drag e<ref> [--from x,y --to x,y --steps <n>]", summary: "Drag an element or coordinates", returns: "ok." },
+  { name: "click-at", surface: "browser", usage: "interceptor click-at <x,y>", summary: "Click page coordinates", returns: "ok." },
+  { name: "navigate", surface: "browser", usage: "interceptor navigate <url>", summary: "Navigate the active tab", returns: "ok." },
+  { name: "wait", surface: "browser", usage: "interceptor wait <ms>", summary: "Sleep", returns: "ok." },
+  { name: "wait-stable", surface: "browser", usage: "interceptor wait-stable [--ms <n>] [--timeout <ms>]", summary: "Wait for DOM stability", returns: "ok when the DOM stops mutating." },
+  // ── tabs / network / capture / data ─────────────────────────────────────────
+  { name: "tabs", surface: "browser", usage: "interceptor tabs", summary: "List managed tabs", returns: "Tab list (id, url, title)." },
+  { name: "tab", surface: "browser", usage: "interceptor tab new|close|activate|reload […]", summary: "Tab lifecycle", returns: "ok / tab info." },
+  { name: "network", surface: "browser", usage: "interceptor net [--filter <pattern>] [--limit <n>] [--format har|json|pcapng --out <path>]", summary: "Passive network log", returns: "Recent requests (method, url, status, type); exportable to HAR/pcapng." },
+  { name: "headers", surface: "browser", usage: "interceptor headers [--filter <pattern>]", summary: "Request headers seen", returns: "Header sets per request." },
+  { name: "screenshot", surface: "browser", usage: "interceptor screenshot [e<ref>] [--save] [--format png|jpeg|webp] [--quality <n>]", summary: "Screenshot page/element", returns: "Image (saved to disk with --save; path on stderr)." },
+  { name: "eval", surface: "browser", usage: "interceptor eval <expr> [--main]", summary: "Evaluate JS in the page (ISOLATED world by default)", returns: "JSON-serialized expression result. Works on strict-CSP pages." },
+  { name: "save", surface: "browser", usage: "interceptor save --out <abs-path> <expr>", summary: "Stream page-produced bytes (Blob/File/ArrayBuffer) to disk", returns: "{path, bytes, sha256} — integrity-checked." },
+  { name: "cookies", surface: "browser", usage: "interceptor cookies [domain] | cookies set/delete …", summary: "Read/write cookies", returns: "Cookie list." },
+  { name: "storage", surface: "browser", usage: "interceptor storage [key] | storage delete <key>", summary: "localStorage access", returns: "Values." },
+  { name: "override", surface: "browser", usage: "interceptor override <sub> …", summary: "Request/response overrides", returns: "Override state." },
+  { name: "monitor", surface: "browser", usage: "interceptor monitor start|stop|status|tail|export …", summary: "Record page/network/user activity into a replayable session", returns: "Session id; export produces workflow artifacts." },
+  { name: "scene", surface: "browser", usage: "interceptor scene <sub> …", summary: "Scene-graph automation for canvas/rich editors", returns: "Scene nodes / action results." },
+  // ── local (no daemon) ───────────────────────────────────────────────────────
+  {
+    name: "skills", surface: "local",
+    usage: "interceptor skills [list|status|show <name>|adopt [names…] [--into claude,codex,agents] [--all] [--force]]",
+    summary: "List installed skill packs and link them into AI runtimes (Claude Code, Codex, ~/.agents)",
+    returns: "Adoption state per runtime; adopt creates symlinks (junctions on Windows) that stay current across updates.",
+    example: "interceptor skills adopt --into claude",
+  },
+  {
+    name: "manifest", surface: "local",
+    usage: "interceptor manifest",
+    summary: "This machine-readable capability manifest",
+    returns: "JSON: {name, version, surfaces, commands[{name,usage,summary,returns,flags}], skills}.",
+  },
+  { name: "status", surface: "local", usage: "interceptor status [--verbose]", summary: "Daemon/bridge/extension health + skills adoption", returns: "Status report." },
+  { name: "init", surface: "local", usage: "interceptor init [--verbose]", summary: "Bootstrap the daemon and report status", returns: "Status report." },
+  { name: "research", surface: "local", usage: "interceptor research [init|log|status|…]", summary: "Deep-research methodology + on-disk source ledger", returns: "Playbook guidance / ledger state." },
+  { name: "upgrade", surface: "local", usage: "interceptor upgrade --full", summary: "Promote browser-only install to full computer-use mode (macOS)", returns: "Installer output." },
+  // ── other surfaces (verbs enumerated via their own --help) ──────────────────
+  { name: "macos", surface: "macos", usage: "interceptor macos <verb> … (see: interceptor help macos)", summary: "Native macOS control: AX trees, background input, windows, screenshots, Apple Events, Electron CDP, app runtime", returns: "Per-verb; background-first — only 'app activate'/'open --activate' move focus." },
+  { name: "ios", surface: "ios", usage: "interceptor ios <verb> … (see: interceptor help ios)", summary: "iPhone automation via on-device XCUITest runner over WiFi", returns: "Per-verb: element trees, taps, typing, screenshots, app lifecycle. NOTE: 'ios devices' → connected:false is the normal idle state; the runner auto-connects on the next verb. Keep the phone unlocked & awake." },
+]
+
+export function runManifestCommand(argv: string[]): null {
+  const surfaces = detectSurfaces(argv)
+  const commands = COMMAND_SPECS.filter(c =>
+    c.surface === "browser" || c.surface === "local" ||
+    (c.surface === "macos" && surfaces.macos) || (c.surface === "ios" && surfaces.ios))
+  let skills: ReturnType<typeof skillsStatusSummary> | { packDir: null } = { packDir: null }
+  try { skills = skillsStatusSummary() } catch {}
+  console.log(JSON.stringify({
+    name: "interceptor",
+    version: VERSION,
+    sha: BUILD_SHA,
+    surfaces,
+    commands,
+    skills,
+  }, null, 2))
+  return null
+}

--- a/cli/normalize.ts
+++ b/cli/normalize.ts
@@ -1,0 +1,127 @@
+/**
+ * cli/normalize.ts — order-independent argument normalization
+ *
+ * Rewrites a command's argv so positionals keep their relative order and come
+ * first, followed by flags (each with its value). Existing command parsers
+ * read positionals at fixed indices (filtered[1], filtered[2]) and locate
+ * flags via indexOf/includes — both patterns work on the normalized shape, so
+ * every browser-surface command gains flag-order independence at this single
+ * choke point instead of 27 per-module rewrites. Fixes the class of bug where
+ * `interceptor open --text-only <url>` created a tab whose URL was literally
+ * "--text-only".
+ *
+ * Also gained for free on normalized commands:
+ *   --flag=value   split into `--flag value` (indexOf parsers understand it)
+ *   --             option terminator: everything after is positional verbatim
+ *
+ * The macos/ios surfaces are NOT normalized: they parse nested verbs with
+ * per-subverb flag semantics (e.g. --activate is a boolean for `macos open`
+ * but takes a value for `macos native tcc`, --on is a boolean for overlays
+ * but names a device for ios). ponytail: verb-first grammars there keep
+ * order-dependence livable; per-subverb specs are a later phase.
+ *
+ * CORRECTNESS CONTRACT: every flag that consumes a following value token in a
+ * command module MUST be listed for that command family below. A value flag
+ * missing from the map would have its value classified as a positional and
+ * reordered ahead of the flags, breaking `indexOf(flag) + 1` reads for
+ * invocations that work today. The sets below were harvested from every
+ * indexOf("--x")/flagValue(...)/VALUE_FLAGS site in cli/commands/*.ts.
+ */
+
+// Flags whose value token is optional (consume the next token only when it
+// does not look like another flag). Mirrors monitor.ts's own parsing.
+const OPTIONAL_VALUE_FLAGS = new Set(["--persist-bodies"])
+
+// buildFilteredArgs strips --tab/--context/--group/--group-color (+values)
+// before normalization, but --frame keeps its value in filtered args.
+const GLOBAL_VALUE_FLAGS = ["--frame"]
+
+const COMPOUND = ["--filter", "--keys", "--limit", "--timeout", "--tree-format"]
+const STATE = ["--depth", "--filter", "--limit", "--max-chars", "--role"]
+const ACTIONS = ["--at", "--duration", "--from", "--steps", "--to"]
+const NAV = ["--amount", "--ms", "--timeout"]
+const NET = ["--filter", "--format", "--limit", "--out", "--since", "--pattern", "--patterns", "--type"]
+const SCREENSHOT = ["--clip", "--element", "--filter", "--format", "--kind", "--limit", "--quality", "--ref", "--region", "--scale", "--selector", "--target-max-long-edge", "--threshold"]
+const DATA = ["--since"]
+const META = ["--css", "--frame-ids", "--since"]
+const SAVE = ["--out", "--chunk-size"]
+const BATCH = ["--timeout"]
+const MONITOR = ["--capture", "--format", "--guard-policy", "--instruction", "--mode", "--out", "--retention-policy", "--session", "--task", "--verifier-policy", "--persist-bodies"]
+const SCENE = ["--profile", "--slide", "--type"]
+const SSE = ["--filter", "--limit", "--timeout"]
+const RESEARCH = ["--dir", "--effort", "--note", "--slug", "--status"]
+const SKILLS = ["--into"]
+
+const VALUE_FLAGS_BY_CMD: Record<string, string[]> = {
+  // compound
+  open: COMPOUND, read: COMPOUND, act: COMPOUND, inspect: COMPOUND,
+  // state
+  state: STATE, tree: STATE, diff: STATE, find: STATE, text: STATE, html: STATE,
+  // actions
+  click: ACTIONS, type: ACTIONS, select: ACTIONS, focus: ACTIONS, blur: ACTIONS,
+  hover: ACTIONS, drag: ACTIONS, dblclick: ACTIONS, rightclick: ACTIONS,
+  check: ACTIONS, keys: ACTIONS, "click-at": ACTIONS, "what-at": ACTIONS, regions: ACTIONS,
+  // navigation
+  navigate: NAV, back: NAV, forward: NAV, scroll: NAV, wait: NAV, "wait-stable": NAV, wait_for: NAV,
+  // tabs (booleans only)
+  tabs: [], tab: [], window: [], frames: [], session: [],
+  // network
+  network: NET, net: NET, headers: NET,
+  // screenshot
+  screenshot: SCREENSHOT, canvas: SCREENSHOT, capture: SCREENSHOT, ocr: SCREENSHOT,
+  // data
+  cookies: DATA, storage: DATA, history: DATA, bookmarks: DATA, downloads: DATA, clear: DATA, clipboard: DATA,
+  // meta
+  status: META, reload: META, meta: META, links: META, images: META, forms: META,
+  info: META, page_info: META, query: META, exists: META, count: META, table: META,
+  attr: META, style: META, events: META, search: META, notify: META, sessions: META,
+  capabilities: META, modals: META, panels: META,
+  // singles
+  eval: [], save: SAVE, brand: [], group: [], batch: BATCH, raw: BATCH,
+  monitor: MONITOR, scene: SCENE, sse: SSE, override: [],
+  upgrade: [], init: [], research: RESEARCH, extensions: [], contexts: [],
+  skills: SKILLS, manifest: [],
+}
+
+/**
+ * Normalize `[cmd, ...rest]` to `[cmd, ...positionals, ...flags]`.
+ * Commands without a value-flag map (macos, ios) are returned untouched.
+ */
+export function normalizeArgs(filtered: string[]): string[] {
+  const cmd = filtered[0]
+  const familyFlags = VALUE_FLAGS_BY_CMD[cmd]
+  if (!familyFlags) return filtered
+  const vf = new Set([...familyFlags, ...GLOBAL_VALUE_FLAGS])
+
+  const positionals: string[] = []
+  const flags: string[] = []
+  let terminated = false
+
+  for (let i = 1; i < filtered.length; i++) {
+    const tok = filtered[i]
+    if (terminated) { positionals.push(tok); continue }
+    if (tok === "--") { terminated = true; continue }
+    if (tok.startsWith("--")) {
+      const eq = tok.indexOf("=")
+      if (eq > 2) {
+        const name = tok.slice(0, eq)
+        if (vf.has(name)) { flags.push(name, tok.slice(eq + 1)); continue }
+        flags.push(tok)
+        continue
+      }
+      flags.push(tok)
+      if (vf.has(tok) && i + 1 < filtered.length) {
+        const next = filtered[i + 1]
+        if (OPTIONAL_VALUE_FLAGS.has(tok) && next.startsWith("-")) continue
+        flags.push(next)
+        i++
+      }
+      continue
+    }
+    // includes single-dash tokens ("-100", "-h" is handled upstream) — they
+    // are values/positionals in this grammar, never short-option groups
+    positionals.push(tok)
+  }
+
+  return [cmd, ...positionals, ...flags]
+}

--- a/cli/version.ts
+++ b/cli/version.ts
@@ -1,6 +1,6 @@
 // Sentinel values used when running from source (`bun run cli`).
 // scripts/build.sh stamps real build values into this file just before
 // each `bun build --compile` and restores it afterwards via `git checkout`.
-export const VERSION = "0.20.12"
+export const VERSION = "0.22.1"
 export const BUILD_SHA = "dev"
 export const BUILD_DATE = "dev"

--- a/daemon/ios/manager.ts
+++ b/daemon/ios/manager.ts
@@ -353,17 +353,23 @@ export class IosManager {
         name: d.name,
         alias: aliasForUdid(d.udid),
         udid: d.udid,
+        // `connected` = a runner session is dialed in RIGHT NOW. It is false
+        // whenever the phone is idle; that is the normal ready state, not an
+        // error — the runner auto-launches and dials in on the next verb.
         connected: this.contexts.has(iosContextId(d.udid)),
         transport: d.transport ?? "unknown",
         productVersion: d.productVersion,
       }))
+    const anyIdle = out.some((d) => !d.connected)
     return {
       success: true,
       data: {
         devices: out,
         ...(out.length === 0
           ? { note: "no devices have the Interceptor agent yet — plug your iPhone in (unlocked) and run: interceptor ios install" }
-          : {}),
+          : anyIdle
+            ? { note: "connected:false is the normal idle state — the on-device runner auto-connects on the next verb (e.g. 'interceptor ios tree --on <name>'). Keep the phone unlocked & awake while driving." }
+            : {}),
       },
     }
   }

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.21.3",
+  "version": "0.22.1",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.21.3",
+  "version": "0.22.1",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.21.3",
+  "version": "0.22.1",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/installer/interceptor.iss
+++ b/scripts/installer/interceptor.iss
@@ -48,11 +48,25 @@ InfoAfterFile=post-install.txt
 
 [Tasks]
 Name: addtopath; Description: "Add Interceptor to your user PATH"; GroupDescription: "Additional integrations:"
+; link the browser-surface skill packs into Claude Code's skills
+; directory (%USERPROFILE%\.claude\skills). Junctions — created by
+; `interceptor skills adopt` — need neither Developer Mode nor elevation.
+; Windows is browser-only, so only the router + browser skills ship here.
+Name: linkskills; Description: "Link Interceptor AI skill packs into %USERPROFILE%\.claude\skills (Claude Code)"; GroupDescription: "Additional integrations:"
 
 [Files]
 Source: "..\..\dist\interceptor.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\daemon\interceptor-daemon.exe"; DestDir: "{app}\daemon"; Flags: ignoreversion
 Source: "..\..\extension\dist\*"; DestDir: "{app}\extension"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Skill packs — resolved by the CLI's skills verb at {app}\skills
+Source: "..\..\.agents\skills\interceptor\*"; DestDir: "{app}\skills\interceptor"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\..\.agents\skills\interceptor-browser\*"; DestDir: "{app}\skills\interceptor-browser"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\..\.agents\skills\interceptor-research\*"; DestDir: "{app}\skills\interceptor-research"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Run]
+; Runs as the installing user (per-user install, no elevation) so the junctions
+; land in the right profile. Codex users: `interceptor skills adopt --into codex`.
+Filename: "{app}\interceptor.exe"; Parameters: "skills adopt --all --into claude"; Flags: runhidden; Tasks: linkskills
 
 [Registry]
 ; Native messaging host registration. Points each Chromium-family browser

--- a/scripts/installer/post-install.txt
+++ b/scripts/installer/post-install.txt
@@ -18,6 +18,14 @@ Once both steps are done, open a fresh terminal and run:
     interceptor status
     interceptor open https://example.com
 
+AI skill packs: if you selected "Link Interceptor AI skill packs" during
+setup, the interceptor + interceptor-browser skills are already linked into
+%USERPROFILE%\.claude\skills (Claude Code). To manage links yourself:
+
+    interceptor skills status
+    interceptor skills adopt --into claude
+    interceptor skills adopt --into codex     (Codex: %USERPROFILE%\.codex\skills)
+
 If "interceptor" is not recognised in your terminal, close and reopen it so
 Windows picks up the updated user PATH. Or call the executable directly:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -450,6 +450,8 @@ if [[ "$BUILD_FULL" == "1" ]]; then
   run chmod 644 "$STAGING_DIR/daemon-full/Library/LaunchAgents/com.interceptor.bridge.plist"
   run ditto "$REPO_ROOT/.agents/skills/interceptor-macos" \
     "$STAGING_DIR/daemon-full/$DEST_SUPPORT_DIR/skills/interceptor-macos"
+  run ditto "$REPO_ROOT/.agents/skills/interceptor-ios" \
+    "$STAGING_DIR/daemon-full/$DEST_SUPPORT_DIR/skills/interceptor-ios"
 
   if [[ "$INCLUDE_AGENT_DYLIBS" == "1" ]]; then
     # Runtime Agent surface (research profile): ship the agent dylib(s) at

--- a/scripts/release/Resources/conclusion-browser.html
+++ b/scripts/release/Resources/conclusion-browser.html
@@ -4,18 +4,24 @@
 <meta charset="utf-8">
 <title>Interceptor — Almost Done</title>
 <style>
+  /* Issue #123: the Installer conclusion pane follows the system appearance.
+     Every color is declared for BOTH schemes — never rely on a default. */
+  :root { color-scheme: light dark; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
     font-size: 13px;
     line-height: 1.5;
     color: #1d1d1f;
-    margin: 18px 22px;
-    background: #fff;
+    /* top margin kept small so the heading never clips at the pane top */
+    margin: 12px 22px 18px;
+    background: transparent;
   }
   h2 {
     font-size: 17px;
     font-weight: 600;
     margin: 0 0 12px 0;
+    line-height: 1.3;
+    overflow-wrap: break-word;
     color: #1d1d1f;
   }
   h3 {
@@ -36,6 +42,7 @@
   code, .path {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     font-size: 12px;
+    color: #1d1d1f;
     background: #f5f5f7;
     padding: 1px 5px;
     border-radius: 3px;
@@ -44,6 +51,7 @@
   pre.cmd {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     font-size: 12px;
+    color: #1d1d1f;
     background: #f5f5f7;
     padding: 8px 10px;
     border-radius: 4px;
@@ -72,6 +80,23 @@
     padding-top: 10px;
     border-top: 1px solid #e5e5e7;
   }
+  @media (prefers-color-scheme: dark) {
+    body { color: #dddde0; }
+    h2, h3, h4 { color: #f5f5f7; }
+    code, .path {
+      color: #e8e8ea;
+      background: #3a3a3c;
+    }
+    pre.cmd {
+      color: #e8e8ea;
+      background: #2c2c2e;
+    }
+    .step-num { background: #0a84ff; color: #fff; }
+    .note {
+      color: #98989d;
+      border-top-color: #48484a;
+    }
+  }
 </style>
 </head>
 <body>
@@ -91,31 +116,12 @@
   <p>After the extension is connected, <code>interceptor reload</code> also refreshes the running extension service worker.</p>
 
   <h3><span class="step-num">2</span>Optional: register skill packs with your AI tooling</h3>
-  <p>Interceptor ships skill packs that teach AI agents how to drive the browser surface and how to research deeply (the <code>interceptor-research</code> methodology skill). Find your runtime below and paste its block into a terminal. Skip the runtimes you don&rsquo;t use. Existing symlinks of the same name are replaced safely; nothing else is touched.</p>
-
-  <h4>Claude Code &mdash; <code>~/.claude/skills</code></h4>
+  <p>Interceptor ships skill packs that teach AI agents how to drive the browser surface and how to research deeply (the <code>interceptor-research</code> methodology skill). One command links the skills you choose into the AI runtimes it detects (Claude Code, Codex, and any <code>~/.agents/skills</code> consumer) &mdash; and keeps them current across updates:</p>
+  <pre class="cmd">interceptor skills adopt</pre>
+  <p>Check what is linked at any time with <code>interceptor skills status</code>. Prefer to do it by hand? Symlink any skill directly, e.g. for Claude Code:</p>
   <pre class="cmd">mkdir -p ~/.claude/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.claude/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.claude/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.claude/skills/interceptor-research</pre>
-
-  <h4>Codex &mdash; <code>~/.agents/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.agents/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.agents/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.agents/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.agents/skills/interceptor-research</pre>
-
-  <h4>OpenClaw &mdash; <code>~/.openclaw/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.openclaw/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.openclaw/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.openclaw/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.openclaw/skills/interceptor-research</pre>
-
-  <h4>OpenCode &mdash; <code>~/.config/opencode/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.config/opencode/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.config/opencode/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.config/opencode/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.config/opencode/skills/interceptor-research</pre>
+ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.claude/skills/interceptor-browser</pre>
+  <p>The same pattern works for any runtime that reads a skills folder (<code>~/.codex/skills</code>, <code>~/.agents/skills</code>, <code>~/.openclaw/skills</code>, <code>~/.config/opencode/skills</code>).</p>
 
   <h3>Try it</h3>
   <p>Open a terminal and run:</p>

--- a/scripts/release/Resources/conclusion-full.html
+++ b/scripts/release/Resources/conclusion-full.html
@@ -4,18 +4,24 @@
 <meta charset="utf-8">
 <title>Interceptor — Almost Done</title>
 <style>
+  /* Issue #123: the Installer conclusion pane follows the system appearance.
+     Every color is declared for BOTH schemes — never rely on a default. */
+  :root { color-scheme: light dark; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
     font-size: 13px;
     line-height: 1.5;
     color: #1d1d1f;
-    margin: 18px 22px;
-    background: #fff;
+    /* top margin kept small so the heading never clips at the pane top */
+    margin: 12px 22px 18px;
+    background: transparent;
   }
   h2 {
     font-size: 17px;
     font-weight: 600;
     margin: 0 0 12px 0;
+    line-height: 1.3;
+    overflow-wrap: break-word;
     color: #1d1d1f;
   }
   h3 {
@@ -36,6 +42,7 @@
   code, .path {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     font-size: 12px;
+    color: #1d1d1f;
     background: #f5f5f7;
     padding: 1px 5px;
     border-radius: 3px;
@@ -44,6 +51,7 @@
   pre.cmd {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     font-size: 12px;
+    color: #1d1d1f;
     background: #f5f5f7;
     padding: 8px 10px;
     border-radius: 4px;
@@ -72,6 +80,23 @@
     padding-top: 10px;
     border-top: 1px solid #e5e5e7;
   }
+  @media (prefers-color-scheme: dark) {
+    body { color: #dddde0; }
+    h2, h3, h4 { color: #f5f5f7; }
+    code, .path {
+      color: #e8e8ea;
+      background: #3a3a3c;
+    }
+    pre.cmd {
+      color: #e8e8ea;
+      background: #2c2c2e;
+    }
+    .step-num { background: #0a84ff; color: #fff; }
+    .note {
+      color: #98989d;
+      border-top-color: #48484a;
+    }
+  }
 </style>
 </head>
 <body>
@@ -94,35 +119,12 @@
   <p>The first time you run an <code>interceptor macos</code> command, macOS will prompt for <strong>Accessibility</strong>, <strong>Screen Recording</strong>, and <strong>Apple Events</strong> for <code>interceptor-bridge</code>. Allow each one in <strong>System Settings &rarr; Privacy &amp; Security</strong>.</p>
 
   <h3><span class="step-num">3</span>Optional: register skill packs with your AI tooling</h3>
-  <p>Interceptor ships skill packs that teach AI agents how to drive both the browser and macOS surfaces, plus the <code>interceptor-research</code> deep-research methodology skill. Find your runtime below and paste its block into a terminal. Skip the runtimes you don&rsquo;t use. Existing symlinks of the same name are replaced safely; nothing else is touched.</p>
-
-  <h4>Claude Code &mdash; <code>~/.claude/skills</code></h4>
+  <p>Interceptor ships skill packs that teach AI agents how to drive the browser, macOS, and iOS surfaces, plus the <code>interceptor-research</code> deep-research methodology skill. One command links the skills you choose into the AI runtimes it detects (Claude Code, Codex, and any <code>~/.agents/skills</code> consumer) &mdash; and keeps them current across updates:</p>
+  <pre class="cmd">interceptor skills adopt</pre>
+  <p>Check what is linked at any time with <code>interceptor skills status</code>. Prefer to do it by hand? Symlink any skill directly, e.g. for Claude Code:</p>
   <pre class="cmd">mkdir -p ~/.claude/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.claude/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.claude/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.claude/skills/interceptor-research
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-macos" ~/.claude/skills/interceptor-macos</pre>
-
-  <h4>Codex &mdash; <code>~/.agents/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.agents/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.agents/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.agents/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.agents/skills/interceptor-research
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-macos" ~/.agents/skills/interceptor-macos</pre>
-
-  <h4>OpenClaw &mdash; <code>~/.openclaw/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.openclaw/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.openclaw/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.openclaw/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.openclaw/skills/interceptor-research
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-macos" ~/.openclaw/skills/interceptor-macos</pre>
-
-  <h4>OpenCode &mdash; <code>~/.config/opencode/skills</code></h4>
-  <pre class="cmd">mkdir -p ~/.config/opencode/skills
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor" ~/.config/opencode/skills/interceptor
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.config/opencode/skills/interceptor-browser
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-research" ~/.config/opencode/skills/interceptor-research
-ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-macos" ~/.config/opencode/skills/interceptor-macos</pre>
+ln -sfn "/Library/Application Support/Interceptor/skills/interceptor-browser" ~/.claude/skills/interceptor-browser</pre>
+  <p>The same pattern works for any runtime that reads a skills folder (<code>~/.codex/skills</code>, <code>~/.agents/skills</code>, <code>~/.openclaw/skills</code>, <code>~/.config/opencode/skills</code>).</p>
 
   <h3>Try it</h3>
   <p>Open a terminal and run:</p>

--- a/scripts/release/postinstall-browser
+++ b/scripts/release/postinstall-browser
@@ -76,4 +76,13 @@ if [[ -n "$TARGET_HOME" && -d "$TARGET_HOME" ]]; then
   done
 fi
 
+# ── skills-refresh marker ────────────────────────────────────────
+# Written on every install AND every (Sparkle-driven) update. The CLI's
+# rate-limited skills hint uses live filesystem probing; this marker records
+# what shipped and when. Failure here must never fail the install.
+{
+  printf 'installed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf 'skills=%s\n' "$(ls "$INSTALL_ROOT/skills" 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
+} >"$INSTALL_ROOT/.skills-refresh" 2>/dev/null || true
+
 exit 0

--- a/scripts/release/postinstall-full
+++ b/scripts/release/postinstall-full
@@ -156,6 +156,16 @@ if [[ -n "$TARGET_UID" && -f "$LAUNCH_AGENT_PATH" ]]; then
   bootstrap_bridge_launchagent "$TARGET_UID" || true
 fi
 
+# ── skills-refresh marker ────────────────────────────────────────
+# Written on every install AND every (Sparkle-driven) update. The CLI's
+# rate-limited skills hint uses live filesystem probing; this marker records
+# what shipped and when, for `interceptor skills status --json` consumers and
+# debugging. Failure here must never fail the install.
+{
+  printf 'installed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf 'skills=%s\n' "$(ls "$INSTALL_ROOT/skills" 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
+} >"$INSTALL_ROOT/.skills-refresh" 2>/dev/null || true
+
 # ── remove obsolete iOS tunnel LaunchDaemon from older installs ──────
 # The no-Xcode iOS path now uses the daemon's unprivileged CoreDeviceProxy
 # userspace tunnel. New packages do not stage com.interceptor.ios-tunnel; upgrades

--- a/test/cli-meta-additions.test.ts
+++ b/test/cli-meta-additions.test.ts
@@ -119,11 +119,21 @@ describe("helpForCommand (#51)", () => {
     expect(r.stdout).toContain("interceptor act <ref>")
   })
 
-  test("CLI: bare `--help` falls back to full HELP", () => {
+  test("CLI: bare `--help` prints the tier-0 capability map", () => {
     const r = runCli(["--help"])
     expect(r.status).toBe(0)
-    expect(r.stdout).toContain("interceptor — browser control CLI")
-    expect(r.stdout).toContain("Compound (agent-optimized)")
+    expect(r.stdout).toContain("drive a real browser, macOS, and iPhone")
+    expect(r.stdout).toContain("interceptor help --all")
+    // A capability MAP: every surface's verbs are named so a skill-less agent
+    // knows the full out-of-box surface — but flag-level detail stays deferred.
+    expect(r.stdout).toContain("BROWSER")
+    expect(r.stdout).toContain("open <url>")
+    expect(r.stdout).toContain("net")
+    expect(r.stdout).toContain("interceptor manifest")
+    // still far smaller than the exhaustive per-flag dump behind --all
+    const all = runCli(["help", "--all"])
+    expect(r.stdout.length).toBeLessThan(all.stdout.length)
+    expect(r.stdout).not.toContain("Compound (agent-optimized)")
   })
 
   test("CLI: nested macos cdp/app help short-circuits without spawning daemon", () => {

--- a/test/manifest-coverage.test.ts
+++ b/test/manifest-coverage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+
+import { COMMAND_SPECS } from "../cli/manifest"
+
+// The agent-facing compound + reading verbs are the manifest's reason to
+// exist — every one must carry a non-empty returns: contract.
+const MUST_HAVE_RETURNS = [
+  "open", "read", "act", "inspect",
+  "text", "html", "tree", "find", "search",
+  "table", "links", "forms", "query",
+  "skills", "manifest",
+]
+
+describe("manifest command specs", () => {
+  test("every agent-critical verb has a spec with returns semantics", () => {
+    for (const name of MUST_HAVE_RETURNS) {
+      const spec = COMMAND_SPECS.find(s => s.name === name)
+      expect(spec, `missing spec for '${name}'`).toBeDefined()
+      expect(spec!.returns.length, `empty returns for '${name}'`).toBeGreaterThan(10)
+      expect(spec!.usage.startsWith("interceptor "), `usage for '${name}' must be a full invocation`).toBe(true)
+    }
+  })
+
+  test("the text-verb disambiguation is explicit (innerText vs textContent vs markdown)", () => {
+    const text = COMMAND_SPECS.find(s => s.name === "text")!
+    expect(text.returns).toContain("innerText")
+    expect(text.returns).toContain("textContent")
+    const read = COMMAND_SPECS.find(s => s.name === "read")!
+    expect(read.returns).toContain("textContent")
+    const html = COMMAND_SPECS.find(s => s.name === "html")!
+    expect(html.returns).toContain("outerHTML")
+  })
+
+  test("no duplicate command names", () => {
+    const names = COMMAND_SPECS.map(s => s.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  test("every spec has a valid surface", () => {
+    for (const s of COMMAND_SPECS) {
+      expect(["browser", "macos", "ios", "local"]).toContain(s.surface)
+    }
+  })
+})

--- a/test/normalize-args.test.ts
+++ b/test/normalize-args.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test"
+
+import { normalizeArgs } from "../cli/normalize"
+
+describe("normalizeArgs", () => {
+  test("the original repro: open --text-only <url> puts the URL back at filtered[1]", () => {
+    expect(normalizeArgs(["open", "--text-only", "https://example.com"]))
+      .toEqual(["open", "https://example.com", "--text-only"])
+  })
+
+  test("flags-last invocations are unchanged", () => {
+    expect(normalizeArgs(["open", "https://example.com", "--text-only", "--no-wait"]))
+      .toEqual(["open", "https://example.com", "--text-only", "--no-wait"])
+  })
+
+  test("value flags keep their value adjacent when hoisted", () => {
+    expect(normalizeArgs(["open", "--timeout", "8000", "https://example.com"]))
+      .toEqual(["open", "https://example.com", "--timeout", "8000"])
+  })
+
+  test("interleaved flags and positionals", () => {
+    expect(normalizeArgs(["act", "--no-read", "e5", "hello", "--timeout", "500", "world"]))
+      .toEqual(["act", "e5", "hello", "world", "--no-read", "--timeout", "500"])
+  })
+
+  test("read --text-only e5 no longer silently ignores the ref", () => {
+    expect(normalizeArgs(["read", "--text-only", "e5"]))
+      .toEqual(["read", "e5", "--text-only"])
+  })
+
+  test("boolean flags do not swallow the following positional", () => {
+    expect(normalizeArgs(["open", "--activate", "https://example.com"]))
+      .toEqual(["open", "https://example.com", "--activate"])
+  })
+
+  test("value flag values may start with a dash (negative amounts)", () => {
+    expect(normalizeArgs(["scroll", "--amount", "-100", "down"]))
+      .toEqual(["scroll", "down", "--amount", "-100"])
+  })
+
+  test("single-dash tokens are positionals, not short-option groups", () => {
+    expect(normalizeArgs(["wait", "-5"]))
+      .toEqual(["wait", "-5"])
+  })
+
+  test("--flag=value is split into indexOf-parseable tokens", () => {
+    expect(normalizeArgs(["read", "--filter=all", "e2"]))
+      .toEqual(["read", "e2", "--filter", "all"])
+  })
+
+  test("-- terminator: everything after is positional verbatim", () => {
+    expect(normalizeArgs(["act", "e5", "--", "--not-a-flag"]))
+      .toEqual(["act", "e5", "--not-a-flag"])
+  })
+
+  test("trailing value flag with no value does not consume anything", () => {
+    expect(normalizeArgs(["open", "https://example.com", "--timeout"]))
+      .toEqual(["open", "https://example.com", "--timeout"])
+  })
+
+  test("optional-value flag does not swallow a following flag", () => {
+    expect(normalizeArgs(["monitor", "start", "--persist-bodies", "--reload"]))
+      .toEqual(["monitor", "start", "--persist-bodies", "--reload"])
+  })
+
+  test("optional-value flag consumes a plain value (stays adjacent)", () => {
+    expect(normalizeArgs(["monitor", "start", "--persist-bodies", "256"]))
+      .toEqual(["monitor", "start", "--persist-bodies", "256"])
+  })
+
+  test("macos and ios argv pass through untouched", () => {
+    const macos = ["macos", "--app", "Safari", "read"]
+    expect(normalizeArgs(macos)).toEqual(macos)
+    const ios = ["ios", "click", "--on", "phone", "e3"]
+    expect(normalizeArgs(ios)).toEqual(ios)
+  })
+
+  test("skills adopt with --into keeps names as positionals", () => {
+    expect(normalizeArgs(["skills", "adopt", "--into", "claude,codex", "interceptor-browser"]))
+      .toEqual(["skills", "adopt", "interceptor-browser", "--into", "claude,codex"])
+  })
+
+  test("network export flags stay paired", () => {
+    expect(normalizeArgs(["net", "--format", "har", "--out", "/tmp/x.har", "--limit", "5"]))
+      .toEqual(["net", "--format", "har", "--out", "/tmp/x.har", "--limit", "5"])
+  })
+
+  test("find keeps multi-word queries in positional order", () => {
+    expect(normalizeArgs(["find", "--role", "button", "submit", "order"]))
+      .toEqual(["find", "submit", "order", "--role", "button"])
+  })
+})

--- a/test/skills-adopt.test.ts
+++ b/test/skills-adopt.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, lstatSync, realpathSync, symlinkSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { classifyLink, adoptSkill, discoverSkills, allTargets, type SkillTarget, type SkillInfo } from "../cli/commands/skills"
+
+let root: string
+let packDir: string
+let targetDir: string
+
+function makeSkill(name: string): SkillInfo {
+  const dir = join(packDir, name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: test skill ${name}\n---\nbody`)
+  return { name, description: `test skill ${name}`, dir }
+}
+
+function target(): SkillTarget {
+  return { id: "claude", label: "Claude Code", parent: join(root, ".claude"), dir: targetDir }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "interceptor-skills-test-"))
+  packDir = join(root, "pack")
+  targetDir = join(root, ".claude", "skills")
+  mkdirSync(packDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe("discoverSkills", () => {
+  test("finds directories with SKILL.md and reads descriptions", () => {
+    makeSkill("interceptor-browser")
+    makeSkill("interceptor")
+    mkdirSync(join(packDir, "not-a-skill"))
+    const skills = discoverSkills(packDir)
+    expect(skills.map(s => s.name)).toEqual(["interceptor", "interceptor-browser"])
+    expect(skills[0].description).toBe("test skill interceptor")
+  })
+})
+
+describe("classifyLink", () => {
+  test("missing when destination does not exist", () => {
+    const s = makeSkill("a")
+    expect(classifyLink(targetDir, "a", s.dir)).toBe("missing")
+  })
+
+  test("linked when symlink resolves to the pack skill", () => {
+    const s = makeSkill("a")
+    mkdirSync(targetDir, { recursive: true })
+    symlinkSync(s.dir, join(targetDir, "a"))
+    expect(classifyLink(targetDir, "a", s.dir)).toBe("linked")
+  })
+
+  test("foreign when symlink points elsewhere", () => {
+    const s = makeSkill("a")
+    const other = makeSkill("b")
+    mkdirSync(targetDir, { recursive: true })
+    symlinkSync(other.dir, join(targetDir, "a"))
+    expect(classifyLink(targetDir, "a", s.dir)).toBe("foreign")
+  })
+
+  test("stale-copy when destination is a real directory", () => {
+    const s = makeSkill("a")
+    mkdirSync(join(targetDir, "a"), { recursive: true })
+    writeFileSync(join(targetDir, "a", "SKILL.md"), "old copy")
+    expect(classifyLink(targetDir, "a", s.dir)).toBe("stale-copy")
+  })
+})
+
+describe("adoptSkill", () => {
+  test("creates a working symlink and reports linked", () => {
+    const s = makeSkill("a")
+    const r = adoptSkill(target(), s, false)
+    expect(r.action).toBe("linked")
+    expect(lstatSync(join(targetDir, "a")).isSymbolicLink()).toBe(true)
+    expect(realpathSync(join(targetDir, "a"))).toBe(realpathSync(s.dir))
+  })
+
+  test("is idempotent (already-linked)", () => {
+    const s = makeSkill("a")
+    adoptSkill(target(), s, false)
+    expect(adoptSkill(target(), s, false).action).toBe("already-linked")
+  })
+
+  test("replaces a foreign symlink (ln -sfn semantics, no data destroyed)", () => {
+    const s = makeSkill("a")
+    const other = makeSkill("b")
+    mkdirSync(targetDir, { recursive: true })
+    symlinkSync(other.dir, join(targetDir, "a"))
+    const r = adoptSkill(target(), s, false)
+    expect(r.action).toBe("linked")
+    expect(realpathSync(join(targetDir, "a"))).toBe(realpathSync(s.dir))
+  })
+
+  test("NEVER replaces a real directory without --force", () => {
+    const s = makeSkill("a")
+    mkdirSync(join(targetDir, "a"), { recursive: true })
+    writeFileSync(join(targetDir, "a", "user-edit.md"), "precious")
+    const r = adoptSkill(target(), s, false)
+    expect(r.action).toBe("skipped")
+    expect(lstatSync(join(targetDir, "a")).isDirectory()).toBe(true)
+  })
+
+  test("replaces a real directory with --force", () => {
+    const s = makeSkill("a")
+    mkdirSync(join(targetDir, "a"), { recursive: true })
+    writeFileSync(join(targetDir, "a", "SKILL.md"), "old copy")
+    const r = adoptSkill(target(), s, true)
+    expect(r.action).toBe("replaced-copy")
+    expect(lstatSync(join(targetDir, "a")).isSymbolicLink()).toBe(true)
+  })
+})
+
+describe("allTargets", () => {
+  test("codex honors CODEX_HOME and defaults to ~/.codex/skills", () => {
+    const defaults = allTargets("/home/u", {})
+    const codex = defaults.find(t => t.id === "codex")!
+    expect(codex.dir).toBe(join("/home/u", ".codex", "skills"))
+    const overridden = allTargets("/home/u", { CODEX_HOME: "/custom/codex" })
+    expect(overridden.find(t => t.id === "codex")!.dir).toBe(join("/custom/codex", "skills"))
+  })
+
+  test("claude targets ~/.claude/skills (resolves to %USERPROFILE%\\.claude on Windows)", () => {
+    const claude = allTargets("/home/u", {}).find(t => t.id === "claude")!
+    expect(claude.dir).toBe(join("/home/u", ".claude", "skills"))
+  })
+})


### PR DESCRIPTION
## Summary

Ships the CLI-contract overhaul and skills adoption work, version-bumped to **0.22.1** across all surfaces (CLI, extension MV2/MV3, package). No PRD/internal references, filesystem paths, or PII in the diff.

## What's new

- **Order-independent argument parsing** — `cli/normalize.ts` rewrites argv to `[cmd, ...positionals, ...flags]` at the dispatch choke point, driven by a per-family value-flag registry. `open --text-only <url>` no longer treats the URL as the flag value; adds `--flag=value` and `--` terminator support to all normalized commands.
- **Progressive-disclosure help** — bare `interceptor` / `--help` / `help` print a concise tier-0 capability card (was ~33KB); `help <cmd>` prints one command's contract + Returns/Example from the manifest; `help --all` keeps the full reference, filtered to installed surfaces.
- **Surface gating** — browser-only installs no longer see macOS/iOS verbs in help, and `interceptor macos|ios` fails fast with an upgrade pointer before any daemon spawn (`--all-surfaces` / `INTERCEPTOR_ALL_SURFACES` override).
- **Agent capability discovery** — `interceptor manifest` emits machine-readable specs (usage, flags, returns semantics) for 50+ verbs plus surfaces and skills state.
- **Skills adoption** — `interceptor skills list|status|show|adopt` links the bundled browser-surface skill packs into supported agent runtimes.
- **iOS connection clarity** — `ios devices` explains that `connected:false` is the normal idle state; the on-device runner auto-connects on the next verb.
- **Installer polish** — Fixes #123: conclusion panes declare light/dark color-scheme with explicit fg/bg pairs and an unclippable heading.

## Validation

- `bunx tsc` — clean
- `bun test` — 649 pass, 10 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `skills` command to list, inspect, and adopt skill packs across supported runtimes.
  * Introduced machine-readable manifest output and improved command help with clearer usage examples and surface-specific guidance.
  * Added install-time options to link skill packs automatically during setup.

* **Bug Fixes**
  * Improved iOS connection/status messaging so idle devices are reported more clearly.
  * Updated status output to show skill-pack linking progress and warn when some targets are only partially linked.

* **Documentation**
  * Expanded help text and installer instructions for connection behavior and skill-pack management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->