### PR TITLE
fix(daemon): identity-check relay-slot release; answer keepalive pings on the originating socket

### DIFF
--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -17,7 +17,7 @@ import {
   type MonitorSessionMeta,
   updateSessionMeta,
 } from "../shared/monitor-artifacts"
-import { chooseOutboundTransport, validateContextRouting } from "./outbound-routing"
+import { chooseOutboundTransport, isRelayPing, relaySlotAfterClose, validateContextRouting } from "./outbound-routing"
 import { claimContextId, type ContextSocket } from "./context-registration"
 import { formatBridgeUnavailableError, getBridgeRecoveryActions, getBridgeRecoveryLayout } from "./bridge-recovery"
 import { clearDaemonRuntimeFiles, clearLockFile, decideDaemonStartupRole, decideSingletonGate, defaultLifecycleDeps, readPidState, spawnDetachedStandaloneDaemon, writeLockFile } from "./lifecycle"
@@ -879,12 +879,17 @@ function sendNativeMessage(msg: unknown, contextId?: string): void {
   if (preferred === "relay" && nativeRelaySocket) {
     if (failOversizedNativeMessage("native relay")) return
     log(`forwarding via relay: ${json.slice(0, 200)}`)
+    const relayAtSend = nativeRelaySocket
     try {
-      socketWriteFramed(nativeRelaySocket, json)
+      socketWriteFramed(relayAtSend, json)
       return
     } catch (err) {
       log(`relay send error: ${(err as Error).message}`)
-      nativeRelaySocket = null
+      // Identity-checked release. This block is synchronous (no yield between
+      // capture and check), so unlike the close handler this guard is
+      // belt-and-suspenders, not a race fix — kept so the invariant
+      // "only the owner releases the slot" holds at every release site.
+      if (nativeRelaySocket === relayAtSend) nativeRelaySocket = null
     }
   }
 
@@ -912,12 +917,13 @@ function sendNativeMessage(msg: unknown, contextId?: string): void {
   if (nativeRelaySocket) {
     if (failOversizedNativeMessage("fallback native relay")) return
     log(`fallback via relay: ${json.slice(0, 200)}`)
+    const relayAtSend = nativeRelaySocket
     try {
-      socketWriteFramed(nativeRelaySocket, json)
+      socketWriteFramed(relayAtSend, json)
       return
     } catch (err) {
       log(`fallback relay send error: ${(err as Error).message}`)
-      nativeRelaySocket = null
+      if (nativeRelaySocket === relayAtSend) nativeRelaySocket = null
     }
   }
 
@@ -1260,6 +1266,9 @@ try {
           // Native relay registration — relay process identifies itself
           if (request.type === "native-relay") {
             ;(socket as any).__nativeRelay = true
+            if (nativeRelaySocket && nativeRelaySocket !== socket) {
+              log("native relay superseded — previous registration replaced (reconnect or second browser)")
+            }
             nativeRelaySocket = socket
             log("native relay registered via IPC socket")
             continue
@@ -1267,6 +1276,16 @@ try {
 
           // Native relay message forwarding — route to extension protocol handler
           if ((socket as any).__nativeRelay) {
+            // Keepalive pings are answered directly on the originating socket:
+            // the extension's pong timer must measure THIS link, not the
+            // relay-slot routing state (a superseded slot starved pongs and
+            // forced endless 15s-timeout reconnects).
+            if (isRelayPing(request)) {
+              log("received ping (relay), sending pong to origin")
+              socketWriteFramed(socket, JSON.stringify({ type: "pong" }))
+              emitEvent("keepalive_ping")
+              continue
+            }
             handleNativeMessage(request as any)
             continue
           }
@@ -1390,8 +1409,13 @@ try {
       },
       close(socket: Bun.Socket<undefined>) {
         if ((socket as any).__nativeRelay) {
-          nativeRelaySocket = null
-          log("native relay disconnected")
+          const { slot, released } = relaySlotAfterClose(nativeRelaySocket, socket)
+          nativeRelaySocket = slot
+          if (released) {
+            log("native relay disconnected")
+          } else {
+            log("stale native relay closed — current relay registration kept")
+          }
         }
         socketBuffers.delete(socket)
         socketWriteQueues.delete(socket)

--- a/daemon/outbound-routing.ts
+++ b/daemon/outbound-routing.ts
@@ -8,6 +8,22 @@ export function isControlMessage(msg: unknown): boolean {
   return candidate?.type === "ping" || candidate?.type === "pong"
 }
 
+/** Keepalive ping arriving over a registered native relay socket. Answered
+ *  directly on the originating socket so liveness never depends on the
+ *  relay-slot routing state. */
+export function isRelayPing(msg: unknown): boolean {
+  return (msg as { type?: unknown } | null)?.type === "ping"
+}
+
+/** Identity-checked relay-slot release: only the CURRENT relay's close frees
+ *  the slot. A superseded relay's lingering process closing later must not
+ *  unregister the live relay — that clobber turned any transient reconnect
+ *  into a permanent pong-timeout loop. */
+export function relaySlotAfterClose<S>(current: S | null, closing: S): { slot: S | null; released: boolean } {
+  if (current === closing) return { slot: null, released: true }
+  return { slot: current, released: false }
+}
+
 export function chooseOutboundTransport(
   msg: unknown,
   state: {

--- a/test/relay-clobber-integration.test.ts
+++ b/test/relay-clobber-integration.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Integration regression for the keepalive pong-timeout reconnect loop:
+// exercises the REAL daemon wiring (registration at the IPC socket, the
+// close(socket) handler, and the pong-to-origin write) rather than the
+// extracted helpers. Scenario that used to fail: relay A registers, relay B
+// supersedes it, A's lingering process dies — the old close handler nulled
+// the slot unconditionally, so B's next keepalive pong was silently queued
+// for ws and the extension force-reconnected forever.
+
+const REPO_ROOT = join(import.meta.dir, "..")
+
+let workDir: string
+let daemon: ReturnType<typeof Bun.spawn> | null = null
+let socketPath: string
+
+function frameMessage(json: string): Buffer {
+  const encoded = Buffer.from(json, "utf-8")
+  const header = Buffer.alloc(4)
+  header.writeUInt32LE(encoded.byteLength, 0)
+  return Buffer.concat([header, encoded])
+}
+
+interface RelayConn {
+  socket: Awaited<ReturnType<typeof Bun.connect>>
+  messages: Array<Record<string, unknown>>
+  close(): void
+}
+
+async function connectRelay(): Promise<RelayConn> {
+  const messages: Array<Record<string, unknown>> = []
+  let buffer = Buffer.alloc(0)
+  const socket = await Bun.connect({
+    unix: socketPath,
+    socket: {
+      data(_socket, chunk) {
+        buffer = Buffer.concat([buffer, Buffer.from(chunk)])
+        while (buffer.length >= 4) {
+          const len = buffer.readUInt32LE(0)
+          if (buffer.length < 4 + len) break
+          const body = buffer.subarray(4, 4 + len).toString("utf-8")
+          buffer = buffer.subarray(4 + len)
+          try { messages.push(JSON.parse(body)) } catch {}
+        }
+      },
+    },
+  })
+  return {
+    socket,
+    messages,
+    close() { socket.end() },
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await Bun.sleep(25)
+  }
+  return predicate()
+}
+
+beforeAll(async () => {
+  workDir = mkdtempSync(join(tmpdir(), "interceptor-clobber-test-"))
+  socketPath = join(workDir, "d.sock")
+  daemon = Bun.spawn(["bun", "run", join(REPO_ROOT, "daemon", "index.ts"), "--standalone"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      INTERCEPTOR_TEMP: workDir,
+      INTERCEPTOR_SOCKET_PATH: socketPath,
+      // Ports distinct from the live daemon (19221/19222) so the test never
+      // loses the singleton gate to a real running instance.
+      INTERCEPTOR_IPC_PORT: "19321",
+      INTERCEPTOR_WS_PORT: "19322",
+    },
+    stdout: "ignore",
+    stderr: "ignore",
+  })
+  const up = await waitFor(() => existsSync(socketPath), 8000)
+  if (!up) throw new Error("test daemon did not create its IPC socket")
+})
+
+afterAll(() => {
+  try { daemon?.kill() } catch {}
+  try { rmSync(workDir, { recursive: true, force: true }) } catch {}
+})
+
+describe("relay supersede wiring (daemon integration)", () => {
+  test("stale relay close does not starve the live relay's keepalive pong", async () => {
+    // Relay A registers.
+    const relayA = await connectRelay()
+    relayA.socket.write(frameMessage(JSON.stringify({ type: "native-relay" })))
+    // A proves the link works: ping → pong on A.
+    relayA.socket.write(frameMessage(JSON.stringify({ type: "ping" })))
+    expect(await waitFor(() => relayA.messages.some(m => m.type === "pong"))).toBe(true)
+
+    // Relay B supersedes A (extension reconnect / second browser).
+    const relayB = await connectRelay()
+    relayB.socket.write(frameMessage(JSON.stringify({ type: "native-relay" })))
+
+    // A's lingering process finally dies AFTER B registered.
+    relayA.close()
+    await Bun.sleep(150)
+
+    // THE regression: B's keepalive must still be answered on B.
+    relayB.socket.write(frameMessage(JSON.stringify({ type: "ping" })))
+    const bGotPong = await waitFor(() => relayB.messages.some(m => m.type === "pong"))
+    expect(bGotPong).toBe(true)
+
+    relayB.close()
+  })
+
+  test("ping is answered on the originating socket even when it does not hold the slot", async () => {
+    // C registers, then D supersedes — C stays connected (dual-browser case).
+    const relayC = await connectRelay()
+    relayC.socket.write(frameMessage(JSON.stringify({ type: "native-relay" })))
+    const relayD = await connectRelay()
+    relayD.socket.write(frameMessage(JSON.stringify({ type: "native-relay" })))
+    await Bun.sleep(100)
+
+    // C no longer holds the slot, but its keepalive must be answered on C —
+    // liveness is a link property, not a routing-slot property.
+    relayC.socket.write(frameMessage(JSON.stringify({ type: "ping" })))
+    const cGotPong = await waitFor(() => relayC.messages.some(m => m.type === "pong"))
+    expect(cGotPong).toBe(true)
+
+    relayC.close()
+    relayD.close()
+  })
+})

--- a/test/relay-slot.test.ts
+++ b/test/relay-slot.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { isRelayPing, relaySlotAfterClose } from "../daemon/outbound-routing"
+
+// Regression: the keepalive pong-timeout reconnect loop (extension error
+// "keepalive pong timeout (15s) — forcing reconnect") was self-sustained by
+// the singleton clearing its relay slot whenever ANY relay-flagged socket
+// closed. A superseded old relay's death unregistered the live relay, so the
+// next pong fell to the ws queue, the extension timed out, reconnected, and
+// the cycle repeated forever.
+describe("relaySlotAfterClose", () => {
+  const relayA = { id: "A" }
+  const relayB = { id: "B" }
+
+  test("current relay closing releases the slot", () => {
+    const result = relaySlotAfterClose<{ id: string }>(relayA, relayA)
+    expect(result.slot).toBeNull()
+    expect(result.released).toBe(true)
+  })
+
+  test("stale relay closing does NOT clobber the current relay", () => {
+    // A registers, B supersedes A, then A's lingering process exits.
+    const afterStaleClose = relaySlotAfterClose<{ id: string }>(relayB, relayA)
+    expect(afterStaleClose.slot).toBe(relayB)
+    expect(afterStaleClose.released).toBe(false)
+  })
+
+  test("close with empty slot stays empty", () => {
+    const result = relaySlotAfterClose<{ id: string }>(null, relayA)
+    expect(result.slot).toBeNull()
+    expect(result.released).toBe(false)
+  })
+
+  test("full supersede sequence keeps the live relay registered", () => {
+    // register A → A is current
+    let slot: { id: string } | null = relayA
+    // B registers (extension reconnected while A lingers) → B is current
+    slot = relayB
+    // A's process finally notices stdin EOF and its socket closes
+    slot = relaySlotAfterClose(slot, relayA).slot
+    expect(slot).toBe(relayB)
+    // B closing afterwards releases normally
+    slot = relaySlotAfterClose(slot, relayB).slot
+    expect(slot).toBeNull()
+  })
+})
+
+describe("isRelayPing", () => {
+  test("detects keepalive pings from a relay", () => {
+    expect(isRelayPing({ type: "ping" })).toBe(true)
+  })
+
+  test("rejects non-ping traffic", () => {
+    expect(isRelayPing({ type: "pong" })).toBe(false)
+    expect(isRelayPing({ type: "native-relay" })).toBe(false)
+    expect(isRelayPing({ id: "abc", result: {} })).toBe(false)
+    expect(isRelayPing(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

The extension can get stuck in a **permanent** `keepalive pong timeout (15s) — forcing reconnect` loop (errors pile up endlessly on the chrome://extensions card, native transport never re-stabilizes).

Root cause in the daemon singleton: the IPC socket `close` handler released `nativeRelaySocket` whenever **any** relay-flagged socket closed — no identity check. Sequence that makes it permanent:

1. Extension reconnects (MV3 SW restart, Chrome restart, or a second browser/profile runs the extension) → relay B registers while relay A's process lingers (~45s until it notices stdin EOF).
2. A finally dies → close handler nulls the slot → **B's live registration is clobbered**.
3. B's next keepalive pong is silently queued for the ws path instead of reaching the extension.
4. Extension hits the 15s pong timeout, force-reconnects → new relay supersedes B → B's later death re-clobbers again. The loop self-sustains from any single transient blip.

With the extension loaded in **two** browsers/profiles simultaneously, the mutual clobbering is perpetual.

## Fix

- **`relaySlotAfterClose()`** — identity-checked slot release: only the *current* relay's close frees the slot; a superseded relay's late death logs `stale native relay closed — current relay registration kept` and touches nothing. Same guard applied (belt-and-suspenders) at both send-error release sites.
- **`isRelayPing()`** — keepalive pings arriving on a relay socket are answered with a pong **directly on the originating socket**, so liveness never depends on the mutable routing slot. This also lets two browsers' extensions coexist without starving each other's keepalives.
- Supersede log line on registration for diagnosability.

## Tests

- `test/relay-slot.test.ts` — helper unit tests (incl. the full A→B→A-dies supersede sequence).
- `test/relay-clobber-integration.test.ts` — spawns a real daemon (env-isolated socket/ports), registers relay A then B over the actual IPC socket, closes A, asserts B still receives its pong; plus the dual-browser non-slot-holder liveness case. **Both integration tests fail against the previous wiring** and pass with this change.
- Full suite: 698 tests / 0 fail; `tsc -p tsconfig.host.json` clean.

Verified live on macOS: with the fix deployed, multi-cycle soaks under dual-browser pressure show every ping answered on its origin socket, zero pongs mis-queued, zero forced reconnects (previously one forced reconnect every ~30–45s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay connection handling so keepalive responses continue working even when relay connections disconnect or are replaced.
  * Prevented stale relay closes from interrupting the active relay connection.
  * Made ping/pong responses more reliable for native relay communication.

* **Tests**
  * Added coverage for relay supersession and keepalive behavior to protect against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->