### PR TITLE
Add an `interceptor csp` toggle to disable CSP across all tabs

### DIFF
--- a/.agents/skills/interceptor-browser/SKILL.md
+++ b/.agents/skills/interceptor-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interceptor-browser
-description: "Drive a signed-in Chrome / Brave session via the interceptor CLI: open/read pages, click, type, inspect DOM/text/network, automate rich browser editors and scene graphs, capture WebSocket/Beacon/BroadcastChannel traffic, record/replay flows, take VLM-budgeted screenshots, compare pages, and route to specific browser profiles with --context. Use for browser page content, tabs, forms, SPA extraction, request overrides, page communication capture, and deployment checks. Not for native macOS apps, Electron desktop app web contents, OS dialogs, browser chrome, or large scraping."
+description: "Drive a signed-in Chrome / Brave session via the interceptor CLI: open/read pages, click, type, inspect DOM/text/network, automate rich browser editors and scene graphs, capture WebSocket/Beacon/BroadcastChannel traffic, record/replay flows, take VLM-budgeted screenshots, compare pages, disable CSP across all tabs to run blocked inline/eval JS, and route to specific browser profiles with --context. Use for browser page content, tabs, forms, SPA extraction, request overrides, CSP bypass, page communication capture, and deployment checks. Not for native macOS apps, Electron desktop app web contents, OS dialogs, browser chrome, or large scraping."
 metadata:
   short-description: Drive a real signed-in Chrome / Brave session via the interceptor CLI
 ---
@@ -59,7 +59,7 @@ Each workflow is a complete self-contained "you are doing X" procedure. Open the
 
 | File | Topic |
 |---|---|
-| [`references/browser-and-network.md`](references/browser-and-network.md) | Command selection, SPA extraction, request overrides, SSE capture, page-world `eval --main` cautions |
+| [`references/browser-and-network.md`](references/browser-and-network.md) | Command selection, SPA extraction, request overrides, SSE capture, page-world `eval --main` cautions, CSP toggle for blocked JS |
 | [`references/page-communication-capture.md`](references/page-communication-capture.md) | P1 WebSocket, Beacon, and BroadcastChannel capture mechanics, commands, event shapes, and limits |
 | [`references/rich-editors.md`](references/rich-editors.md) | Overview: Canva, Google Docs, Google Slides behavior, canvas-rendered editor input, WebGL camera apps, blob export capture (deep mechanics in the four `references/canvas-*`/`webgl-*`/`blob-*` files below) |
 | [`references/canvas-rendered-editor-input.md`](references/canvas-rendered-editor-input.md) | Deep mechanic: caret / typing / key-nav inside canvas-rendered editors (Docs/Slides/Sheets) via dispatched events + iframe-window `KeyboardEvent`. The `eval --main` + `__interceptor_trust`/`userActivation` foundation lives here. |

--- a/.agents/skills/interceptor-browser/references/browser-and-network.md
+++ b/.agents/skills/interceptor-browser/references/browser-and-network.md
@@ -47,6 +47,7 @@ interceptor net log --filter api --limit 20
 
 - Use `eval --main` only when the structured command surface is not enough.
 - On strict-CSP sites, the first `eval --main` attempt may trigger an automatic reload/retry path before succeeding.
+- To run page-origin JS that CSP would block up front — inline `<script>` injection, a PoC payload, or many evals without the per-call reload — disable CSP explicitly first: `interceptor csp off` (browser-global: all tabs current and future, session-scoped, reloads open tabs to apply; `csp on` restores it, `csp status` reports state). See `references/command-catalog.md`.
 - Prefer staged injections over one giant payload when cooking or building page overlays.
 
 

