### PR TITLE
Release 0.22.6 — browser delegation + relay keepalive fix + Linux Brave detection

### DIFF
--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
Version bump to 0.22.6 for the public auto-update rollout.

**Browser delegation** (new feature line, no CDP): file attach via `interceptor upload` into `<input type=file>` and dropzones; human→agent intent handoff via context-menu / keyboard shortcut + `interceptor delegate log`; unattended-run support via `interceptor keepawake` (survives service-worker restarts) and `interceptor idle` yield-on-return. Adds `contextMenus`/`idle`/`power` permissions and a `commands` manifest key — no new host permissions, no debugger.

**Fixes:**
- Native relay keepalive pong-timeout reconnect loop — identity-checked relay-slot release + keepalive pings answered on the originating socket. Community contribution, thanks @JohnnyDisco7 (#134).
- Linux Brave detection when the binary is `brave` (e.g. Arch `brave-bin`). Community contribution, thanks @gwarf (#135).
- Troubleshooting note clarifying the Chromium preload/credentials console warning is a site-level notice. Thanks @ryan-baum (#122).

Full suite 698 pass / 0 fail; all tsconfigs typecheck clean. Details in the release commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)