### PR TITLE
fix(install): detect Brave on Linux when the binary is 'brave'

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,8 @@ browser_installed() {
     Darwin:chrome-for-testing) [[ -d "/Applications/Google Chrome for Testing.app" ]]  && echo 1 || echo 0 ;;
     Darwin:edge)               [[ -d "/Applications/Microsoft Edge.app" ]]             && echo 1 || echo 0 ;;
     Darwin:vivaldi)            [[ -d "/Applications/Vivaldi.app" ]]                    && echo 1 || echo 0 ;;
-    Linux:brave)    command -v brave-browser >/dev/null 2>&1 && echo 1 || echo 0 ;;
+    Linux:brave)    ( command -v brave-browser >/dev/null 2>&1 \
+                  || command -v brave >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
     Linux:chrome)   ( command -v google-chrome >/dev/null 2>&1 \
                   || command -v google-chrome-stable >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
     *) echo 0 ;;
@@ -96,6 +97,7 @@ browser_bin_for() {
     Darwin:vivaldi)            echo "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi" ;;
     Linux:brave)
       if command -v brave-browser >/dev/null 2>&1; then echo brave-browser
+      elif command -v brave >/dev/null 2>&1; then echo brave
       else return 1; fi
       ;;
     Linux:chrome)

--- a/test/install-modes.test.ts
+++ b/test/install-modes.test.ts
@@ -58,7 +58,7 @@ function browserInstalled(target: "chrome" | "brave" | "edge" | "vivaldi"): bool
   if (target === "edge" || target === "vivaldi") return false
   const candidates = target === "chrome"
     ? ["google-chrome", "google-chrome-stable"]
-    : ["brave-browser"]
+    : ["brave-browser", "brave"]
   return candidates.some(b => spawnSync("command", ["-v", b], { shell: true }).status === 0)
 }
 


### PR DESCRIPTION
The Linux Brave probes in `browser_installed_for()` and `browser_bin_for()` only check for `brave-browser`. Distributions that ship the binary as `brave` (e.g. Arch's `brave-bin` AUR package installs `/usr/bin/brave`) fail detection: the native-messaging manifest installs correctly, but the script then aborts with "Brave binary not found in PATH".

This adds `brave` as a fallback in both functions, matching the existing multi-name pattern already used for `google-chrome` / `google-chrome-stable`.

Tested on Arch Linux with Brave: `--browser-only --brave` now completes and browser-only automation (tabs, a11y tree, text extraction) works on v0.22.5. Follows up on the Linux-support feedback in discussion #66.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Brave browser detection on Linux so the installer recognizes both `brave-browser` and `brave` when checking if the browser is installed.
  * Added a fallback so Brave can launch correctly when only the `brave` command is available on the system.
* **Tests**
  * Updated Linux installer mode detection tests to reflect Brave being detected via `brave`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->