--- a/.agents/skills/interceptor-browser/references/command-catalog.md
+++ b/.agents/skills/interceptor-browser/references/command-catalog.md
@@ -270,7 +270,25 @@ interceptor eval --main "document.title"
 interceptor eval --main "window.__APP_STATE__"
 ```
 
-Use only when no built-in command exposes what you need. Strict-CSP sites may trigger an automatic reload/retry on first attempt.
+Use only when no built-in command exposes what you need. On strict-CSP sites the first `eval --main` triggers an automatic reload/retry (the reactive CSP strip). To make page-origin JS run reliably up front — inline `<script>` injection, an XSS/PoC payload, repeated evals without the per-call reload dance — strip CSP explicitly first with `csp off` (below).
+
+## CSP (disable Content-Security-Policy)
+
+Browser-global toggle that removes CSP so injected page-origin JS runs even when `script-src` would block inline / `eval` code. Affects **every tab** — the ones already open and any opened later.
+
+```bash
+interceptor csp off                 # disable CSP on all tabs, then reload open tabs so it's live
+interceptor csp on                  # re-enable CSP on all tabs (reloads open tabs)
+interceptor csp status              # → "csp: disabled (all tabs)" | "csp: enabled (all tabs)"
+interceptor csp off --no-reload     # toggle without reloading; each tab applies it on its next navigation
+```
+
+- **Mechanism:** one `declarativeNetRequest` session rule (no tab scope) that removes the `content-security-policy` and `content-security-policy-report-only` **response headers** — no `chrome.debugger`, no debugging banner.
+- **Scope:** all tabs, current and future. New tabs and later navigations are covered automatically; no per-tab setup.
+- **Lifetime:** session only (cleared on browser restart) — a global "CSP off" never silently persists across restarts.
+- **Reload:** `off`/`on` reload every open http/https tab by default so already-loaded pages go live immediately; `--no-reload` skips the reloads (each tab then applies the change on its next navigation).
+- **Limitation:** removes header-delivered CSP only, not a `<meta http-equiv="Content-Security-Policy">` tag baked into the HTML.
+- `disable`/`enable` are accepted as aliases for `off`/`on`.
 
 ## Output mode
 

--- a/cli/commands/csp.ts
+++ b/cli/commands/csp.ts
@@ -1,0 +1,109 @@
+/**
+ * cli/commands/csp.ts — interceptor csp off|on|status [--no-reload]
+ *
+ * Browser-global toggle that disables (or restores) Content-Security-Policy so
+ * injected page-origin JS runs even on strict-CSP sites. It affects ALL tabs,
+ * current and future — one declarativeNetRequest rule with no tab scope.
+ *
+ *   interceptor csp off      disable CSP on every tab (reloads open tabs to apply)
+ *   interceptor csp on       restore CSP on every tab
+ *   interceptor csp status   is CSP currently disabled?
+ *
+ * `disable`/`enable` are accepted as aliases for `off`/`on`. `--no-reload`
+ * installs/removes the rule without reloading open tabs (each tab then applies
+ * the change on its next navigation; new tabs are covered either way).
+ */
+
+import { sendCommand, sendCommandWs, type DaemonResponse } from "../transport"
+
+type Result = { success: boolean; error?: string; data?: unknown }
+type CspSender = (
+  action: { type: string; [key: string]: unknown },
+  tabId?: number,
+  useWs?: boolean,
+  contextId?: string
+) => Promise<Result>
+
+async function send(
+  action: { type: string; [key: string]: unknown },
+  tabId?: number,
+  useWs = false,
+  contextId?: string
+): Promise<Result> {
+  try {
+    const resp: DaemonResponse = useWs
+      ? await sendCommandWs(action, tabId, contextId)
+      : await sendCommand(action, tabId, contextId)
+    return resp.result
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+const USAGE =
+  "error: interceptor csp requires a subcommand. Usage: interceptor csp off|on|status [--no-reload]"
+
+export async function runCsp(
+  filtered: string[],
+  opts: { jsonMode?: boolean; useWs?: boolean; globalTabId?: number; contextId?: string },
+  sender: CspSender = send
+): Promise<void> {
+  const sub = filtered[1]
+
+  if (!sub) {
+    console.error(USAGE)
+    process.exit(1)
+    return
+  }
+
+  const reload = !filtered.includes("--no-reload")
+
+  let action: { type: string; [key: string]: unknown }
+  switch (sub) {
+    case "off":
+    case "disable":
+      action = { type: "csp_strip", reload }
+      break
+    case "on":
+    case "enable":
+      action = { type: "csp_restore", reload }
+      break
+    case "status":
+      action = { type: "csp_status" }
+      break
+    default:
+      console.error(`error: unknown csp subcommand '${sub}'. ${USAGE}`)
+      process.exit(1)
+      return
+  }
+
+  const result = await sender(action, opts.globalTabId, opts.useWs, opts.contextId)
+
+  if (opts.jsonMode) {
+    console.log(JSON.stringify(result, null, 2))
+    if (!result.success) process.exit(1)
+    return
+  }
+
+  if (!result.success) {
+    console.error(`error: ${result.error}`)
+    process.exit(1)
+  }
+
+  const data = (result.data ?? {}) as { cspStripped?: boolean; tabsReloaded?: number }
+
+  if (sub === "status") {
+    console.log(data.cspStripped ? "csp: disabled (all tabs)" : "csp: enabled (all tabs)")
+    return
+  }
+
+  const applied =
+    typeof data.tabsReloaded === "number" && data.tabsReloaded > 0
+      ? `reloaded ${data.tabsReloaded} tab(s)`
+      : "applies on next navigation"
+  if (action.type === "csp_strip") {
+    console.log(`CSP disabled for all tabs (${applied})`)
+  } else {
+    console.log(`CSP restored for all tabs (${applied})`)
+  }
+}

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -292,6 +292,12 @@ Request Override (passive, no CDP):
   interceptor override "*api*" limit=50 offset=0  Multiple params
   interceptor override clear                  Remove all overrides
 
+Content-Security-Policy (all tabs, session):
+  interceptor csp off                        Disable CSP on every tab so injected inline/eval JS runs (reloads open tabs)
+  interceptor csp on                         Re-enable CSP on every tab (reloads open tabs)
+  interceptor csp status                     Report whether CSP is disabled
+  interceptor csp off --no-reload            Toggle without reloading (each tab applies it on its next navigation)
+
 Passive Network (always-on, no CDP):
   interceptor net log                        Passively captured fetch/XHR traffic
   interceptor net log --filter <pattern>     Filter by URL substring

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -30,6 +30,7 @@ import { parseSceneCommand } from "./commands/scene"
 import { parseSseCommand } from "./commands/sse"
 import { runCompoundCommand } from "./commands/compound"
 import { runOverride } from "./commands/override"
+import { runCsp } from "./commands/csp"
 import { runMacosCommand } from "./commands/macos"
 import { runIosCommand } from "./commands/ios"
 import { runUpgradeCommand } from "./commands/upgrade"
@@ -60,6 +61,7 @@ const SCENE_CMDS = new Set(["scene"])
 const SSE_CMDS = new Set(["sse"])
 const COMPOUND_CMDS = new Set(["open", "read", "act", "inspect"])
 const OVERRIDE_CMDS = new Set(["override"])
+const CSP_CMDS = new Set(["csp"])
 const MACOS_CMDS = new Set(["macos"])
 const IOS_CMDS = new Set(["ios"])
 const UPGRADE_CMDS = new Set(["upgrade"])
@@ -82,7 +84,7 @@ const ALL_KNOWN_CMDS = new Set<string>([
   ...STATE_CMDS, ...ACTION_CMDS, ...NAV_CMDS, ...TAB_CMDS, ...NET_CMDS,
   ...SS_CMDS, ...DATA_CMDS, ...META_CMDS, ...EVAL_CMDS,
   ...SAVE_CMDS, ...BRAND_CMDS, ...GROUP_CMDS, ...BATCH_CMDS, ...MONITOR_CMDS, ...SCENE_CMDS, ...SSE_CMDS,
-  ...COMPOUND_CMDS, ...OVERRIDE_CMDS, ...MACOS_CMDS, ...IOS_CMDS,
+  ...COMPOUND_CMDS, ...OVERRIDE_CMDS, ...CSP_CMDS, ...MACOS_CMDS, ...IOS_CMDS,
   ...UPGRADE_CMDS, ...INIT_CMDS, ...RESEARCH_CMDS, ...EXTENSIONS_CMDS,
   ...SKILLS_CMDS, ...MANIFEST_CMDS, ...DIAGNOSE_CMDS,
   "help", "contexts",
@@ -311,6 +313,11 @@ async function main() {
 
   if (OVERRIDE_CMDS.has(cmd)) {
     await runOverride(filtered, { jsonMode, useWs, globalTabId, contextId: globalContextId })
+    return
+  }
+
+  if (CSP_CMDS.has(cmd)) {
+    await runCsp(filtered, { jsonMode, useWs, globalTabId, contextId: globalContextId })
     return
   }
 

--- a/cli/manifest.ts
+++ b/cli/manifest.ts
@@ -154,6 +154,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   { name: "cookies", surface: "browser", usage: "interceptor cookies [domain] | cookies set/delete …", summary: "Read/write cookies", returns: "Cookie list." },
   { name: "storage", surface: "browser", usage: "interceptor storage [key] | storage delete <key>", summary: "localStorage access", returns: "Values." },
   { name: "override", surface: "browser", usage: "interceptor override <sub> …", summary: "Request/response overrides", returns: "Override state." },
+  { name: "csp", surface: "browser", usage: "interceptor csp off|on|status [--no-reload]", summary: "Disable/restore Content-Security-Policy across ALL tabs (session)", returns: "off/on → {scope:'all-tabs', cspStripped, tabsReloaded}; status → {scope, cspStripped}. Removes CSP response headers via one global declarativeNetRequest rule so injected page-origin JS runs on strict-CSP sites — every tab, current and future." },
   { name: "monitor", surface: "browser", usage: "interceptor monitor start|stop|status|tail|export …", summary: "Record page/network/user activity into a replayable session", returns: "Session id; export produces workflow artifacts." },
   { name: "scene", surface: "browser", usage: "interceptor scene <sub> …", summary: "Scene-graph automation for canvas/rich editors", returns: "Scene nodes / action results." },
   // ── local (no daemon) ───────────────────────────────────────────────────────

--- a/cli/normalize.ts
+++ b/cli/normalize.ts
@@ -78,7 +78,7 @@ const VALUE_FLAGS_BY_CMD: Record<string, string[]> = {
   capabilities: META, modals: META, panels: META,
   // singles
   eval: [], save: SAVE, brand: [], group: [], batch: BATCH, raw: BATCH,
-  monitor: MONITOR, scene: SCENE, sse: SSE, override: [],
+  monitor: MONITOR, scene: SCENE, sse: SSE, override: [], csp: [],
   upgrade: [], init: [], research: RESEARCH, extensions: [], contexts: [],
   skills: SKILLS, manifest: [],
 }

--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -2458,6 +2458,94 @@ async function handleEvaluateActions(action, tabId) {
   return runWithCspStripBypass(tabId, world, (t, w) => executeEval(t, w, code));
 }
 
+// extension/src/background/capabilities/csp.ts
+var CSP_GLOBAL_RULE_ID = 900000;
+function buildGlobalCspRule() {
+  return {
+    id: CSP_GLOBAL_RULE_ID,
+    priority: 10,
+    action: {
+      type: "modifyHeaders",
+      responseHeaders: [
+        { header: "content-security-policy", operation: "remove" },
+        { header: "content-security-policy-report-only", operation: "remove" }
+      ]
+    },
+    condition: {
+      resourceTypes: ["main_frame", "sub_frame"]
+    }
+  };
+}
+async function isCspStripped() {
+  const rules = await chrome.declarativeNetRequest.getSessionRules();
+  return rules.some((r) => r.id === CSP_GLOBAL_RULE_ID);
+}
+async function reloadAllWebTabs() {
+  let tabs;
+  try {
+    tabs = await chrome.tabs.query({});
+  } catch {
+    return 0;
+  }
+  const targets = tabs.filter((t) => typeof t.id === "number" && /^https?:/i.test(t.url || t.pendingUrl || ""));
+  const results = await Promise.all(targets.map((t) => chrome.tabs.reload(t.id, { bypassCache: true }).then(() => true, () => false)));
+  return results.filter(Boolean).length;
+}
+async function handleCspActions(action) {
+  switch (action.type) {
+    case "csp_strip": {
+      const reload = action.reload !== false;
+      let alreadyStripped;
+      try {
+        alreadyStripped = await isCspStripped();
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${err.message}` };
+      }
+      if (alreadyStripped) {
+        return { success: true, data: { scope: "all-tabs", cspStripped: true, tabsReloaded: 0 } };
+      }
+      try {
+        await chrome.declarativeNetRequest.updateSessionRules({
+          removeRuleIds: [CSP_GLOBAL_RULE_ID],
+          addRules: [buildGlobalCspRule()]
+        });
+      } catch (err) {
+        return { success: false, error: `failed to install CSP bypass rule: ${err.message}` };
+      }
+      const tabsReloaded = reload ? await reloadAllWebTabs() : 0;
+      return { success: true, data: { scope: "all-tabs", cspStripped: true, tabsReloaded } };
+    }
+    case "csp_restore": {
+      const reload = action.reload !== false;
+      let stripped;
+      try {
+        stripped = await isCspStripped();
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${err.message}` };
+      }
+      if (!stripped) {
+        return { success: true, data: { scope: "all-tabs", cspStripped: false, tabsReloaded: 0 } };
+      }
+      try {
+        await chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: [CSP_GLOBAL_RULE_ID] });
+      } catch (err) {
+        return { success: false, error: `failed to remove CSP bypass rule: ${err.message}` };
+      }
+      const tabsReloaded = reload ? await reloadAllWebTabs() : 0;
+      return { success: true, data: { scope: "all-tabs", cspStripped: false, tabsReloaded } };
+    }
+    case "csp_status": {
+      try {
+        const stripped = await isCspStripped();
+        return { success: true, data: { scope: "all-tabs", cspStripped: stripped } };
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${err.message}` };
+      }
+    }
+  }
+  return { success: false, error: `unknown csp action: ${action.type}` };
+}
+
 // extension/src/background/capabilities/binary-sink.ts
 var DEFAULT_CHUNK_SIZE = 1024 * 1024;
 async function executeNormalize(tabId, world, code) {
@@ -4138,6 +4226,7 @@ var NOTIFICATION_ACTIONS = new Set(["notification_create", "notification_clear"]
 var BROWSING_DATA_ACTIONS = new Set(["browsing_data_remove"]);
 var HEADER_ACTIONS = new Set(["headers_modify"]);
 var EVALUATE_ACTIONS = new Set(["evaluate"]);
+var CSP_ACTIONS = new Set(["csp_strip", "csp_restore", "csp_status"]);
 var BINARY_SINK_ACTIONS = new Set(["binary_sink_save"]);
 var STYLE_ACTIONS = new Set(["style_inject", "style_remove"]);
 var FRAME_ACTIONS = new Set(["frames_list", "frames_read_tree"]);
@@ -4213,6 +4302,8 @@ async function routeAction(action, tabId) {
     return handleHeaderActions(action, tabId);
   if (EVALUATE_ACTIONS.has(action.type))
     return handleEvaluateActions(action, tabId);
+  if (CSP_ACTIONS.has(action.type))
+    return handleCspActions(action);
   if (BINARY_SINK_ACTIONS.has(action.type))
     return handleBinarySinkActions(action, tabId);
   if (STYLE_ACTIONS.has(action.type))
@@ -4309,7 +4400,10 @@ var NO_TAB_ACTIONS = new Set([
   "monitor_stop",
   "brand_set_tab_group",
   "group_list",
-  "group_close"
+  "group_close",
+  "csp_strip",
+  "csp_restore",
+  "csp_status"
 ]);
 function needsTab(type) {
   return !NO_TAB_ACTIONS.has(type);

--- a/extension/src/background/capabilities/csp.ts
+++ b/extension/src/background/capabilities/csp.ts
@@ -1,0 +1,146 @@
+// csp.ts
+//
+// Browser-global toggle that disables (or restores) Content-Security-Policy so
+// injected page-origin JS — string eval, an appended inline <script>, an
+// XSS/PoC payload — runs even on strict-CSP sites.
+//
+// Scope: ALL tabs, current AND future. It installs ONE declarativeNetRequest
+// session rule with no `tabIds` condition, so every main_frame / sub_frame
+// response in every tab — including tabs opened later — has its
+// `content-security-policy` (+ `-report-only`) response headers removed. New
+// tabs and future navigations are covered automatically with no per-tab setup.
+//
+// Lifetime: session only. A session rule survives service-worker restarts but is
+// cleared when the browser closes — so a global "CSP off" never silently
+// persists across restarts.
+//
+// Reload: a modifyHeaders DNR rule only rewrites FUTURE responses, so an
+// already-parsed document keeps its CSP until reloaded. csp_strip / csp_restore
+// therefore reload every open web tab by default so the change is live now;
+// pass `reload: false` (CLI --no-reload) to skip the reloads, in which case each
+// open tab applies the change on its next navigation.
+//
+// Rule id: a single fixed id (900000), deliberately BELOW the per-tab bases used
+// by the reactive eval strip (evaluate.ts, 910000 + tabId) and the screenshot
+// CORS rule (screenshot-cors.ts, 920000 + tabId), so it can never collide with
+// either for any tab id.
+
+const CSP_GLOBAL_RULE_ID = 900_000
+
+type ActionResult = { success: boolean; error?: string; data?: unknown }
+
+function buildGlobalCspRule(): chrome.declarativeNetRequest.Rule {
+  return {
+    id: CSP_GLOBAL_RULE_ID,
+    priority: 10,
+    action: {
+      type: "modifyHeaders",
+      responseHeaders: [
+        { header: "content-security-policy", operation: "remove" },
+        { header: "content-security-policy-report-only", operation: "remove" }
+      ]
+    },
+    condition: {
+      // No tabIds → applies to every tab, current and future. No URL condition →
+      // matches all URLs; resourceTypes limits it to the documents that actually
+      // carry a page CSP.
+      resourceTypes: ["main_frame", "sub_frame"]
+    }
+  }
+}
+
+async function isCspStripped(): Promise<boolean> {
+  const rules = await chrome.declarativeNetRequest.getSessionRules()
+  return rules.some((r) => r.id === CSP_GLOBAL_RULE_ID)
+}
+
+// Reload every open http/https tab so a header change is live on already-loaded
+// documents. A tab mid-navigation exposes its target via `pendingUrl` (its
+// `url` is still ""), so match either. Returns how many tabs actually reloaded:
+// per-tab failures (a tab closing mid-flight, a discarded tab) are counted as
+// misses, not successes, and never fail the toggle — the DNR change already
+// succeeded.
+async function reloadAllWebTabs(): Promise<number> {
+  let tabs: chrome.tabs.Tab[]
+  try {
+    tabs = await chrome.tabs.query({})
+  } catch {
+    return 0
+  }
+  const targets = tabs.filter(
+    (t) => typeof t.id === "number" && /^https?:/i.test(t.url || t.pendingUrl || "")
+  )
+  const results = await Promise.all(
+    targets.map((t) =>
+      chrome.tabs.reload(t.id as number, { bypassCache: true }).then(() => true, () => false)
+    )
+  )
+  return results.filter(Boolean).length
+}
+
+export async function handleCspActions(
+  action: { type: string; [key: string]: unknown }
+): Promise<ActionResult> {
+  switch (action.type) {
+    case "csp_strip": {
+      // reload defaults to true; only an explicit `reload === false` skips it.
+      const reload = action.reload !== false
+      let alreadyStripped: boolean
+      try {
+        alreadyStripped = await isCspStripped()
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${(err as Error).message}` }
+      }
+      // Already active → no-op. Do NOT reinstall or reload: a reload storm across
+      // every open tab for an already-live rule would needlessly discard page
+      // state (mirrors the csp_restore no-op guard below).
+      if (alreadyStripped) {
+        return { success: true, data: { scope: "all-tabs", cspStripped: true, tabsReloaded: 0 } }
+      }
+      try {
+        await chrome.declarativeNetRequest.updateSessionRules({
+          removeRuleIds: [CSP_GLOBAL_RULE_ID],
+          addRules: [buildGlobalCspRule()]
+        })
+      } catch (err) {
+        return { success: false, error: `failed to install CSP bypass rule: ${(err as Error).message}` }
+      }
+      // Install the rule BEFORE reloading so the reloads fetch CSP-free responses.
+      const tabsReloaded = reload ? await reloadAllWebTabs() : 0
+      return { success: true, data: { scope: "all-tabs", cspStripped: true, tabsReloaded } }
+    }
+
+    case "csp_restore": {
+      const reload = action.reload !== false
+      let stripped: boolean
+      try {
+        stripped = await isCspStripped()
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${(err as Error).message}` }
+      }
+      // Nothing installed → nothing to restore, and no reload (a reload storm
+      // across every open tab for a no-op would needlessly discard page state).
+      if (!stripped) {
+        return { success: true, data: { scope: "all-tabs", cspStripped: false, tabsReloaded: 0 } }
+      }
+      try {
+        await chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: [CSP_GLOBAL_RULE_ID] })
+      } catch (err) {
+        return { success: false, error: `failed to remove CSP bypass rule: ${(err as Error).message}` }
+      }
+      const tabsReloaded = reload ? await reloadAllWebTabs() : 0
+      return { success: true, data: { scope: "all-tabs", cspStripped: false, tabsReloaded } }
+    }
+
+    case "csp_status": {
+      try {
+        const stripped = await isCspStripped()
+        return { success: true, data: { scope: "all-tabs", cspStripped: stripped } }
+      } catch (err) {
+        return { success: false, error: `failed to read CSP bypass state: ${(err as Error).message}` }
+      }
+    }
+  }
+
+  return { success: false, error: `unknown csp action: ${action.type}` }
+}

--- a/extension/src/background/no-tab-actions.ts
+++ b/extension/src/background/no-tab-actions.ts
@@ -5,7 +5,10 @@ export const NO_TAB_ACTIONS = new Set([
   "bookmark_create", "downloads_search", "browsing_data_remove",
   "session_list", "session_restore", "notification_create", "notification_clear",
   "search_query", "monitor_status", "monitor_start", "monitor_pause", "monitor_resume",
-  "monitor_stop", "brand_set_tab_group", "group_list", "group_close"
+  "monitor_stop", "brand_set_tab_group", "group_list", "group_close",
+  // CSP toggle is browser-global (one DNR rule, no tabIds), so it never needs a
+  // resolved active tab — it operates on every tab, current and future.
+  "csp_strip", "csp_restore", "csp_status"
 ])
 
 export function needsTab(type: string): boolean {

--- a/extension/src/background/router.ts
+++ b/extension/src/background/router.ts
@@ -17,6 +17,7 @@ import { handleSearchActions } from "./capabilities/search"
 import { handleBrowsingDataActions } from "./capabilities/browsing-data"
 import { handleHeaderActions } from "./capabilities/headers"
 import { handleEvaluateActions } from "./capabilities/evaluate"
+import { handleCspActions } from "./capabilities/csp"
 import { handleBinarySinkActions } from "./capabilities/binary-sink"
 import { handleStyleActions } from "./capabilities/style"
 import { handleFrameActions } from "./capabilities/frames"
@@ -68,6 +69,7 @@ const NOTIFICATION_ACTIONS = new Set(["notification_create", "notification_clear
 const BROWSING_DATA_ACTIONS = new Set(["browsing_data_remove"])
 const HEADER_ACTIONS = new Set(["headers_modify"])
 const EVALUATE_ACTIONS = new Set(["evaluate"])
+const CSP_ACTIONS = new Set(["csp_strip", "csp_restore", "csp_status"])
 const BINARY_SINK_ACTIONS = new Set(["binary_sink_save"])
 const STYLE_ACTIONS = new Set(["style_inject", "style_remove"])
 const FRAME_ACTIONS = new Set(["frames_list", "frames_read_tree"])
@@ -107,6 +109,7 @@ export async function routeAction(
   if (BROWSING_DATA_ACTIONS.has(action.type)) return handleBrowsingDataActions(action, tabId)
   if (HEADER_ACTIONS.has(action.type)) return handleHeaderActions(action, tabId)
   if (EVALUATE_ACTIONS.has(action.type)) return handleEvaluateActions(action, tabId)
+  if (CSP_ACTIONS.has(action.type)) return handleCspActions(action)
   if (BINARY_SINK_ACTIONS.has(action.type)) return handleBinarySinkActions(action, tabId)
   if (STYLE_ACTIONS.has(action.type)) return handleStyleActions(action, tabId)
   if (FRAME_ACTIONS.has(action.type)) return handleFrameActions(action, tabId)

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -12,6 +12,9 @@ export type Action =
   | { type: "extract_markdown"; index?: number; ref?: string; frameId?: number; maxChars?: number }
   | { type: "extract_html"; index?: number; ref?: string; frameId?: number }
   | { type: "evaluate"; code: string; world?: "MAIN" | "ISOLATED" }
+  | { type: "csp_strip"; reload?: boolean }
+  | { type: "csp_restore"; reload?: boolean }
+  | { type: "csp_status" }
   | { type: "screenshot"; format?: "png" | "jpeg" | "webp"; quality?: number; save?: boolean; clip?: { x: number; y: number; width: number; height: number }; element?: number; full?: boolean; target_max_long_edge?: number }
   | { type: "tab_create"; url?: string; reuse?: boolean; active?: boolean }
   | { type: "tab_close"; tabId?: number }

--- a/test/csp-cli.test.ts
+++ b/test/csp-cli.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test"
+
+import { runCsp } from "../cli/commands/csp"
+
+type CspAction = { type: string; [key: string]: unknown }
+type CspResult = { success: boolean; error?: string; data?: unknown }
+type CspSender = NonNullable<Parameters<typeof runCsp>[2]>
+type SenderCall = {
+  action: CspAction
+  tabId?: number
+  useWs?: boolean
+  contextId?: string
+}
+
+function makeSender(calls: SenderCall[], result: CspResult = { success: true, data: {} }): CspSender {
+  return async (action, tabId, useWs, contextId) => {
+    calls.push({ action, tabId, useWs, contextId })
+    return result
+  }
+}
+
+async function withMutedConsole(fn: () => Promise<void>): Promise<void> {
+  const originalLog = console.log
+  console.log = () => {}
+  try {
+    await fn()
+  } finally {
+    console.log = originalLog
+  }
+}
+
+// Capture stdout/stderr AND intercept process.exit so we can assert the
+// human-readable output and the exit-code contract without killing the runner.
+async function capture(fn: () => Promise<void>): Promise<{ out: string[]; err: string[]; exit?: number }> {
+  const origLog = console.log
+  const origErr = console.error
+  const origExit = process.exit
+  const out: string[] = []
+  const err: string[] = []
+  let exit: number | undefined
+  console.log = (...a: unknown[]) => { out.push(a.join(" ")) }
+  console.error = (...a: unknown[]) => { err.push(a.join(" ")) }
+  process.exit = ((code?: number) => { exit = code ?? 0; throw new Error("__exit__") }) as typeof process.exit
+  try {
+    await fn()
+  } catch (e) {
+    if ((e as Error).message !== "__exit__") throw e
+  } finally {
+    console.log = origLog
+    console.error = origErr
+    process.exit = origExit
+  }
+  return { out, err, exit }
+}
+
+describe("runCsp", () => {
+  test("off disables CSP (reload default true) and passes routing options", async () => {
+    const calls: SenderCall[] = []
+    await withMutedConsole(() =>
+      runCsp(["csp", "off"], { globalTabId: 7, useWs: true, contextId: "work" }, makeSender(calls))
+    )
+    expect(calls).toEqual([
+      { action: { type: "csp_strip", reload: true }, tabId: 7, useWs: true, contextId: "work" },
+    ])
+  })
+
+  test("on restores CSP", async () => {
+    const calls: SenderCall[] = []
+    await withMutedConsole(() => runCsp(["csp", "on"], { contextId: "work" }, makeSender(calls)))
+    expect(calls).toEqual([
+      { action: { type: "csp_restore", reload: true }, tabId: undefined, useWs: undefined, contextId: "work" },
+    ])
+  })
+
+  test("status queries state and sends no reload flag", async () => {
+    const calls: SenderCall[] = []
+    await withMutedConsole(() => runCsp(["csp", "status"], {}, makeSender(calls)))
+    expect(calls).toEqual([
+      { action: { type: "csp_status" }, tabId: undefined, useWs: undefined, contextId: undefined },
+    ])
+  })
+
+  test("--no-reload sets reload:false", async () => {
+    const calls: SenderCall[] = []
+    await withMutedConsole(() => runCsp(["csp", "off", "--no-reload"], {}, makeSender(calls)))
+    expect(calls[0].action).toEqual({ type: "csp_strip", reload: false })
+  })
+
+  test("disable/enable are aliases for off/on", async () => {
+    const calls: SenderCall[] = []
+    await withMutedConsole(async () => {
+      await runCsp(["csp", "disable"], {}, makeSender(calls))
+      await runCsp(["csp", "enable"], {}, makeSender(calls))
+    })
+    expect(calls.map((c) => c.action.type)).toEqual(["csp_strip", "csp_restore"])
+  })
+
+  test("status prints disabled / enabled for all tabs", async () => {
+    const disabled = await capture(() =>
+      runCsp(["csp", "status"], {}, makeSender([], { success: true, data: { scope: "all-tabs", cspStripped: true } }))
+    )
+    expect(disabled.out).toContain("csp: disabled (all tabs)")
+
+    const enabled = await capture(() =>
+      runCsp(["csp", "status"], {}, makeSender([], { success: true, data: { scope: "all-tabs", cspStripped: false } }))
+    )
+    expect(enabled.out).toContain("csp: enabled (all tabs)")
+  })
+
+  test("off reports reloaded-tab count vs applies-on-next-navigation", async () => {
+    const reloaded = await capture(() =>
+      runCsp(["csp", "off"], {}, makeSender([], { success: true, data: { cspStripped: true, tabsReloaded: 4 } }))
+    )
+    expect(reloaded.out.join("\n")).toContain("reloaded 4 tab(s)")
+
+    const deferred = await capture(() =>
+      runCsp(["csp", "off", "--no-reload"], {}, makeSender([], { success: true, data: { cspStripped: true, tabsReloaded: 0 } }))
+    )
+    expect(deferred.out.join("\n")).toContain("applies on next navigation")
+  })
+
+  test("a failed daemon response exits non-zero", async () => {
+    const res = await capture(() =>
+      runCsp(["csp", "off"], {}, makeSender([], { success: false, error: "DNR quota" }))
+    )
+    expect(res.exit).toBe(1)
+    expect(res.err.join("\n")).toContain("DNR quota")
+  })
+
+  test("an unknown subcommand exits non-zero", async () => {
+    const res = await capture(() => runCsp(["csp", "bogus"], {}, makeSender([])))
+    expect(res.exit).toBe(1)
+    expect(res.err.join("\n")).toContain("unknown csp subcommand")
+  })
+
+  test("no subcommand prints usage and exits non-zero", async () => {
+    const res = await capture(() => runCsp(["csp"], {}, makeSender([])))
+    expect(res.exit).toBe(1)
+    expect(res.err.join("\n")).toContain("requires a subcommand")
+  })
+
+  test("on prints the restore string with reloaded count", async () => {
+    const res = await capture(() =>
+      runCsp(["csp", "on"], {}, makeSender([], { success: true, data: { cspStripped: false, tabsReloaded: 2 } }))
+    )
+    expect(res.out.join("\n")).toContain("CSP restored for all tabs")
+    expect(res.out.join("\n")).toContain("reloaded 2 tab(s)")
+  })
+
+  test("--json prints the raw result and exits 1 on failure", async () => {
+    const ok = await capture(() =>
+      runCsp(["csp", "status"], { jsonMode: true }, makeSender([], { success: true, data: { scope: "all-tabs", cspStripped: true } }))
+    )
+    expect(ok.exit).toBeUndefined()
+    expect(JSON.parse(ok.out.join("\n"))).toEqual({ success: true, data: { scope: "all-tabs", cspStripped: true } })
+
+    const fail = await capture(() =>
+      runCsp(["csp", "off"], { jsonMode: true }, makeSender([], { success: false, error: "DNR quota" }))
+    )
+    expect(fail.exit).toBe(1)
+    expect(JSON.parse(fail.out.join("\n"))).toEqual({ success: false, error: "DNR quota" })
+  })
+})

--- a/test/csp-toggle.test.ts
+++ b/test/csp-toggle.test.ts
@@ -1,0 +1,223 @@
+/// <reference lib="dom" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+// csp toggle — browser-global extension handler.
+//
+// handleCspActions installs/removes ONE declarativeNetRequest session rule (id
+// 900000, no tabIds) that strips CSP response headers on every tab, and by
+// default reloads every open http/https tab so the change is live now. These
+// tests drive it against a stateful chrome.declarativeNetRequest + chrome.tabs
+// mock. `callLog` records the relative order of DNR writes vs tab reloads so the
+// "rule installed before reload" invariant can be asserted.
+
+const GLOBAL_RULE_ID = 900_000
+
+type SessionRule = {
+  id: number
+  action: { responseHeaders: Array<{ header: string; operation: string }> }
+  condition: { tabIds?: number[]; resourceTypes?: string[] }
+  [k: string]: unknown
+}
+type UpdateCall = { removeRuleIds?: number[]; addRules?: SessionRule[] }
+
+let sessionRules: SessionRule[]
+let reloadCalls: Array<{ id: number; opts: { bypassCache?: boolean } }>
+let callLog: string[]
+let tabsFixture: Array<{ id?: number; url?: string; pendingUrl?: string }>
+let originalChrome: unknown
+
+beforeEach(() => {
+  sessionRules = []
+  reloadCalls = []
+  callLog = []
+  tabsFixture = [
+    { id: 1, url: "https://a.example/" },
+    { id: 2, url: "https://b.example/" },
+    { id: 3, url: "http://c.example/" },
+    { id: 4, url: "chrome://extensions/" }, // skipped — not http/https
+    { id: 5, url: "about:blank" },          // skipped
+    { url: "https://no-id.example/" },       // skipped — no tab id
+  ]
+  originalChrome = (globalThis as { chrome?: unknown }).chrome
+  ;(globalThis as { chrome: unknown }).chrome = {
+    declarativeNetRequest: {
+      updateSessionRules: async ({ removeRuleIds = [], addRules = [] }: UpdateCall) => {
+        sessionRules = sessionRules.filter((r) => !removeRuleIds.includes(r.id))
+        sessionRules.push(...(addRules as SessionRule[]))
+        callLog.push(addRules.length ? "rules:add" : "rules:remove")
+      },
+      getSessionRules: async () => sessionRules.slice(),
+    },
+    tabs: {
+      query: async () => tabsFixture.slice(),
+      reload: async (id: number, opts: { bypassCache?: boolean }) => {
+        reloadCalls.push({ id, opts })
+        callLog.push("reload:" + id)
+      },
+    },
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as { chrome?: unknown }).chrome = originalChrome
+})
+
+async function load() {
+  return await import("../extension/src/background/capabilities/csp")
+}
+
+const reloadedIds = () => reloadCalls.map((c) => c.id).sort((a, b) => a - b)
+const globalRule = () => sessionRules.find((r) => r.id === GLOBAL_RULE_ID)
+const isStripped = () => sessionRules.some((r) => r.id === GLOBAL_RULE_ID)
+const dataOf = (res: { data?: unknown }) =>
+  res.data as { scope?: string; cspStripped?: boolean; tabsReloaded?: number }
+
+describe("handleCspActions (global)", () => {
+  test("csp_strip installs ONE global rule (no tabIds) removing both CSP headers", async () => {
+    const { handleCspActions } = await load()
+    const res = await handleCspActions({ type: "csp_strip" })
+
+    expect(res.success).toBe(true)
+    const rule = globalRule()
+    expect(rule).toBeDefined()
+    expect(rule!.condition.tabIds).toBeUndefined() // applies to ALL tabs, current + future
+    expect(rule!.condition.resourceTypes?.slice().sort()).toEqual(["main_frame", "sub_frame"])
+    const removed = rule!.action.responseHeaders
+      .filter((h) => h.operation === "remove")
+      .map((h) => h.header)
+      .sort()
+    expect(removed).toEqual(["content-security-policy", "content-security-policy-report-only"])
+    expect(dataOf(res).scope).toBe("all-tabs")
+    expect(dataOf(res).cspStripped).toBe(true)
+  })
+
+  test("csp_strip reloads every open http/https tab with bypassCache (skips chrome:// / about: / id-less)", async () => {
+    const { handleCspActions } = await load()
+    const res = await handleCspActions({ type: "csp_strip" })
+    expect(reloadedIds()).toEqual([1, 2, 3])
+    expect(reloadCalls.every((c) => c.opts?.bypassCache === true)).toBe(true)
+    expect(dataOf(res).tabsReloaded).toBe(3)
+  })
+
+  test("the rule is installed BEFORE any tab reload fires", async () => {
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip" })
+    expect(callLog[0]).toBe("rules:add")
+    expect(callLog.slice(1).every((e) => e.startsWith("reload:"))).toBe(true)
+  })
+
+  test("--no-reload installs the rule but reloads nothing", async () => {
+    const { handleCspActions } = await load()
+    const res = await handleCspActions({ type: "csp_strip", reload: false })
+    expect(isStripped()).toBe(true)
+    expect(reloadCalls).toEqual([])
+    expect(dataOf(res).tabsReloaded).toBe(0)
+  })
+
+  test("csp_strip reloads a mid-navigation tab matched via pendingUrl", async () => {
+    tabsFixture = [{ id: 9, url: "", pendingUrl: "https://loading.example/" }]
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip" })
+    expect(reloadedIds()).toEqual([9])
+  })
+
+  test("csp_restore removes the global rule and reloads by default", async () => {
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip", reload: false })
+    expect(isStripped()).toBe(true)
+
+    const res = await handleCspActions({ type: "csp_restore" })
+    expect(isStripped()).toBe(false)
+    expect(dataOf(res).cspStripped).toBe(false)
+    expect(reloadedIds()).toEqual([1, 2, 3])
+  })
+
+  test("csp_restore when nothing is disabled is a no-op and does NOT reload", async () => {
+    const { handleCspActions } = await load()
+    const res = await handleCspActions({ type: "csp_restore" }) // default reload=true
+    expect(res.success).toBe(true)
+    expect(dataOf(res).cspStripped).toBe(false)
+    expect(dataOf(res).tabsReloaded).toBe(0)
+    expect(reloadCalls).toEqual([]) // must not reload every tab for a no-op
+  })
+
+  test("csp_status reflects the global rule presence", async () => {
+    const { handleCspActions } = await load()
+    expect(dataOf(await handleCspActions({ type: "csp_status" })).cspStripped).toBe(false)
+    await handleCspActions({ type: "csp_strip", reload: false })
+    expect(dataOf(await handleCspActions({ type: "csp_status" })).cspStripped).toBe(true)
+  })
+
+  test("re-stripping does not stack duplicate global rules", async () => {
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip", reload: false })
+    await handleCspActions({ type: "csp_strip", reload: false })
+    expect(sessionRules.filter((r) => r.id === GLOBAL_RULE_ID)).toHaveLength(1)
+  })
+
+  test("re-running csp_strip when already active is a no-op (no reinstall, no reload storm)", async () => {
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip", reload: false }) // install
+    callLog.length = 0
+    reloadCalls.length = 0
+
+    const res = await handleCspActions({ type: "csp_strip" }) // default reload=true
+    expect(res.success).toBe(true)
+    expect(dataOf(res).cspStripped).toBe(true)
+    expect(dataOf(res).tabsReloaded).toBe(0)
+    expect(reloadCalls).toEqual([]) // must not reload every tab when already active
+    expect(callLog).toEqual([])     // must not touch updateSessionRules again
+  })
+
+  test("tabsReloaded counts successes, not attempts, and a failure never fails the toggle", async () => {
+    const { handleCspActions } = await load()
+    ;(globalThis as { chrome: { tabs: { reload: (id: number, opts: { bypassCache?: boolean }) => Promise<void> } } }).chrome.tabs.reload =
+      async (id: number, opts: { bypassCache?: boolean }) => {
+        if (id === 2) throw new Error("No tab with id 2")
+        reloadCalls.push({ id, opts })
+      }
+    const res = await handleCspActions({ type: "csp_strip" })
+    expect(res.success).toBe(true)          // the DNR install succeeded
+    expect(isStripped()).toBe(true)
+    expect(reloadedIds()).toEqual([1, 3])   // tab 2 threw
+    expect(dataOf(res).tabsReloaded).toBe(2) // only the 2 that actually reloaded
+  })
+
+  test("a DNR install failure surfaces as an error result rather than throwing", async () => {
+    const { handleCspActions } = await load()
+    ;(globalThis as unknown as { chrome: { declarativeNetRequest: { updateSessionRules: (o: unknown) => Promise<void> } } })
+      .chrome.declarativeNetRequest.updateSessionRules = async () => { throw new Error("DNR quota") }
+    const res = await handleCspActions({ type: "csp_strip", reload: false })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain("DNR quota")
+  })
+
+  test("csp_restore surfaces a read (getSessionRules) failure", async () => {
+    const { handleCspActions } = await load()
+    ;(globalThis as unknown as { chrome: { declarativeNetRequest: { getSessionRules: () => Promise<unknown> } } })
+      .chrome.declarativeNetRequest.getSessionRules = async () => { throw new Error("DNR read failed") }
+    const res = await handleCspActions({ type: "csp_restore" })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain("failed to read CSP bypass state")
+  })
+
+  test("csp_restore surfaces a remove (updateSessionRules) failure", async () => {
+    const { handleCspActions } = await load()
+    await handleCspActions({ type: "csp_strip", reload: false }) // install so restore reaches the remove
+    ;(globalThis as unknown as { chrome: { declarativeNetRequest: { updateSessionRules: (o: unknown) => Promise<void> } } })
+      .chrome.declarativeNetRequest.updateSessionRules = async () => { throw new Error("remove failed") }
+    const res = await handleCspActions({ type: "csp_restore", reload: false })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain("failed to remove CSP bypass rule")
+  })
+
+  test("csp_status surfaces a getSessionRules failure as an error result", async () => {
+    const { handleCspActions } = await load()
+    ;(globalThis as unknown as { chrome: { declarativeNetRequest: { getSessionRules: () => Promise<unknown> } } })
+      .chrome.declarativeNetRequest.getSessionRules = async () => { throw new Error("DNR read failed") }
+    const res = await handleCspActions({ type: "csp_status" })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain("DNR read failed")
+  })
+})


### PR DESCRIPTION
I hit strict-CSP pages constantly where I can't run injected JS — inline `<script>` and `eval` get blocked. The only thing that helps today is `eval`'s automatic strip-on-failure, but it's tied to `eval`, works one tab at a time, and you can't turn it off or see its state.

This adds a simple switch that works across every tab:

- `interceptor csp off` — disable CSP on all tabs
- `interceptor csp on` — put it back
- `interceptor csp status` — check the current state

How it works: one `declarativeNetRequest` session rule with no tab scope strips the CSP response headers, so every tab is covered — the ones already open and any you open later. No `chrome.debugger`, no banner. Session-only, so it never lingers after a browser restart.

By default `off`/`on` reload the open web tabs so already-loaded pages go live immediately (`--no-reload` skips that; new tabs are covered regardless).

Built this for my own workflow and I'm keeping it in my fork regardless — putting it up in case it's useful. Happy to change anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-wide Content Security Policy (CSP) toggle with commands to disable, re-enable, and check status.
  * Included optional “no-reload” behavior so CSP changes can apply on next navigation.
  * CSP disabling/restoring is now applied across current and future tabs.

* **Documentation**
  * Expanded help and reference guidance to describe CSP behavior, scope, reload behavior, and strict-CSP workflow notes.

* **Tests**
  * Added/updated test coverage for the CSP CLI and browser-side CSP handling, including reload logic, status output, aliases, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->