### PR TITLE
Release 0.22.4 — screenshot render hardening

### DIFF
--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
Version bump to 0.22.4 covering the PR #130 adoption (screenshot render hardening, thanks @atabisz) plus the maintainer follow-up: oversized-render guard (no more silent size:0 captures) and raster-time region cropping (--region works past the browser canvas limit). Details in the release commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the release version to **0.22.4** across the extension and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->