### PR TITLE
fix(screenshot): surface real render errors, refcount CORS rule, bound webp re-encode

### DIFF
--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -611,14 +611,34 @@ function buildScreenshotCorsRule(tabId) {
     }
   };
 }
+var corsRuleRefcount = new Map;
 async function installScreenshotCorsRule(tabId) {
-  const rule = buildScreenshotCorsRule(tabId);
-  await chrome.declarativeNetRequest.updateSessionRules({
-    removeRuleIds: [rule.id],
-    addRules: [rule]
-  });
+  const prev = corsRuleRefcount.get(tabId) ?? 0;
+  corsRuleRefcount.set(tabId, prev + 1);
+  if (prev === 0) {
+    const rule = buildScreenshotCorsRule(tabId);
+    try {
+      await chrome.declarativeNetRequest.updateSessionRules({
+        removeRuleIds: [rule.id],
+        addRules: [rule]
+      });
+    } catch (err) {
+      const cur = corsRuleRefcount.get(tabId) ?? 0;
+      if (cur <= 1)
+        corsRuleRefcount.delete(tabId);
+      else
+        corsRuleRefcount.set(tabId, cur - 1);
+      throw err;
+    }
+  }
 }
 async function uninstallScreenshotCorsRule(tabId) {
+  const prev = corsRuleRefcount.get(tabId) ?? 0;
+  if (prev > 1) {
+    corsRuleRefcount.set(tabId, prev - 1);
+    return;
+  }
+  corsRuleRefcount.delete(tabId);
   const ruleId = SCREENSHOT_CORS_RULE_ID_BASE + tabId;
   try {
     await chrome.declarativeNetRequest.updateSessionRules({
@@ -803,9 +823,12 @@ async function handleDomRenderScreenshot(action, tabId) {
     let outputFormat = renderResult.data.format;
     if (requestedFormat === "webp") {
       try {
-        dataUrl = await reencodeAsWebP(dataUrl, webpQuality);
+        dataUrl = await withCaptureTimeout("webp-reencode", reencodeAsWebP(dataUrl, webpQuality), DOM_RENDER_TIMEOUT_MS);
         outputFormat = "webp";
       } catch (err) {
+        if (err instanceof CaptureTimeoutError) {
+          return { success: false, error: `webp re-encode timed out after ${DOM_RENDER_TIMEOUT_MS}ms — the rendered page was too large to re-encode in time` };
+        }
         return { success: false, error: `webp re-encode failed: ${err.message}` };
       }
     }

--- a/extension/dist-mv2/content.js
+++ b/extension/dist-mv2/content.js
@@ -4257,37 +4257,26 @@ async function nativeRenderToDataUrl(node, o) {
   const svgUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
   const img = await loadSvgImage(svgUrl);
   const canvas = document.createElement("canvas");
-  canvas.width = Math.max(1, Math.round(o.width * o.pixelRatio));
-  canvas.height = Math.max(1, Math.round(o.height * o.pixelRatio));
+  const fullW = Math.max(1, Math.round(o.width * o.pixelRatio));
+  const fullH = Math.max(1, Math.round(o.height * o.pixelRatio));
+  canvas.width = o.crop ? Math.max(1, Math.round(o.crop.width * o.pixelRatio)) : fullW;
+  canvas.height = o.crop ? Math.max(1, Math.round(o.crop.height * o.pixelRatio)) : fullH;
   const ctx = canvas.getContext("2d");
   if (!ctx)
     throw new Error("2d canvas context unavailable");
-  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-  return o.format === "jpeg" ? canvas.toDataURL("image/jpeg", o.quality) : canvas.toDataURL("image/png");
+  if (o.crop) {
+    ctx.drawImage(img, -Math.round(o.crop.x * o.pixelRatio), -Math.round(o.crop.y * o.pixelRatio), fullW, fullH);
+  } else {
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  }
+  const out = o.format === "jpeg" ? canvas.toDataURL("image/jpeg", o.quality) : canvas.toDataURL("image/png");
+  return checkRasterizeOutput(out, canvas.width, canvas.height);
 }
-async function cropDataUrl(dataUrl, x, y, w, h, format, quality) {
-  return new Promise((resolve) => {
-    const img = new Image;
-    img.onload = () => {
-      try {
-        const canvas = document.createElement("canvas");
-        canvas.width = w;
-        canvas.height = h;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) {
-          resolve(null);
-          return;
-        }
-        ctx.drawImage(img, x, y, w, h, 0, 0, w, h);
-        const out = format === "jpeg" ? canvas.toDataURL("image/jpeg", quality) : canvas.toDataURL("image/png");
-        resolve(out);
-      } catch {
-        resolve(null);
-      }
-    };
-    img.onerror = () => resolve(null);
-    img.src = dataUrl;
-  });
+function checkRasterizeOutput(dataUrl, width, height) {
+  const payloadStart = dataUrl.indexOf(",") + 1;
+  if (payloadStart > 0 && dataUrl.length - payloadStart >= 24)
+    return dataUrl;
+  throw new Error(`rendered canvas ${width}x${height}px exceeds the browser's canvas size limit and produced no image data — ` + `capture a smaller area with --region, or reduce output size with --target-max-long-edge or a smaller --scale`);
 }
 function resolveTarget(action) {
   const mode = action.mode || "full";
@@ -4353,32 +4342,38 @@ async function handleDomScreenshot(action) {
     }
   }
   try {
-    let dataUrl = await nativeRenderToDataUrl(node, {
+    const crop = mode === "region" && action.region ? action.region : undefined;
+    const dataUrl = await nativeRenderToDataUrl(node, {
       width,
       height,
       pixelRatio,
       format,
       quality: qualityPct / 100,
-      isFull
+      isFull,
+      crop
     });
-    let outWidth = Math.round(width * pixelRatio);
-    let outHeight = Math.round(height * pixelRatio);
-    if (mode === "region" && action.region) {
-      const region = action.region;
-      const cropped = await cropDataUrl(dataUrl, Math.round(region.x * pixelRatio), Math.round(region.y * pixelRatio), Math.round(region.width * pixelRatio), Math.round(region.height * pixelRatio), format, qualityPct / 100);
-      if (cropped) {
-        dataUrl = cropped;
-        outWidth = Math.round(region.width * pixelRatio);
-        outHeight = Math.round(region.height * pixelRatio);
-      }
-    }
+    const outWidth = Math.round((crop ? crop.width : width) * pixelRatio);
+    const outHeight = Math.round((crop ? crop.height : height) * pixelRatio);
     return {
       success: true,
       data: { dataUrl, format, width: outWidth, height: outHeight, pixelRatio, mode }
     };
   } catch (err) {
-    return { success: false, error: `dom render failed: ${err.message}` };
+    return { success: false, error: `dom render failed: ${describeRenderError(err)}` };
   }
+}
+function describeRenderError(err) {
+  if (err instanceof Error && err.message)
+    return err.message;
+  if (typeof Event !== "undefined" && err instanceof Event) {
+    const target = err.target;
+    return `image load failed (${err.type}${target?.tagName ? ` on <${target.tagName.toLowerCase()}>` : ""}) — the rendered SVG could not be decoded, likely too large or a resource blocked`;
+  }
+  const s = typeof err === "string" ? err : String(err);
+  if (!s || s === "undefined" || s === "null" || s === "[object Object]") {
+    return "unknown render error (non-Error thrown)";
+  }
+  return s;
 }
 
 // extension/src/content.ts

--- a/extension/src/background/capabilities/screenshot-cors.ts
+++ b/extension/src/background/capabilities/screenshot-cors.ts
@@ -75,10 +75,15 @@ export async function installScreenshotCorsRule(tabId: number): Promise<void> {
         addRules: [rule]
       })
     } catch (err) {
-      // Roll the refcount back so a failed install doesn't leave a phantom
-      // reference that blocks a later teardown. Callers place install OUTSIDE
-      // their try/finally, so a throw here means uninstall won't run.
-      corsRuleRefcount.delete(tabId)
+      // Roll back only THIS acquire's increment, not the whole entry — a
+      // concurrent same-tab acquire may have already bumped the count while this
+      // install was in flight, and wiping the map would strand it. Decrement by
+      // one; delete only if that leaves zero. Callers place install OUTSIDE
+      // their try/finally, so a throw here means uninstall won't run for this
+      // acquire, which is why we must undo its increment here.
+      const cur = corsRuleRefcount.get(tabId) ?? 0
+      if (cur <= 1) corsRuleRefcount.delete(tabId)
+      else corsRuleRefcount.set(tabId, cur - 1)
       throw err
     }
   }

--- a/extension/src/background/capabilities/screenshot-cors.ts
+++ b/extension/src/background/capabilities/screenshot-cors.ts
@@ -53,15 +53,45 @@ export function buildScreenshotCorsRule(tabId: number): chrome.declarativeNetReq
   }
 }
 
+// Per-tab refcount. The rule ID is keyed on tabId, so two concurrent
+// screenshots of the SAME tab share one DNR rule. Without refcounting, the
+// first to finish would uninstall the rule out from under the second — its
+// in-flight subresource fetches would lose ACAO:* and taint/fail the render.
+// install increments; uninstall decrements and only removes the rule when the
+// last concurrent operation on that tab releases it. Different tabs are
+// independent (distinct rule IDs and distinct counts).
+const corsRuleRefcount = new Map<number, number>()
+
 export async function installScreenshotCorsRule(tabId: number): Promise<void> {
-  const rule = buildScreenshotCorsRule(tabId)
-  await chrome.declarativeNetRequest.updateSessionRules({
-    removeRuleIds: [rule.id],
-    addRules: [rule]
-  })
+  const prev = corsRuleRefcount.get(tabId) ?? 0
+  corsRuleRefcount.set(tabId, prev + 1)
+  // Rule is idempotent (removeRuleIds + addRules), so re-installing on a nested
+  // acquire is harmless — but only the first acquire needs to touch DNR.
+  if (prev === 0) {
+    const rule = buildScreenshotCorsRule(tabId)
+    try {
+      await chrome.declarativeNetRequest.updateSessionRules({
+        removeRuleIds: [rule.id],
+        addRules: [rule]
+      })
+    } catch (err) {
+      // Roll the refcount back so a failed install doesn't leave a phantom
+      // reference that blocks a later teardown. Callers place install OUTSIDE
+      // their try/finally, so a throw here means uninstall won't run.
+      corsRuleRefcount.delete(tabId)
+      throw err
+    }
+  }
 }
 
 export async function uninstallScreenshotCorsRule(tabId: number): Promise<void> {
+  const prev = corsRuleRefcount.get(tabId) ?? 0
+  // Only the LAST concurrent operation on this tab tears the rule down.
+  if (prev > 1) {
+    corsRuleRefcount.set(tabId, prev - 1)
+    return
+  }
+  corsRuleRefcount.delete(tabId)
   const ruleId = SCREENSHOT_CORS_RULE_ID_BASE + tabId
   try {
     await chrome.declarativeNetRequest.updateSessionRules({

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -236,9 +236,15 @@ async function handleDomRenderScreenshot(
 
     if (requestedFormat === "webp") {
       try {
-        dataUrl = await reencodeAsWebP(dataUrl, webpQuality)
+        // Bound the post-render webp re-encode too, so a large render that
+        // succeeds but re-encodes slowly can't hang past the CLI ceiling
+        // (the render guard above only covers the render itself).
+        dataUrl = await withCaptureTimeout("webp-reencode", reencodeAsWebP(dataUrl, webpQuality), DOM_RENDER_TIMEOUT_MS)
         outputFormat = "webp"
       } catch (err) {
+        if (err instanceof CaptureTimeoutError) {
+          return { success: false, error: `webp re-encode timed out after ${DOM_RENDER_TIMEOUT_MS}ms — the rendered page was too large to re-encode in time` }
+        }
         return { success: false, error: `webp re-encode failed: ${(err as Error).message}` }
       }
     }

--- a/extension/src/content/dom-screenshot.ts
+++ b/extension/src/content/dom-screenshot.ts
@@ -355,6 +355,25 @@ export async function handleDomScreenshot(action: DomScreenshotAction): Promise<
       data: { dataUrl, format, width: outWidth, height: outHeight, pixelRatio, mode }
     }
   } catch (err) {
-    return { success: false, error: `dom render failed: ${(err as Error).message}` }
+    return { success: false, error: `dom render failed: ${describeRenderError(err)}` }
   }
+}
+
+// html-to-image can reject with a raw `error` DOM Event (an <img>/SVG onerror)
+// when the serialized-and-resource-embedded SVG fails to load/decode on a heavy
+// real page. A DOM Event has no `.message`, so `(err as Error).message` renders
+// the useless literal "undefined". Coerce every error shape into a meaningful,
+// non-"undefined" string, sanitizing AFTER coercion so a thrown literal
+// "undefined"/"null"/"" or "[object Object]" can never leak.
+export function describeRenderError(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message
+  if (typeof Event !== "undefined" && err instanceof Event) {
+    const target = err.target as { src?: string; tagName?: string } | null
+    return `image load failed (${err.type}${target?.tagName ? ` on <${target.tagName.toLowerCase()}>` : ""}) — the rendered SVG could not be decoded, likely too large or a resource blocked`
+  }
+  const s = typeof err === "string" ? err : String(err)
+  if (!s || s === "undefined" || s === "null" || s === "[object Object]") {
+    return "unknown render error (non-Error thrown)"
+  }
+  return s
 }

--- a/extension/src/content/dom-screenshot.ts
+++ b/extension/src/content/dom-screenshot.ts
@@ -163,7 +163,14 @@ function buildStyledClone(src: Node, collect: CloneCollect): Node | null {
 
 async function nativeRenderToDataUrl(
   node: HTMLElement,
-  o: { width: number; height: number; pixelRatio: number; format: "png" | "jpeg"; quality: number; isFull: boolean }
+  o: {
+    width: number; height: number; pixelRatio: number; format: "png" | "jpeg"; quality: number; isFull: boolean
+    // Region crop in CSS px, applied at rasterize time: the canvas is
+    // allocated at the crop size and the decoded SVG is drawn offset into it.
+    // Decoding a huge SVG image succeeds where allocating a full-page canvas
+    // fails, so --region works on pages far past the canvas size limit.
+    crop?: { x: number; y: number; width: number; height: number }
+  }
 ): Promise<string> {
   const collect: CloneCollect = { imgJobs: [], bgJobs: [], urls: new Set() }
   const clone = buildStyledClone(node, collect) as HTMLElement | null
@@ -208,44 +215,35 @@ async function nativeRenderToDataUrl(
 
   const img = await loadSvgImage(svgUrl)
   const canvas = document.createElement("canvas")
-  canvas.width = Math.max(1, Math.round(o.width * o.pixelRatio))
-  canvas.height = Math.max(1, Math.round(o.height * o.pixelRatio))
+  const fullW = Math.max(1, Math.round(o.width * o.pixelRatio))
+  const fullH = Math.max(1, Math.round(o.height * o.pixelRatio))
+  canvas.width = o.crop ? Math.max(1, Math.round(o.crop.width * o.pixelRatio)) : fullW
+  canvas.height = o.crop ? Math.max(1, Math.round(o.crop.height * o.pixelRatio)) : fullH
   const ctx = canvas.getContext("2d")
   if (!ctx) throw new Error("2d canvas context unavailable")
-  ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
-  return o.format === "jpeg" ? canvas.toDataURL("image/jpeg", o.quality) : canvas.toDataURL("image/png")
+  if (o.crop) {
+    // Draw the full decoded image scaled to full size but offset so only the
+    // crop rect lands on the (crop-sized) canvas.
+    ctx.drawImage(img, -Math.round(o.crop.x * o.pixelRatio), -Math.round(o.crop.y * o.pixelRatio), fullW, fullH)
+  } else {
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+  }
+  const out = o.format === "jpeg" ? canvas.toDataURL("image/jpeg", o.quality) : canvas.toDataURL("image/png")
+  return checkRasterizeOutput(out, canvas.width, canvas.height)
 }
 
-async function cropDataUrl(
-  dataUrl: string,
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-  format: "png" | "jpeg",
-  quality: number
-): Promise<string | null> {
-  return new Promise((resolve) => {
-    const img = new Image()
-    img.onload = () => {
-      try {
-        const canvas = document.createElement("canvas")
-        canvas.width = w
-        canvas.height = h
-        const ctx = canvas.getContext("2d")
-        if (!ctx) { resolve(null); return }
-        ctx.drawImage(img, x, y, w, h, 0, 0, w, h)
-        const out = format === "jpeg"
-          ? canvas.toDataURL("image/jpeg", quality)
-          : canvas.toDataURL("image/png")
-        resolve(out)
-      } catch {
-        resolve(null)
-      }
-    }
-    img.onerror = () => resolve(null)
-    img.src = dataUrl
-  })
+// A canvas past the browser's max dimension/area limits doesn't throw — the
+// backing store silently fails to allocate and toDataURL() returns "data:,"
+// (or a near-empty payload). Without this guard the pipeline reports
+// success with size: 0, which downstream consumers can't distinguish from a
+// real capture. Turn it into an actionable error instead.
+export function checkRasterizeOutput(dataUrl: string, width: number, height: number): string {
+  const payloadStart = dataUrl.indexOf(",") + 1
+  if (payloadStart > 0 && dataUrl.length - payloadStart >= 24) return dataUrl
+  throw new Error(
+    `rendered canvas ${width}x${height}px exceeds the browser's canvas size limit and produced no image data — ` +
+    `capture a smaller area with --region, or reduce output size with --target-max-long-edge or a smaller --scale`
+  )
 }
 
 function resolveTarget(action: DomScreenshotAction): { node: HTMLElement | null; error?: string } {
@@ -324,31 +322,15 @@ export async function handleDomScreenshot(action: DomScreenshotAction): Promise<
   }
 
   try {
-    let dataUrl = await nativeRenderToDataUrl(node, {
-      width, height, pixelRatio, format, quality: qualityPct / 100, isFull
+    // Region mode crops at rasterize time (crop-sized canvas, offset draw),
+    // which keeps inter-frame / SW→daemon messages small AND works on pages
+    // whose full-size canvas would exceed the browser's canvas limits.
+    const crop = mode === "region" && action.region ? action.region : undefined
+    const dataUrl = await nativeRenderToDataUrl(node, {
+      width, height, pixelRatio, format, quality: qualityPct / 100, isFull, crop
     })
-    let outWidth = Math.round(width * pixelRatio)
-    let outHeight = Math.round(height * pixelRatio)
-
-    // Region mode: crop here in the content script before sending the dataUrl
-    // back, so the inter-frame / SW→daemon messages stay small.
-    if (mode === "region" && action.region) {
-      const region = action.region
-      const cropped = await cropDataUrl(
-        dataUrl,
-        Math.round(region.x * pixelRatio),
-        Math.round(region.y * pixelRatio),
-        Math.round(region.width * pixelRatio),
-        Math.round(region.height * pixelRatio),
-        format,
-        qualityPct / 100
-      )
-      if (cropped) {
-        dataUrl = cropped
-        outWidth = Math.round(region.width * pixelRatio)
-        outHeight = Math.round(region.height * pixelRatio)
-      }
-    }
+    const outWidth = Math.round((crop ? crop.width : width) * pixelRatio)
+    const outHeight = Math.round((crop ? crop.height : height) * pixelRatio)
 
     return {
       success: true,

--- a/test/dom-screenshot-error-describe.test.ts
+++ b/test/dom-screenshot-error-describe.test.ts
@@ -1,0 +1,61 @@
+/// <reference lib="dom" />
+
+import { describe, expect, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+try { GlobalRegistrator.register() } catch { /* already registered by an earlier test file */ }
+
+import { describeRenderError } from "../extension/src/content/dom-screenshot"
+
+// html-to-image rejects createImage with a raw DOM `error` Event (img.onerror
+// = reject) when the serialized+embedded SVG fails to decode on a heavy page.
+// A DOM Event has no `.message`, so the old `(err as Error).message` reported
+// the literal "undefined". describeRenderError must coerce every shape into a
+// meaningful, non-"undefined" string so the failure is actionable and the SW
+// can recognise it to fall back to --pixel.
+
+describe("describeRenderError", () => {
+  test("Error with a message passes the message through", () => {
+    expect(describeRenderError(new Error("canvas tainted"))).toBe("canvas tainted")
+  })
+
+  test("a DOM error Event yields an actionable string, never 'undefined'", () => {
+    const ev = new Event("error")
+    const out = describeRenderError(ev)
+    expect(out).not.toBe("undefined")
+    expect(out).not.toContain("[object")
+    expect(out.toLowerCase()).toContain("image load failed")
+  })
+
+  test("an <img> onerror Event names the element", () => {
+    const img = document.createElement("img")
+    const ev = new Event("error")
+    Object.defineProperty(ev, "target", { value: img })
+    expect(describeRenderError(ev).toLowerCase()).toContain("<img>")
+  })
+
+  test("a bare string error is returned as-is", () => {
+    expect(describeRenderError("boom")).toBe("boom")
+  })
+
+  test("an opaque non-Error never leaks 'undefined' or '[object Object]'", () => {
+    expect(describeRenderError({})).toBe("unknown render error (non-Error thrown)")
+    expect(describeRenderError(undefined)).toBe("unknown render error (non-Error thrown)")
+  })
+
+  test("a thrown literal 'undefined'/'null' string is sanitized, not leaked", () => {
+    // Guard order regression: the string branch used to return before the
+    // sanitize check, leaking the exact value this function exists to remove.
+    expect(describeRenderError("undefined")).toBe("unknown render error (non-Error thrown)")
+    expect(describeRenderError("null")).toBe("unknown render error (non-Error thrown)")
+    expect(describeRenderError("")).toBe("unknown render error (non-Error thrown)")
+  })
+
+  test("bare primitives never leak 'null'/'0'", () => {
+    expect(describeRenderError(null)).toBe("unknown render error (non-Error thrown)")
+  })
+
+  test("a meaningful thrown string is still returned as-is", () => {
+    expect(describeRenderError("canvas is 0x0")).toBe("canvas is 0x0")
+  })
+})

--- a/test/dom-screenshot-rasterize-guard.test.ts
+++ b/test/dom-screenshot-rasterize-guard.test.ts
@@ -1,0 +1,51 @@
+/// <reference lib="dom" />
+
+import { describe, expect, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+try { GlobalRegistrator.register() } catch { /* already registered by an earlier test file */ }
+
+import { checkRasterizeOutput } from "../extension/src/content/dom-screenshot"
+
+// Oversized-render guard (PRD-123). A canvas past the browser's max
+// dimension/area limits doesn't throw — toDataURL() silently returns "data:,"
+// and the pipeline used to report success with size: 0 (reproduced live:
+// 3016x600214 and 100016x400214 "captures" that were empty PNGs). The guard
+// must turn that into an actionable error naming the remedy flags, and must
+// never fire on a real capture payload.
+
+// Smallest real-world payload: a 1x1 canvas PNG is ~100+ base64 chars.
+const REAL_PAYLOAD = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+describe("checkRasterizeOutput", () => {
+  test("a real dataUrl passes through unchanged", () => {
+    const url = `data:image/png;base64,${REAL_PAYLOAD}`
+    expect(checkRasterizeOutput(url, 1280, 800)).toBe(url)
+  })
+
+  test("the oversized-canvas 'data:,' result throws, never returns", () => {
+    expect(() => checkRasterizeOutput("data:,", 3016, 600214)).toThrow(/canvas size limit/)
+  })
+
+  test("the error names the remedy flags and the failed dimensions", () => {
+    let msg = ""
+    try { checkRasterizeOutput("data:,", 100016, 400214) } catch (e) { msg = (e as Error).message }
+    expect(msg).toContain("100016x400214")
+    expect(msg).toContain("--region")
+    expect(msg).toContain("--target-max-long-edge")
+    expect(msg).toContain("--scale")
+  })
+
+  test("a near-empty payload (allocation failure) also throws", () => {
+    expect(() => checkRasterizeOutput("data:image/png;base64,AAAA", 65536, 65536)).toThrow(/canvas size limit/)
+  })
+
+  test("the thrown Error survives describeRenderError intact (no 'undefined')", async () => {
+    const { describeRenderError } = await import("../extension/src/content/dom-screenshot")
+    let err: unknown
+    try { checkRasterizeOutput("data:,", 3016, 600214) } catch (e) { err = e }
+    const described = describeRenderError(err)
+    expect(described).toContain("canvas size limit")
+    expect(described).not.toContain("undefined")
+  })
+})

--- a/test/screenshot-cors-refcount.test.ts
+++ b/test/screenshot-cors-refcount.test.ts
@@ -101,4 +101,42 @@ describe("screenshot CORS rule refcount", () => {
     await installScreenshotCorsRule(9)
     expect(addsFor(9)).toBe(1)
   })
+
+  test("a failed install does NOT strand a concurrent same-tab acquire", async () => {
+    // Interleaving CodeRabbit flagged: A starts installing (0→1) and suspends
+    // on the DNR call; B acquires (1→2) while A is in flight and returns without
+    // touching DNR; then A's install FAILS. A's rollback must undo only its own
+    // increment (2→1), NOT wipe the whole entry — otherwise B is left believing
+    // the rule is live with no refcount, and a later uninstall accounting goes
+    // wrong. After the dust settles, B's single release must remove the rule.
+    const { installScreenshotCorsRule, uninstallScreenshotCorsRule } = await load()
+    const chromeUnderTest = (globalThis as { chrome: { declarativeNetRequest: { updateSessionRules: (o: SessionRuleCall) => Promise<void> } } }).chrome
+    const original = chromeUnderTest.declarativeNetRequest.updateSessionRules
+
+    // First DNR call (A's install) hangs until we release it, then rejects.
+    let releaseA: () => void
+    const aInstallGate = new Promise<void>((r) => { releaseA = r })
+    chromeUnderTest.declarativeNetRequest.updateSessionRules = async () => {
+      await aInstallGate
+      throw new Error("DNR quota")
+    }
+
+    const aDone = installScreenshotCorsRule(5).then(() => "ok", (e) => (e as Error).message)
+    // B acquires while A is still suspended in updateSessionRules.
+    await installScreenshotCorsRule(5) // 1→2, no DNR touch (prev !== 0)
+    // Let A's install fail now.
+    releaseA!()
+    expect(await aDone).toBe("DNR quota")
+
+    // B's reference must survive: a fresh install must NOT re-install DNR
+    // (count is still 1, so prev !== 0), and B's single uninstall must remove.
+    chromeUnderTest.declarativeNetRequest.updateSessionRules = original
+    await installScreenshotCorsRule(5) // if B were stranded (count 0), this would re-add
+    expect(addsFor(5)).toBe(0) // original was replaced with a no-op stub during A; real adds only counted post-restore
+    // Now release both remaining references (B + the last acquire) → one remove.
+    await uninstallScreenshotCorsRule(5)
+    expect(removesFor(5)).toBe(0) // still one ref alive
+    await uninstallScreenshotCorsRule(5)
+    expect(removesFor(5)).toBe(1) // last one out removes exactly once
+  })
 })

--- a/test/screenshot-cors-refcount.test.ts
+++ b/test/screenshot-cors-refcount.test.ts
@@ -1,0 +1,104 @@
+/// <reference lib="dom" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+// screenshot-cors refcount.
+//
+// The CORS DNR rule id is keyed on tabId, so two concurrent screenshots of the
+// SAME tab share one rule. Without refcounting, whichever finishes first tears
+// the rule down while the other is still fetching subresources → that render
+// loses ACAO:* and taints/fails. These tests verify install/uninstall
+// refcount so the rule is added once per tab and removed only when the last
+// concurrent operation on that tab releases it.
+
+type SessionRuleCall = { removeRuleIds?: number[]; addRules?: chrome.declarativeNetRequest.Rule[] }
+
+let calls: SessionRuleCall[]
+let originalChrome: unknown
+
+const RULE_ID_BASE = 920_000
+
+beforeEach(() => {
+  calls = []
+  originalChrome = (globalThis as { chrome?: unknown }).chrome
+  ;(globalThis as { chrome: unknown }).chrome = {
+    declarativeNetRequest: {
+      updateSessionRules: async (opts: SessionRuleCall) => { calls.push(opts) },
+    },
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as { chrome?: unknown }).chrome = originalChrome
+})
+
+async function load() {
+  // Fresh import so the module-level refcount Map starts clean per test.
+  return await import("../extension/src/background/capabilities/screenshot-cors")
+}
+
+const addsFor = (tabId: number) =>
+  calls.filter((c) => c.addRules?.some((r) => r.id === RULE_ID_BASE + tabId)).length
+const removesFor = (tabId: number) =>
+  calls.filter((c) => (c.removeRuleIds ?? []).includes(RULE_ID_BASE + tabId) && !c.addRules).length
+
+describe("screenshot CORS rule refcount", () => {
+  test("single install/uninstall installs once and removes once", async () => {
+    const { installScreenshotCorsRule, uninstallScreenshotCorsRule } = await load()
+    await installScreenshotCorsRule(7)
+    await uninstallScreenshotCorsRule(7)
+    expect(addsFor(7)).toBe(1)
+    expect(removesFor(7)).toBe(1)
+  })
+
+  test("concurrent same-tab operations keep the rule until the LAST release", async () => {
+    const { installScreenshotCorsRule, uninstallScreenshotCorsRule } = await load()
+    // Two overlapping operations on tab 7.
+    await installScreenshotCorsRule(7) // A acquires — installs
+    await installScreenshotCorsRule(7) // B acquires — no second install
+    expect(addsFor(7)).toBe(1)
+
+    await uninstallScreenshotCorsRule(7) // A releases — MUST NOT remove (B still needs it)
+    expect(removesFor(7)).toBe(0)
+
+    await uninstallScreenshotCorsRule(7) // B releases — last one out, removes
+    expect(removesFor(7)).toBe(1)
+  })
+
+  test("different tabs are independent", async () => {
+    const { installScreenshotCorsRule, uninstallScreenshotCorsRule } = await load()
+    await installScreenshotCorsRule(1)
+    await installScreenshotCorsRule(2)
+    await uninstallScreenshotCorsRule(1) // releasing tab 1 must not affect tab 2
+    expect(addsFor(1)).toBe(1)
+    expect(addsFor(2)).toBe(1)
+    expect(removesFor(1)).toBe(1)
+    expect(removesFor(2)).toBe(0)
+    await uninstallScreenshotCorsRule(2)
+    expect(removesFor(2)).toBe(1)
+  })
+
+  test("re-acquire after full release installs again", async () => {
+    const { installScreenshotCorsRule, uninstallScreenshotCorsRule } = await load()
+    await installScreenshotCorsRule(3)
+    await uninstallScreenshotCorsRule(3)
+    await installScreenshotCorsRule(3) // count fell to 0, so this re-installs
+    expect(addsFor(3)).toBe(2)
+    await uninstallScreenshotCorsRule(3)
+    expect(removesFor(3)).toBe(2)
+  })
+
+  test("a failed install rolls back the refcount (no phantom reference)", async () => {
+    const { installScreenshotCorsRule } = await load()
+    // Make the DNR call throw for the first (installing) acquire.
+    const chromeUnderTest = (globalThis as { chrome: { declarativeNetRequest: { updateSessionRules: (o: SessionRuleCall) => Promise<void> } } }).chrome
+    const original = chromeUnderTest.declarativeNetRequest.updateSessionRules
+    chromeUnderTest.declarativeNetRequest.updateSessionRules = async () => { throw new Error("DNR quota") }
+    await expect(installScreenshotCorsRule(9)).rejects.toThrow("DNR quota")
+    // Refcount must be back to 0 — a subsequent successful acquire installs
+    // (prev===0 branch), proving no phantom reference was left behind.
+    chromeUnderTest.declarativeNetRequest.updateSessionRules = original
+    await installScreenshotCorsRule(9)
+    expect(addsFor(9)).toBe(1)
+  })
+})


### PR DESCRIPTION
Three fixes to the DOM-render screenshot path, found while running screenshots against large real-world pages on Windows.

## What's here

**1. Surface the real render error instead of "undefined"**

`html-to-image` can reject with a raw DOM `error` Event — an `<img>`/SVG `onerror` when the serialized, resource-embedded SVG fails to decode on a large page. A DOM Event has no `.message`, so `(err as Error).message` rendered the literal string `dom render failed: undefined`, which tells you nothing.

`describeRenderError` coerces every error shape (Error, DOM Event, string, opaque object) into a real message, and sanitizes *after* coercion so a thrown literal `"undefined"`/`"null"`/`"[object Object]"` can't leak either. An `<img>` failure now reads `image load failed (error on <img>) — the rendered SVG could not be decoded, likely too large or a resource blocked`.

**2. Refcount the CORS DNR rule**

The screenshot CORS rule id is keyed on `tabId`, so two concurrent screenshots of the same tab share one rule. Whichever finishes first tore the rule down while the other was still fetching subresources — that render lost `Access-Control-Allow-Origin: *` mid-flight and tainted or failed.

`installScreenshotCorsRule`/`uninstallScreenshotCorsRule` now keep a per-tab refcount: install adds the rule on the first acquire, uninstall removes it only when the last concurrent operation releases. A failed install rolls the count back so it leaves no phantom reference (callers place install outside their try/finally, so a throw there means uninstall never runs).

**3. Bound the webp re-encode**

The render is already guarded by `DOM_RENDER_TIMEOUT_MS`, but the post-render webp re-encode wasn't. A large image that re-encodes slowly could hang past the CLI's timeout with no diagnostic. The re-encode now uses the same 30s guard and returns an actionable error.

## Tests

- `describeRenderError` — Error / DOM Event / `<img>` Event / string / bare primitive coercion, and that no shape leaks `undefined`.
- CORS refcount — single install/uninstall, concurrent same-tab (rule survives until the last release), independent tabs, re-acquire after full release, and failed-install rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screenshot CORS rule lifecycle by reference-counting per tab, preventing premature removal during overlapping captures.
  * Added a bounded timeout for DOM-render WebP re-encoding to fail clearly when it stalls.
  * Improved DOM-render region screenshot rasterization by cropping during rasterization and adding stronger output validation plus consistent error messages.
* **Tests**
  * Added Bun tests for DOM-render error formatting and for screenshot CORS per-tab refcount behavior, including failure/rollback and concurrency cases.
  * Added Bun tests covering rasterize output guard behavior for oversized/near-empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
