### PR TITLE
macOS AX: injectable transport seam, typed codec, secure redaction, bounded traversal (0.22.8)

### DIFF
--- a/.agents/rules/macos-command-parser.md
+++ b/.agents/rules/macos-command-parser.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "cli/commands/macos.ts"
+  - "cli/help.ts"
+---
+
+# macOS command parser / help / handler must stay in sync
+
+When you add, rename, or change a flag on a `macos` subcommand, update **all four** places so they cannot drift:
+
+1. the parser payload in `cli/commands/macos.ts` (the flag must be forwarded into the action),
+2. the help text in `cli/help.ts` (only advertise flags the parser actually forwards),
+3. the Swift handler in `interceptor-bridge/Sources/Domains/` that reads the field,
+4. a case in `test/macos-parser.test.ts` asserting the flag is forwarded.
+
+A flag advertised in help but dropped by the parser (or vice-versa) is a silent bug: the user passes it, nothing happens, no error. The parser test is the guard — add or extend a case whenever you touch this surface.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,10 @@ Deep mechanic notes (the `userActivation` override + `__interceptor_trust` marke
 - Rich editor exposes no usable DOM refs → `scene profile`.
 - Action did nothing → `inspect` before retrying.
 - Network behavior unclear → `inspect --net-only` or `net log --filter <term>`.
+- AX tree came back truncated with a trailing `… (stopped: …)` line → that is the traversal budget, not an error. Widen with `interceptor macos tree --max-nodes N` / `--max-ms N`, or scope tighter with `--app` / `--depth`. Large trees (e.g. Finder with the desktop) intentionally return a bounded partial instead of hanging.
+- `interceptor macos text` on a password / secure field returns `•••` → secure fields are always redacted. That is correct behavior; do not retry expecting the value.
 - Native control failed → `interceptor macos trust` to check permissions.
-- Interceptor itself unavailable → see install routes in repository scripts.
+- `interceptor macos *` hangs or returns stale results → confirm exactly one bridge owns `/tmp/interceptor-bridge.sock`; a leftover duplicate install can shadow the current one. Otherwise see install routes in repository scripts.
 
 ## Repository Maintenance
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,6 +263,16 @@ The Router collapses an action `type` like `macos_nlp` into `command="nlp"` for 
 
 For screenshot saving, `interceptor-bridge/Sources/Domains/CaptureDomain.swift` no longer relies on `FileManager.default.currentDirectoryPath` when running under `launchd`. The CLI passes its working directory (`cli/commands/macos.ts`), and the bridge falls back through Downloads, home, then temp so `interceptor macos screenshot --save` works cleanly under LaunchAgent execution.
 
+#### AX transport seam, typed codec, and traversal budget
+
+Every Accessibility C call in the bridge routes through one injectable seam, `AXTransport` ([`interceptor-bridge/Sources/AXTransport.swift`](interceptor-bridge/Sources/AXTransport.swift)). `LiveAXTransport` is the only production implementation that imports `ApplicationServices`; a fake implementation drives the same surface in unit tests, so messaging timeouts, malformed values, and per-slot errors are testable without a live app. Nine domains route through it (`AccessibilityDomain`, `TextDomain`, `MenuDomain`, `InputDomain`, `MonitorAxBridge`, `MonitorInputBridge`, `MonitorDomain`, `DisplayDomain`, `TrustDomain`) — no domain calls an AX C function directly.
+
+Values decode through one non-trapping typed codec, `AXValueCodec`, which checks the CF type ID, then `AXValueGetType`, then the typed extraction result before touching a value. Failed extraction becomes a typed `decode_failed` instead of a trap, and the previous force casts (`as! AXValue`, `as! AXUIElement`, `unsafeBitCast`) are removed. Output is acyclic and JSON-safe: elements become ref tokens (never nested handles), integers outside the JS safe-integer range become decimal strings, and non-finite numbers never leak into JSON.
+
+Secure classification is centralized in `AXSecureRedaction`: a value from an `AXSecureTextField` is redacted to a fixed placeholder before serialization, logging, and error construction, and no flag can override it.
+
+`tree` and `find` walk under a per-command budget (`AXBudget`): a wall-clock deadline plus node and AX-call caps, checked cooperatively between calls, with a per-element messaging timeout as the in-flight bound for a single synchronous call. A large or slow tree returns a bounded partial ending in a `… (stopped: <reason>)` marker instead of running to the CLI timeout; callers tune it with `--max-nodes` / `--max-ms`, and the bridge clamps to safety hard caps.
+
 ### CDP app control — Electron / Chromium desktop apps
 
 A third control surface (after browser and macOS bridge): drive the *web content

--- a/README.md
+++ b/README.md
@@ -838,12 +838,17 @@ The Swift bridge exposes 28 domains. The five **daily-driver domains** are surfa
 
 Refs (`e1`, `e2`, ...) work the same as browser refs. AXObserver auto-invalidates when the tree changes.
 
+**Bounded by construction.** `tree` and `find` walk under a per-command budget (node cap + wall-clock deadline). A large or slow app returns a **partial result** ending in a `… (stopped: <reason>)` marker rather than hanging — widen with `--max-nodes` / `--max-ms`, or scope with `--app` / `--depth`. **Secure fields are never emitted:** `interceptor macos text` on a password field (`AXSecureTextField`) returns `•••`, never the contents.
+
 ```bash
 interceptor macos tree                           # AX tree for frontmost app
 interceptor macos tree --app "Finder"            # Specific app
 interceptor macos tree --filter interactive      # Only actionable elements (default)
 interceptor macos tree --depth 5                 # Limit depth
+interceptor macos tree --app Finder --max-nodes 500   # Bound nodes visited (partial + stop marker)
+interceptor macos tree --app Finder --max-ms 3000     # Bound wall-clock time
 interceptor macos find "Save" --role button      # Find elements by name/role
+interceptor macos find "Save" --pid 1234         # --pid targets find/focused/windows too
 interceptor macos inspect e5                     # All attributes + actions for ref
 interceptor macos value e5                       # Read element value
 interceptor macos value e5 "new text"            # Set element value

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -229,6 +229,11 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
         pid: flagInt(filtered, "--pid"),
         filter: flagVal(filtered, "--filter") || "interactive",
         depth: flagInt(filtered, "--depth") || 10,
+        // help advertises `--max-chars`; forward it (was dropped).
+        maxChars: flagInt(filtered, "--max-chars") || 50000,
+        // traversal bounds (bridge clamps to the safety hard caps; omit ⇒ defaults).
+        maxNodes: flagInt(filtered, "--max-nodes"),
+        maxMs: flagInt(filtered, "--max-ms"),
       }
 
     case "find": {
@@ -238,7 +243,10 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
         type: "macos_find",
         query,
         app: flagVal(filtered, "--app"),
+        pid: flagInt(filtered, "--pid"),          // was dropped
         role: flagVal(filtered, "--role"),
+        maxNodes: flagInt(filtered, "--max-nodes"),
+        maxMs: flagInt(filtered, "--max-ms"),
       }
     }
 
@@ -268,10 +276,10 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
     }
 
     case "focused":
-      return { type: "macos_focused", app: flagVal(filtered, "--app") }
+      return { type: "macos_focused", app: flagVal(filtered, "--app"), pid: flagInt(filtered, "--pid") }
 
     case "windows":
-      return { type: "macos_windows", app: flagVal(filtered, "--app") }
+      return { type: "macos_windows", app: flagVal(filtered, "--app"), pid: flagInt(filtered, "--pid") }
 
     // ── Text ──
     case "text": {

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.22.6",
+  "version": "0.22.8",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.22.6",
+  "version": "0.22.8",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/interceptor-bridge/Sources/AXBudget.swift
+++ b/interceptor-bridge/Sources/AXBudget.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// per-command budget + deadline meter.
+//
+// Bounds a traversal by wall-clock deadline, nodes visited, and AX calls issued,
+// so a large or slow target cannot stall a command (the exact unbounded-walk
+// gap). Cancellation is cooperative: the walker checks `shouldStop()`
+// between synchronous AX calls. A per-element messaging timeout
+// (`AXTransport.setMessagingTimeout`) is the in-flight bound for a single call
+// already inside the C API — a Swift deadline cannot interrupt that.
+//
+// Created per command and used only within that command's synchronous flow, so
+// it needs no Sendable conformance.
+final class AXBudget {
+    let deadline: Date
+    let maxNodes: Int
+    let maxCalls: Int
+    private(set) var nodesVisited = 0
+    private(set) var callsUsed = 0
+    private(set) var limitHit: String?
+
+    init(maxMs: Int, maxNodes: Int, maxCalls: Int, now: Date = Date()) {
+        self.deadline = now.addingTimeInterval(Double(maxMs) / 1000.0)
+        self.maxNodes = maxNodes
+        self.maxCalls = maxCalls
+    }
+
+    func countNode() { nodesVisited += 1 }
+    func countCalls(_ n: Int) { callsUsed += n }
+
+    /// True once any bound is exceeded; records the first reason and sticks.
+    func shouldStop(now: Date = Date()) -> Bool {
+        if limitHit != nil { return true }
+        if nodesVisited >= maxNodes { limitHit = "max_nodes"; return true }
+        if callsUsed >= maxCalls { limitHit = "budget_exceeded"; return true }
+        if now >= deadline { limitHit = "deadline_exceeded"; return true }
+        return false
+    }
+
+    /// A short human marker for the compatibility text outputs. Empty when no
+    /// limit was hit. (The structured snapshot command emits this in `meta`.)
+    var stopMarker: String {
+        guard let reason = limitHit else { return "" }
+        return "… (stopped: \(reason); visited \(nodesVisited) nodes, \(callsUsed) AX calls)"
+    }
+
+    // Product-safety defaults + hard caps for scan-class commands.
+    static let defaultMaxMs = 5_000
+    static let hardMaxMs = 10_000
+    static let defaultMaxNodes = 2_000
+    static let hardMaxNodes = 10_000
+    static let defaultMaxCalls = 12_000
+    static let hardMaxCalls = 50_000
+    static let scanMessagingTimeoutSeconds: Float = 0.5
+
+    /// Clamp a caller-supplied value into `[1, hard]`, falling back to `def`.
+    static func clamp(_ value: Int?, def: Int, hard: Int) -> Int {
+        guard let v = value, v > 0 else { return def }
+        return min(v, hard)
+    }
+}

--- a/interceptor-bridge/Sources/AXSecureRedaction.swift
+++ b/interceptor-bridge/Sources/AXSecureRedaction.swift
@@ -1,0 +1,39 @@
+import Foundation
+import ApplicationServices
+
+// one central secure-field boundary.
+//
+// Secure classification happens BEFORE DTO serialization, logging, metrics, ref
+// previews, and error construction. A secure value is always `redacted`;
+// `--include-sensitive` can never override this. The placeholder is a fixed
+// constant that shares no bytes with any real field content.
+enum AXSecureRedaction {
+    static let placeholder = "\u{2022}\u{2022}\u{2022}"   // "•••" — never real content
+
+    /// A role/subrole pair identifies a secure text field.
+    static func isSecure(role: String?, subrole: String?) -> Bool {
+        role == "AXSecureTextField" || subrole == "AXSecureTextField"
+    }
+
+    /// Read role + subrole through the transport and classify. Used by domains
+    /// before emitting any value for an element.
+    static func isSecureElement(_ element: AXUIElement, transport: any AXTransport) -> Bool {
+        let (rr, roleVal) = transport.copyAttributeValue(element, kAXRoleAttribute as String)
+        let (sr, subVal) = transport.copyAttributeValue(element, kAXSubroleAttribute as String)
+        let role = rr == .success ? AXValueCodec.displayString(roleVal) : nil
+        let subrole = sr == .success ? AXValueCodec.displayString(subVal) : nil
+        return isSecure(role: role, subrole: subrole)
+    }
+
+    /// Tagged redacted variant (never carries the underlying value).
+    static func redactedTag(reason: String = "secure_value") -> [String: Any] {
+        ["kind": "redacted", "reason": reason]
+    }
+
+    /// Compat display value that respects secure classification. Non-secure
+    /// values pass through `displayString`; secure values become the placeholder.
+    static func displayString(_ value: CFTypeRef?, secure: Bool) -> String? {
+        if secure { return placeholder }
+        return AXValueCodec.displayString(value)
+    }
+}

--- a/interceptor-bridge/Sources/AXTransport.swift
+++ b/interceptor-bridge/Sources/AXTransport.swift
@@ -1,0 +1,180 @@
+import Foundation
+import ApplicationServices
+
+// the single AX C-call boundary.
+//
+// One protocol owns every Accessibility C function the product uses. After this seam lands
+// no domain calls an AX C function directly; each goes through an injected
+// `AXTransport`. `LiveAXTransport` (below) is the only production implementation
+// that touches ApplicationServices; `FakeAXTransport` (test target) drives the
+// same surface with deterministic graphs, delays, per-slot errors, and
+// cannotComplete-after-effect fixtures.
+//
+// Return shape: every fallible read returns `(AXError, T?)` so callers branch on
+// the status and never force-unwrap. Values cross as `CFTypeRef` and are decoded
+// through `AXValueCodec` — the bridge never force-casts an unverified value.
+protocol AXTransport: Sendable {
+    // element creation
+    func createApplication(pid: pid_t) -> AXUIElement
+    func createSystemWide() -> AXUIElement
+
+    // attribute reads
+    func copyAttributeValue(_ element: AXUIElement, _ attribute: String) -> (AXError, CFTypeRef?)
+    func copyMultipleAttributeValues(_ element: AXUIElement, _ attributes: [String], stopOnError: Bool) -> (AXError, [CFTypeRef]?)
+    func copyAttributeNames(_ element: AXUIElement) -> (AXError, [String]?)
+    func attributeValueCount(_ element: AXUIElement, _ attribute: String) -> (AXError, Int?)
+    func copyAttributeValues(_ element: AXUIElement, _ attribute: String, index: Int, maxValues: Int) -> (AXError, [CFTypeRef]?)
+
+    // settability + mutation
+    func isAttributeSettable(_ element: AXUIElement, _ attribute: String) -> (AXError, Bool?)
+    func setAttributeValue(_ element: AXUIElement, _ attribute: String, _ value: CFTypeRef) -> AXError
+
+    // parameterized
+    func copyParameterizedAttributeNames(_ element: AXUIElement) -> (AXError, [String]?)
+    func copyParameterizedAttributeValue(_ element: AXUIElement, _ attribute: String, _ parameter: CFTypeRef) -> (AXError, CFTypeRef?)
+
+    // actions
+    func copyActionNames(_ element: AXUIElement) -> (AXError, [String]?)
+    func copyActionDescription(_ element: AXUIElement, _ action: String) -> (AXError, String?)
+    func performAction(_ element: AXUIElement, _ action: String) -> AXError
+
+    // hit test + identity + timeout
+    func copyElementAtPosition(_ application: AXUIElement, x: Float, y: Float) -> (AXError, AXUIElement?)
+    func pid(_ element: AXUIElement) -> (AXError, pid_t?)
+    func setMessagingTimeout(_ element: AXUIElement, seconds: Float) -> AXError
+
+    // observers
+    func observerCreate(pid: pid_t, callback: @escaping AXObserverCallback) -> (AXError, AXObserver?)
+    func observerAddNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String, _ refcon: UnsafeMutableRawPointer?) -> AXError
+    func observerRemoveNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String) -> AXError
+    func observerGetRunLoopSource(_ observer: AXObserver) -> CFRunLoopSource
+
+    // process trust (global predicate — no element, cannot hang)
+    func isProcessTrusted() -> Bool
+    func isProcessTrustedWithOptions(_ options: CFDictionary) -> Bool
+}
+
+// The only production implementation. Stateless, so trivially Sendable. Each
+// method is a faithful, thin wrapper over the AX C function — no policy, no
+// budget, no decoding lives here. Budgets/deadlines/codec are layered above it
+// (a later layer) precisely because this seam exists.
+struct LiveAXTransport: AXTransport {
+    func createApplication(pid: pid_t) -> AXUIElement {
+        AXUIElementCreateApplication(pid)
+    }
+
+    func createSystemWide() -> AXUIElement {
+        AXUIElementCreateSystemWide()
+    }
+
+    func copyAttributeValue(_ element: AXUIElement, _ attribute: String) -> (AXError, CFTypeRef?) {
+        var value: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        return (err, value)
+    }
+
+    func copyMultipleAttributeValues(_ element: AXUIElement, _ attributes: [String], stopOnError: Bool) -> (AXError, [CFTypeRef]?) {
+        var values: CFArray?
+        let options: AXCopyMultipleAttributeOptions = stopOnError ? .stopOnError : AXCopyMultipleAttributeOptions(rawValue: 0)
+        let err = AXUIElementCopyMultipleAttributeValues(element, attributes as CFArray, options, &values)
+        return (err, values as? [CFTypeRef])
+    }
+
+    func copyAttributeNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        var names: CFArray?
+        let err = AXUIElementCopyAttributeNames(element, &names)
+        return (err, names as? [String])
+    }
+
+    func attributeValueCount(_ element: AXUIElement, _ attribute: String) -> (AXError, Int?) {
+        var count: CFIndex = 0
+        let err = AXUIElementGetAttributeValueCount(element, attribute as CFString, &count)
+        return (err, err == .success ? Int(count) : nil)
+    }
+
+    func copyAttributeValues(_ element: AXUIElement, _ attribute: String, index: Int, maxValues: Int) -> (AXError, [CFTypeRef]?) {
+        var values: CFArray?
+        let err = AXUIElementCopyAttributeValues(element, attribute as CFString, CFIndex(index), CFIndex(maxValues), &values)
+        return (err, values as? [CFTypeRef])
+    }
+
+    func isAttributeSettable(_ element: AXUIElement, _ attribute: String) -> (AXError, Bool?) {
+        var settable: DarwinBoolean = false
+        let err = AXUIElementIsAttributeSettable(element, attribute as CFString, &settable)
+        return (err, err == .success ? settable.boolValue : nil)
+    }
+
+    func setAttributeValue(_ element: AXUIElement, _ attribute: String, _ value: CFTypeRef) -> AXError {
+        AXUIElementSetAttributeValue(element, attribute as CFString, value)
+    }
+
+    func copyParameterizedAttributeNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        var names: CFArray?
+        let err = AXUIElementCopyParameterizedAttributeNames(element, &names)
+        return (err, names as? [String])
+    }
+
+    func copyParameterizedAttributeValue(_ element: AXUIElement, _ attribute: String, _ parameter: CFTypeRef) -> (AXError, CFTypeRef?) {
+        var value: CFTypeRef?
+        let err = AXUIElementCopyParameterizedAttributeValue(element, attribute as CFString, parameter, &value)
+        return (err, value)
+    }
+
+    func copyActionNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        var names: CFArray?
+        let err = AXUIElementCopyActionNames(element, &names)
+        return (err, names as? [String])
+    }
+
+    func copyActionDescription(_ element: AXUIElement, _ action: String) -> (AXError, String?) {
+        var desc: CFString?
+        let err = AXUIElementCopyActionDescription(element, action as CFString, &desc)
+        return (err, desc as String?)
+    }
+
+    func performAction(_ element: AXUIElement, _ action: String) -> AXError {
+        AXUIElementPerformAction(element, action as CFString)
+    }
+
+    func copyElementAtPosition(_ application: AXUIElement, x: Float, y: Float) -> (AXError, AXUIElement?) {
+        var element: AXUIElement?
+        let err = AXUIElementCopyElementAtPosition(application, x, y, &element)
+        return (err, element)
+    }
+
+    func pid(_ element: AXUIElement) -> (AXError, pid_t?) {
+        var p: pid_t = 0
+        let err = AXUIElementGetPid(element, &p)
+        return (err, err == .success ? p : nil)
+    }
+
+    func setMessagingTimeout(_ element: AXUIElement, seconds: Float) -> AXError {
+        AXUIElementSetMessagingTimeout(element, seconds)
+    }
+
+    func observerCreate(pid: pid_t, callback: @escaping AXObserverCallback) -> (AXError, AXObserver?) {
+        var observer: AXObserver?
+        let err = AXObserverCreate(pid, callback, &observer)
+        return (err, observer)
+    }
+
+    func observerAddNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String, _ refcon: UnsafeMutableRawPointer?) -> AXError {
+        AXObserverAddNotification(observer, element, notification as CFString, refcon)
+    }
+
+    func observerRemoveNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String) -> AXError {
+        AXObserverRemoveNotification(observer, element, notification as CFString)
+    }
+
+    func observerGetRunLoopSource(_ observer: AXObserver) -> CFRunLoopSource {
+        AXObserverGetRunLoopSource(observer)
+    }
+
+    func isProcessTrusted() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    func isProcessTrustedWithOptions(_ options: CFDictionary) -> Bool {
+        AXIsProcessTrustedWithOptions(options)
+    }
+}

--- a/interceptor-bridge/Sources/AXTypedError.swift
+++ b/interceptor-bridge/Sources/AXTypedError.swift
@@ -1,0 +1,99 @@
+import Foundation
+import ApplicationServices
+
+// stable typed wire errors.
+//
+// Maps an `AXError` to a stable product error code while retaining the raw AX
+// code + symbolic name, and keeps the old string `error` populated so existing
+// consumers are unaffected. This is additive: `WireFormat.error(msg)` still
+// works; `AXTypedError.errorDict(...)` layers `code`/`details.axError` on top.
+enum AXTypedError {
+    /// Apple's symbolic name for an AXError case (stable across OS versions).
+    static func symbolicName(_ err: AXError) -> String {
+        switch err {
+        case .success: return "kAXErrorSuccess"
+        case .failure: return "kAXErrorFailure"
+        case .illegalArgument: return "kAXErrorIllegalArgument"
+        case .invalidUIElement: return "kAXErrorInvalidUIElement"
+        case .invalidUIElementObserver: return "kAXErrorInvalidUIElementObserver"
+        case .cannotComplete: return "kAXErrorCannotComplete"
+        case .attributeUnsupported: return "kAXErrorAttributeUnsupported"
+        case .actionUnsupported: return "kAXErrorActionUnsupported"
+        case .notificationUnsupported: return "kAXErrorNotificationUnsupported"
+        case .notImplemented: return "kAXErrorNotImplemented"
+        case .notificationAlreadyRegistered: return "kAXErrorNotificationAlreadyRegistered"
+        case .notificationNotRegistered: return "kAXErrorNotificationNotRegistered"
+        case .apiDisabled: return "kAXErrorAPIDisabled"
+        case .noValue: return "kAXErrorNoValue"
+        case .parameterizedAttributeUnsupported: return "kAXErrorParameterizedAttributeUnsupported"
+        case .notEnoughPrecision: return "kAXErrorNotEnoughPrecision"
+        @unknown default: return "kAXErrorUnknown"
+        }
+    }
+
+    /// Stable product error code for an AXError. `nil` for success.
+    static func productCode(_ err: AXError) -> String? {
+        switch err {
+        case .success: return nil
+        case .apiDisabled: return "accessibility_unusable"
+        case .invalidUIElement, .invalidUIElementObserver: return "invalid_ref"
+        case .cannotComplete: return "cannot_complete"
+        case .attributeUnsupported: return "unsupported_attribute"
+        case .parameterizedAttributeUnsupported: return "unsupported_parameterized_attribute"
+        case .actionUnsupported: return "unsupported_action"
+        case .noValue: return "no_value"
+        case .illegalArgument, .notEnoughPrecision: return "invalid_value"
+        case .notificationUnsupported, .notImplemented,
+             .notificationAlreadyRegistered, .notificationNotRegistered:
+            return "capability_unavailable"
+        case .failure:
+            return "cannot_complete"
+        @unknown default:
+            return "cannot_complete"
+        }
+    }
+
+    /// `cannot_complete` retryability is operation-dependent; action results
+    /// default to false until verification proves no effect and policy permits
+    /// retry. Non-action reads may treat it as retryable.
+    static func defaultRetryable(_ err: AXError) -> Bool {
+        switch err {
+        case .cannotComplete: return false
+        default: return false
+        }
+    }
+
+    /// Build the additive typed error envelope. The old string `error`
+    /// stays populated; `code`/`details.axError`/`retryable` are new fields.
+    static func errorDict(
+        _ message: String,
+        code: String,
+        axError: AXError? = nil,
+        provider: String = "macos_ax",
+        ref: String? = nil,
+        dispatched: Bool = false,
+        verified: Bool = false,
+        retryable: Bool = false
+    ) -> [String: Any] {
+        var details: [String: Any] = ["provider": provider, "dispatched": dispatched, "verified": verified]
+        if let ref = ref { details["ref"] = ref }
+        if let axError = axError, axError != .success {
+            details["axError"] = ["code": Int(axError.rawValue), "name": symbolicName(axError)]
+        } else {
+            details["axError"] = NSNull()
+        }
+        return [
+            "success": false,
+            "error": message,
+            "code": code,
+            "details": details,
+            "retryable": retryable,
+        ]
+    }
+
+    /// Convenience: derive code + retryable straight from an AXError.
+    static func from(_ err: AXError, message: String, ref: String? = nil) -> [String: Any] {
+        errorDict(message, code: productCode(err) ?? "cannot_complete", axError: err,
+                  ref: ref, retryable: defaultRetryable(err))
+    }
+}

--- a/interceptor-bridge/Sources/AXValueCodec.swift
+++ b/interceptor-bridge/Sources/AXValueCodec.swift
@@ -1,0 +1,215 @@
+import Foundation
+import ApplicationServices
+
+// the one non-trapping typed codec.
+//
+// Every CF/AX value crossing the bridge is decoded here. Nothing force-casts an
+// unverified `CFTypeRef`: we check `CFGetTypeID`, then (for AXValue) the
+// `AXValueGetType`, then the typed extraction result. A failed extraction is a
+// typed `decode_failed`, never a trap or an empty string. Output is an acyclic,
+// JSON-safe tagged dictionary (`kind` + payload) — safe for
+// `JSONSerialization` (finite numbers only; integers outside the ECMA safe
+// range become decimal strings; elements become ref tokens, never nested
+// handles, so cycles are impossible).
+enum AXValueCodec {
+    static let safeIntegerMax: Int64 = 9_007_199_254_740_991   // 2^53 - 1
+    static let defaultMaxStringBytes = 64 * 1024
+    static let defaultMaxArrayItems = 1024
+    static let defaultMaxDepth = 16
+
+    // MARK: - Full tagged DTO
+
+    /// Decode a value to its acyclic tagged form. `secure == true` always yields
+    /// `redacted` regardless of the underlying value. `elementToken` maps a live
+    /// element to an exported ref token (never a pointer); nil ⇒ token omitted.
+    static func tag(
+        _ value: CFTypeRef?,
+        secure: Bool = false,
+        maxStringBytes: Int = defaultMaxStringBytes,
+        maxArrayItems: Int = defaultMaxArrayItems,
+        depth: Int = 0,
+        maxDepth: Int = defaultMaxDepth,
+        elementToken: ((AXUIElement) -> String?)? = nil
+    ) -> [String: Any] {
+        if secure { return ["kind": "redacted", "reason": "secure_value"] }
+        guard let value = value else { return ["kind": "null"] }
+
+        let typeID = CFGetTypeID(value)
+
+        if typeID == CFNullGetTypeID() { return ["kind": "null"] }
+
+        if typeID == CFBooleanGetTypeID() {
+            return ["kind": "boolean", "value": CFBooleanGetValue(unsafeDowncast(value, to: CFBoolean.self))]
+        }
+
+        if typeID == AXValueGetTypeID() {
+            return tagAXValue(unsafeDowncast(value, to: AXValue.self))
+        }
+
+        if typeID == AXUIElementGetTypeID() {
+            var out: [String: Any] = ["kind": "element_ref"]
+            if let token = elementToken?(unsafeDowncast(value, to: AXUIElement.self)) { out["ref"] = token }
+            return out
+        }
+
+        if typeID == CFNumberGetTypeID() {
+            return tagNumber(unsafeDowncast(value, to: CFNumber.self))
+        }
+
+        if typeID == CFStringGetTypeID() {
+            let s = unsafeDowncast(value, to: CFString.self) as String
+            return ["kind": "string", "value": boundedString(s, maxBytes: maxStringBytes)]
+        }
+
+        if typeID == CFURLGetTypeID() {
+            let s = (value as? URL)?.absoluteString ?? (CFURLGetString(unsafeDowncast(value, to: CFURL.self)) as String)
+            return ["kind": "url", "value": boundedString(s, maxBytes: maxStringBytes)]
+        }
+
+        if typeID == CFAttributedStringGetTypeID() {
+            let attr = unsafeDowncast(value, to: CFAttributedString.self)
+            let plain = CFAttributedStringGetString(attr) as String
+            // Runs are optional (when available); omitted for now.
+            return ["kind": "attributed_string", "value": boundedString(plain, maxBytes: maxStringBytes)]
+        }
+
+        if typeID == CFArrayGetTypeID() {
+            return tagArray(value as? [CFTypeRef] ?? [],
+                            secure: secure, maxStringBytes: maxStringBytes,
+                            maxArrayItems: maxArrayItems, depth: depth, maxDepth: maxDepth,
+                            elementToken: elementToken)
+        }
+
+        // Unknown CF type: name is safe (a class name, not content).
+        var out: [String: Any] = ["kind": "unsupported", "typeId": Int(typeID)]
+        if let name = CFCopyTypeIDDescription(typeID) as String? { out["typeName"] = name }
+        return out
+    }
+
+    private static func tagAXValue(_ ax: AXValue) -> [String: Any] {
+        switch AXValueGetType(ax) {
+        case .cgPoint:
+            var p = CGPoint.zero
+            guard AXValueGetValue(ax, .cgPoint, &p) else { return ["kind": "decode_failed"] }
+            return ["kind": "point", "x": p.x, "y": p.y]
+        case .cgSize:
+            var s = CGSize.zero
+            guard AXValueGetValue(ax, .cgSize, &s) else { return ["kind": "decode_failed"] }
+            return ["kind": "size", "width": s.width, "height": s.height]
+        case .cgRect:
+            var r = CGRect.zero
+            guard AXValueGetValue(ax, .cgRect, &r) else { return ["kind": "decode_failed"] }
+            return ["kind": "rect", "x": r.origin.x, "y": r.origin.y, "width": r.size.width, "height": r.size.height]
+        case .cfRange:
+            var range = CFRange(location: 0, length: 0)
+            guard AXValueGetValue(ax, .cfRange, &range) else { return ["kind": "decode_failed"] }
+            return ["kind": "range", "location": intOrString(Int64(range.location)), "length": intOrString(Int64(range.length))]
+        case .axError:
+            var err = AXError.success
+            guard AXValueGetValue(ax, .axError, &err) else { return ["kind": "decode_failed"] }
+            return ["kind": "ax_error", "code": Int(err.rawValue), "name": AXTypedError.symbolicName(err)]
+        case .illegal:
+            return ["kind": "unsupported", "typeName": "AXValueIllegal"]
+        @unknown default:
+            return ["kind": "unsupported", "typeName": "AXValueUnknown"]
+        }
+    }
+
+    private static func tagNumber(_ num: CFNumber) -> [String: Any] {
+        if CFNumberIsFloatType(num) {
+            var d = 0.0
+            CFNumberGetValue(num, .doubleType, &d)
+            if d.isFinite { return ["kind": "number", "value": d] }
+            let special = d.isNaN ? "nan" : (d > 0 ? "infinity" : "-infinity")
+            return ["kind": "number", "finite": false, "special": special]
+        }
+        var i: Int64 = 0
+        CFNumberGetValue(num, .sInt64Type, &i)
+        return intOrString(i)
+    }
+
+    /// Integers inside the ECMA safe range serialize as Number; outside, as a
+    /// decimal string under the `integer` tag.
+    private static func intOrString(_ i: Int64) -> [String: Any] {
+        if abs(i) <= safeIntegerMax { return ["kind": "number", "value": Int(i)] }
+        return ["kind": "integer", "value": String(i)]
+    }
+
+    private static func tagArray(
+        _ items: [CFTypeRef], secure: Bool, maxStringBytes: Int, maxArrayItems: Int,
+        depth: Int, maxDepth: Int, elementToken: ((AXUIElement) -> String?)?
+    ) -> [String: Any] {
+        if depth >= maxDepth { return ["kind": "array", "items": [], "truncated": true] }
+        let slice = items.prefix(maxArrayItems)
+        let tagged: [[String: Any]] = slice.map {
+            tag($0, secure: secure, maxStringBytes: maxStringBytes, maxArrayItems: maxArrayItems,
+                depth: depth + 1, maxDepth: maxDepth, elementToken: elementToken)
+        }
+        var out: [String: Any] = ["kind": "array", "items": tagged]
+        if items.count > maxArrayItems {
+            out["truncated"] = true
+            out["cursor"] = String(maxArrayItems)
+        }
+        return out
+    }
+
+    // MARK: - Compatibility / safe-extraction helpers
+    //
+    // These replace the current force casts (`as! AXValue`, `as! AXUIElement`,
+    // `unsafeBitCast`) with type-ID-checked downcasts. The compat display path
+    // keeps the current String/NSNumber behavior exactly, just without a trap.
+
+    /// Display string for compatibility commands. Matches the previous
+    /// `getStringAttribute` contract (String or NSNumber → String, else nil),
+    /// but non-trapping.
+    static func displayString(_ value: CFTypeRef?) -> String? {
+        guard let value = value else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? NSNumber { return num.stringValue }
+        return nil
+    }
+
+    /// Type-checked downcast to `AXUIElement` (replaces `as!` / `unsafeBitCast`).
+    static func asElement(_ value: CFTypeRef?) -> AXUIElement? {
+        guard let value = value, CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+        return unsafeDowncast(value, to: AXUIElement.self)
+    }
+
+    /// Type-checked downcast to `AXValue` (replaces `as! AXValue`).
+    static func asAXValue(_ value: CFTypeRef?) -> AXValue? {
+        guard let value = value, CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+        return unsafeDowncast(value, to: AXValue.self)
+    }
+
+    static func point(from value: CFTypeRef?) -> CGPoint? {
+        guard let ax = asAXValue(value), AXValueGetType(ax) == .cgPoint else { return nil }
+        var p = CGPoint.zero
+        return AXValueGetValue(ax, .cgPoint, &p) ? p : nil
+    }
+
+    static func size(from value: CFTypeRef?) -> CGSize? {
+        guard let ax = asAXValue(value), AXValueGetType(ax) == .cgSize else { return nil }
+        var s = CGSize.zero
+        return AXValueGetValue(ax, .cgSize, &s) ? s : nil
+    }
+
+    static func range(from value: CFTypeRef?) -> CFRange? {
+        guard let ax = asAXValue(value), AXValueGetType(ax) == .cfRange else { return nil }
+        var r = CFRange(location: 0, length: 0)
+        return AXValueGetValue(ax, .cfRange, &r) ? r : nil
+    }
+
+    /// Truncate a string to a UTF-8 byte budget without splitting a scalar.
+    static func boundedString(_ s: String, maxBytes: Int) -> String {
+        guard s.utf8.count > maxBytes else { return s }
+        var result = ""
+        var bytes = 0
+        for ch in s {
+            let n = String(ch).utf8.count
+            if bytes + n > maxBytes { break }
+            result.append(ch)
+            bytes += n
+        }
+        return result + "…"
+    }
+}

--- a/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
@@ -4,8 +4,16 @@ import AppKit
 
 final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
     let refRegistry = RefRegistry.shared
+    // every AX C call in this domain now routes through the
+    // injectable transport, and every value decodes through AXValueCodec — no
+    // force casts on unverified AX values. Public command behavior is unchanged.
+    private let transport: any AXTransport
     private var observer: AXObserver?
     private var observedPID: pid_t = 0
+
+    init(transport: any AXTransport = LiveAXTransport()) {
+        self.transport = transport
+    }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         switch command {
@@ -55,10 +63,19 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
 
         let pid = app.processIdentifier
         ensureObserver(pid: pid)
-        let axApp = AXUIElementCreateApplication(pid)
+        let axApp = transport.createApplication(pid: pid)
         let depth = action["depth"] as? Int ?? 10
         let filter = action["filter"] as? String ?? "interactive"
         let maxChars = action["maxChars"] as? Int ?? 50000
+        // bound the traversal so a huge/slow tree returns a partial
+        // result instead of hanging until the CLI's 15s timeout. Overridable via
+        // --max-nodes / --max-ms; clamped to the safety hard caps.
+        let budget = AXBudget(
+            maxMs: AXBudget.clamp(action["maxMs"] as? Int, def: AXBudget.defaultMaxMs, hard: AXBudget.hardMaxMs),
+            maxNodes: AXBudget.clamp(action["maxNodes"] as? Int, def: AXBudget.defaultMaxNodes, hard: AXBudget.hardMaxNodes),
+            maxCalls: AXBudget.defaultMaxCalls
+        )
+        _ = transport.setMessagingTimeout(axApp, seconds: AXBudget.scanMessagingTimeoutSeconds)
 
         // wake up the AX tree for Electron / Chromium apps.
         // Electron and Chromium-based apps (Slack, Discord, Signal, VS Code,
@@ -68,12 +85,13 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         // tree generation. Without this, `mac_tree --app Signal` returns empty
         // when Signal is in the background.
         // Refs: AXUIElement.h, Apple a11y guides, Chromium a11y_extension.cc.
-        Self.wakeAXTree(app: axApp)
+        wakeAXTree(app: axApp)
 
         refRegistry.clear()
 
         var output = ""
-        buildTree(element: axApp, pid: pid, depth: 0, maxDepth: depth, filter: filter, output: &output, maxChars: maxChars)
+        buildTree(element: axApp, pid: pid, depth: 0, maxDepth: depth, filter: filter, output: &output, maxChars: maxChars, budget: budget)
+        if !budget.stopMarker.isEmpty { output += budget.stopMarker + "\n" }
 
         completion(WireFormat.success(output))
     }
@@ -91,16 +109,20 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
     /// foregrounding AppKit apps even after the CompoundDomain activation
     /// removal. AppKit apps don't need either flag — their AX tree is
     /// always populated. Chromium needs only AXManualAccessibility.
-    static func wakeAXTree(app: AXUIElement) {
-        AXUIElementSetAttributeValue(app, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+    func wakeAXTree(app: AXUIElement) {
+        _ = transport.setAttributeValue(app, "AXManualAccessibility", kCFBooleanTrue)
         // Tiny grace so Chromium's BrowserAccessibilityManager has a chance
         // to assemble the tree before we walk it. ~30 ms is enough on M-series
         // for typical Electron renderers.
         usleep(30_000)
     }
 
-    private func buildTree(element: AXUIElement, pid: pid_t, depth: Int, maxDepth: Int, filter: String, output: inout String, maxChars: Int) {
-        guard depth < maxDepth, output.count < maxChars else { return }
+    // internal (not private) so the budget-bounded traversal is unit-testable
+    // with a FakeAXTransport, without depending on a live NSRunningApplication.
+    func buildTree(element: AXUIElement, pid: pid_t, depth: Int, maxDepth: Int, filter: String, output: inout String, maxChars: Int, budget: AXBudget) {
+        guard depth < maxDepth, output.count < maxChars, !budget.shouldStop() else { return }
+        budget.countNode()
+        budget.countCalls(5)   // 4 attribute reads + 1 children read below
 
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? "unknown"
         let title = getStringAttribute(element, kAXTitleAttribute as CFString)
@@ -139,51 +161,40 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             output += line + "\n"
         }
 
-        var children: CFTypeRef?
-        let childResult = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &children)
+        let (childResult, children) = transport.copyAttributeValue(element, kAXChildrenAttribute as String)
         guard childResult == .success, let childArray = children as? [AXUIElement] else { return }
 
         for child in childArray {
-            buildTree(element: child, pid: pid, depth: depth + 1, maxDepth: maxDepth, filter: filter, output: &output, maxChars: maxChars)
+            buildTree(element: child, pid: pid, depth: depth + 1, maxDepth: maxDepth, filter: filter, output: &output, maxChars: maxChars, budget: budget)
         }
     }
 
     private func getStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
-        var value: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(element, attribute, &value)
+        let (result, value) = transport.copyAttributeValue(element, attribute as String)
         guard result == .success else { return nil }
-        if let str = value as? String { return str }
-        if let num = value as? NSNumber { return num.stringValue }
-        return nil
+        return AXValueCodec.displayString(value)
     }
 
     private func getFrame(_ element: AXUIElement) -> CGRect? {
-        var posValue: CFTypeRef?
-        var sizeValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posValue) == .success,
-              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success else {
-            return nil
-        }
-        var point = CGPoint.zero
-        var size = CGSize.zero
-        guard AXValueGetValue(posValue as! AXValue, .cgPoint, &point),
-              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else {
+        let (posResult, posValue) = transport.copyAttributeValue(element, kAXPositionAttribute as String)
+        let (sizeResult, sizeValue) = transport.copyAttributeValue(element, kAXSizeAttribute as String)
+        guard posResult == .success, sizeResult == .success,
+              let point = AXValueCodec.point(from: posValue),
+              let size = AXValueCodec.size(from: sizeValue) else {
             return nil
         }
         return CGRect(origin: point, size: size)
     }
 
     private func searchRootElement(for app: AXUIElement) -> AXUIElement? {
-        var focusedWindow: CFTypeRef?
-        if AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &focusedWindow) == .success,
-           let window = focusedWindow {
-            return unsafeBitCast(window, to: AXUIElement.self)
+        let (focusedResult, focusedWindow) = transport.copyAttributeValue(app, kAXFocusedWindowAttribute as String)
+        if focusedResult == .success, let window = AXValueCodec.asElement(focusedWindow) {
+            return window
         }
 
-        var mainWindow: CFTypeRef?
-        if AXUIElementCopyAttributeValue(app, kAXMainWindowAttribute as CFString, &mainWindow) == .success,
-           let window = mainWindow {
-            return unsafeBitCast(window, to: AXUIElement.self)
+        let (mainResult, mainWindow) = transport.copyAttributeValue(app, kAXMainWindowAttribute as String)
+        if mainResult == .success, let window = AXValueCodec.asElement(mainWindow) {
+            return window
         }
 
         return nil
@@ -200,21 +211,29 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         }
 
         let pid = app.processIdentifier
-        let axApp = AXUIElementCreateApplication(pid)
+        let axApp = transport.createApplication(pid: pid)
         let roleFilter = action["role"] as? String
+        let budget = AXBudget(
+            maxMs: AXBudget.clamp(action["maxMs"] as? Int, def: AXBudget.defaultMaxMs, hard: AXBudget.hardMaxMs),
+            maxNodes: AXBudget.clamp(action["maxNodes"] as? Int, def: AXBudget.defaultMaxNodes, hard: AXBudget.hardMaxNodes),
+            maxCalls: AXBudget.defaultMaxCalls
+        )
+        _ = transport.setMessagingTimeout(axApp, seconds: AXBudget.scanMessagingTimeoutSeconds)
 
-        Self.wakeAXTree(app: axApp)
+        wakeAXTree(app: axApp)
         refRegistry.clear()
         let searchRoot = searchRootElement(for: axApp) ?? axApp
 
         var matches: [[String: Any]] = []
-        findElements(element: searchRoot, pid: pid, query: query.lowercased(), roleFilter: roleFilter?.lowercased(), depth: 0, maxDepth: 15, maxMatches: 25, matches: &matches)
+        findElements(element: searchRoot, pid: pid, query: query.lowercased(), roleFilter: roleFilter?.lowercased(), depth: 0, maxDepth: 15, maxMatches: 25, matches: &matches, budget: budget)
 
         completion(WireFormat.success(matches))
     }
 
-    private func findElements(element: AXUIElement, pid: pid_t, query: String, roleFilter: String?, depth: Int, maxDepth: Int, maxMatches: Int, matches: inout [[String: Any]]) {
-        guard depth < maxDepth, matches.count < maxMatches else { return }
+    private func findElements(element: AXUIElement, pid: pid_t, query: String, roleFilter: String?, depth: Int, maxDepth: Int, maxMatches: Int, matches: inout [[String: Any]], budget: AXBudget) {
+        guard depth < maxDepth, matches.count < maxMatches, !budget.shouldStop() else { return }
+        budget.countNode()
+        budget.countCalls(6)   // 6 attribute reads per node
 
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
         let identifier = getStringAttribute(element, kAXIdentifierAttribute as CFString) ?? ""
@@ -251,11 +270,10 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             }
         }
 
-        var children: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &children) == .success,
-              let childArray = children as? [AXUIElement] else { return }
+        let (childResult, children) = transport.copyAttributeValue(element, kAXChildrenAttribute as String)
+        guard childResult == .success, let childArray = children as? [AXUIElement] else { return }
         for child in childArray {
-            findElements(element: child, pid: pid, query: query, roleFilter: roleFilter, depth: depth + 1, maxDepth: maxDepth, maxMatches: maxMatches, matches: &matches)
+            findElements(element: child, pid: pid, query: query, roleFilter: roleFilter, depth: depth + 1, maxDepth: maxDepth, maxMatches: maxMatches, matches: &matches, budget: budget)
         }
     }
 
@@ -266,9 +284,8 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        var attrNames: CFArray?
-        guard AXUIElementCopyAttributeNames(element, &attrNames) == .success,
-              let names = attrNames as? [String] else {
+        let (namesResult, namesOpt) = transport.copyAttributeNames(element)
+        guard namesResult == .success, let names = namesOpt else {
             completion(WireFormat.error("failed to read attributes"))
             return
         }
@@ -285,9 +302,8 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
                              "width": frame.size.width, "height": frame.size.height]
         }
 
-        var actionNames: CFArray?
-        if AXUIElementCopyActionNames(element, &actionNames) == .success,
-           let actions = actionNames as? [String] {
+        let (actionsResult, actionsOpt) = transport.copyActionNames(element)
+        if actionsResult == .success, let actions = actionsOpt {
             attrs["actions"] = actions.map { $0.replacingOccurrences(of: "AX", with: "") }
         }
 
@@ -302,7 +318,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         }
 
         if let newValue = action["value"] as? String {
-            let result = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, newValue as CFTypeRef)
+            let result = transport.setAttributeValue(element, kAXValueAttribute as String, newValue as CFTypeRef)
             if result == .success {
                 completion(WireFormat.success("value set"))
             } else {
@@ -324,11 +340,13 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         let actionName = action["action"] as? String ?? "press"
         let axAction = "AX" + actionName.prefix(1).uppercased() + actionName.dropFirst()
 
-        let result = AXUIElementPerformAction(element, axAction as CFString)
+        let result = transport.performAction(element, axAction)
         if result == .success {
             completion(WireFormat.success("ok"))
         } else {
-            // Auto-escalation: try CGEvent click using element frame
+            // Auto-escalation: try CGEvent click using element frame.
+            // NOTE (future work): this global-click fallback is slated for removal
+            // in favor of PID-routed InputDomain delegation; G0 preserves it.
             if let frame = getFrame(element) {
                 let centerX = frame.origin.x + frame.size.width / 2
                 let centerY = frame.origin.y + frame.size.height / 2
@@ -358,15 +376,14 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
-        Self.wakeAXTree(app: axApp)
-        var focused: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(axApp, kAXFocusedUIElementAttribute as CFString, &focused) == .success else {
+        let axApp = transport.createApplication(pid: app.processIdentifier)
+        wakeAXTree(app: axApp)
+        let (focusedResult, focused) = transport.copyAttributeValue(axApp, kAXFocusedUIElementAttribute as String)
+        guard focusedResult == .success, let element = AXValueCodec.asElement(focused) else {
             completion(WireFormat.error("no focused element"))
             return
         }
 
-        let element = focused as! AXUIElement
         let ref = refRegistry.register(element, pid: app.processIdentifier)
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? "unknown"
         let title = getStringAttribute(element, kAXTitleAttribute as CFString) ?? ""
@@ -389,11 +406,10 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
-        Self.wakeAXTree(app: axApp)
-        var windowsRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
-              let windows = windowsRef as? [AXUIElement] else {
+        let axApp = transport.createApplication(pid: app.processIdentifier)
+        wakeAXTree(app: axApp)
+        let (windowsResult, windowsRef) = transport.copyAttributeValue(axApp, kAXWindowsAttribute as String)
+        guard windowsResult == .success, let windows = windowsRef as? [AXUIElement] else {
             completion(WireFormat.success([]))
             return
         }
@@ -520,27 +536,26 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
     private func setSize(_ element: AXUIElement, _ size: CGSize) -> AXError? {
         var s = size
         guard let axSize = AXValueCreate(.cgSize, &s) else { return .failure }
-        let result = AXUIElementSetAttributeValue(element, kAXSizeAttribute as CFString, axSize)
+        let result = transport.setAttributeValue(element, kAXSizeAttribute as String, axSize)
         return result == .success ? nil : result
     }
 
     private func setPosition(_ element: AXUIElement, _ point: CGPoint) -> AXError? {
         var p = point
         guard let axPoint = AXValueCreate(.cgPoint, &p) else { return .failure }
-        let result = AXUIElementSetAttributeValue(element, kAXPositionAttribute as CFString, axPoint)
+        let result = transport.setAttributeValue(element, kAXPositionAttribute as String, axPoint)
         return result == .success ? nil : result
     }
 
     private func settabilityError(element: AXUIElement, attribute: CFString, verb: String) -> [String: Any]? {
-        var settable: DarwinBoolean = false
-        let probe = AXUIElementIsAttributeSettable(element, attribute, &settable)
+        let (probe, settable) = transport.isAttributeSettable(element, attribute as String)
         if probe != .success {
             // If the probe itself fails (e.g. .cannotComplete), surface that —
             // but don't block the verb on it; some apps refuse the probe yet
             // honor the set. Fall through.
             return nil
         }
-        if !settable.boolValue {
+        if settable == false {
             return WireFormat.error("\(verb) failed: attribute not settable on this element (use a top-level window ref)")
         }
         return nil
@@ -619,22 +634,22 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
 
         // Clean up old observer
         if let old = observer {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(old), .defaultMode)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), transport.observerGetRunLoopSource(old), .defaultMode)
             observer = nil
         }
 
-        var newObserver: AXObserver?
         let callback: AXObserverCallback = { _, element, notification, refcon in
             let domain = Unmanaged<AccessibilityDomain>.fromOpaque(refcon!).takeUnretainedValue()
             domain.refRegistry.clear()
             Platform.emitEvent("ax_notification", data: ["notification": notification as String])
         }
 
-        guard AXObserverCreate(pid, callback, &newObserver) == .success, let obs = newObserver else {
+        let (createResult, newObserver) = transport.observerCreate(pid: pid, callback: callback)
+        guard createResult == .success, let obs = newObserver else {
             return
         }
 
-        let axApp = AXUIElementCreateApplication(pid)
+        let axApp = transport.createApplication(pid: pid)
         let notifications: [String] = [
             kAXUIElementDestroyedNotification as String,
             kAXWindowCreatedNotification as String,
@@ -644,10 +659,10 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
 
         let refcon = Unmanaged.passUnretained(self).toOpaque()
         for note in notifications {
-            AXObserverAddNotification(obs, axApp, note as CFString, refcon)
+            _ = transport.observerAddNotification(obs, axApp, note, refcon)
         }
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(obs), .defaultMode)
+        CFRunLoopAddSource(CFRunLoopGetMain(), transport.observerGetRunLoopSource(obs), .defaultMode)
         observer = obs
         observedPID = pid
     }

--- a/interceptor-bridge/Sources/Domains/DisplayDomain.swift
+++ b/interceptor-bridge/Sources/Domains/DisplayDomain.swift
@@ -5,6 +5,9 @@ import AppKit
 final class DisplayDomain: DomainHandler, @unchecked Sendable {
     private let lock = NSLock()
     private var virtualDisplays: [String: VirtualDisplayContext] = [:]
+    // the system-wide focused-application read routes through
+    // the transport.
+    private let transport: any AXTransport = LiveAXTransport()
 
     struct VirtualDisplayContext {
         let display: AnyObject
@@ -307,9 +310,8 @@ final class DisplayDomain: DomainHandler, @unchecked Sendable {
         let targetOrigin = displayBounds.origin
 
         // Find the window via accessibility and set its position
-        let systemWide = AXUIElementCreateSystemWide()
-        var focusedApp: CFTypeRef?
-        AXUIElementCopyAttributeValue(systemWide, kAXFocusedApplicationAttribute as CFString, &focusedApp)
+        let systemWide = transport.createSystemWide()
+        _ = transport.copyAttributeValue(systemWide, kAXFocusedApplicationAttribute as String)
 
         // Try moving via CGS private API first
         typealias CGSConnectionID = UInt32

--- a/interceptor-bridge/Sources/Domains/InputDomain.swift
+++ b/interceptor-bridge/Sources/Domains/InputDomain.swift
@@ -10,6 +10,9 @@ enum InputError: Error {
 final class InputDomain: DomainHandler, @unchecked Sendable {
     private let refRegistry: RefRegistry
     private let selector: InputTargetSelector
+    // AX press / value-set / role-probe / center-point reads
+    // route through the transport + codec (removes `posValue as! AXValue`).
+    private let transport: any AXTransport = LiveAXTransport()
 
     init(refRegistry: RefRegistry = .shared) {
         self.refRegistry = refRegistry
@@ -84,7 +87,7 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         // AX press doesn't model double-click or right-click semantics;
         // those keep going through synthesized CGEvents.
         if case .axPress(let element) = target, !double, !right {
-            let err = AXUIElementPerformAction(element, kAXPressAction as CFString)
+            let err = transport.performAction(element, kAXPressAction as String)
             if err == .success {
                 completion(WireFormat.success("ax-pressed ref"))
                 return
@@ -168,8 +171,8 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         // Apple documents this as the supported way to programmatically
         // populate text fields.
         if let ref = action["ref"] as? String, let element = refRegistry.resolve(ref) {
-            if Self.isTextRole(element) {
-                let err = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, text as CFString)
+            if isTextRole(element) {
+                let err = transport.setAttributeValue(element, kAXValueAttribute as String, text as CFString)
                 if err == .success {
                     completion(WireFormat.success("ax-set value (\(text.count) chars)"))
                     return
@@ -181,7 +184,7 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
             }
             // Focus the element first so synthesized keys land in it,
             // even though the app stays in the background.
-            AXUIElementPerformAction(element, kAXPressAction as CFString)
+            _ = transport.performAction(element, kAXPressAction as String)
             usleep(100_000)
         }
 
@@ -227,10 +230,9 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
     // Roles that we accept programmatic value-set on. These are the
     // standard text-bearing AX roles per Apple's accessibility
     // documentation.
-    private static func isTextRole(_ element: AXUIElement) -> Bool {
-        var role: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role) == .success,
-              let r = role as? String else {
+    private func isTextRole(_ element: AXUIElement) -> Bool {
+        let (result, role) = transport.copyAttributeValue(element, kAXRoleAttribute as String)
+        guard result == .success, let r = AXValueCodec.displayString(role) else {
             return false
         }
         switch r {
@@ -528,18 +530,13 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func centerPoint(of element: AXUIElement) -> CGPoint? {
-        var posValue: CFTypeRef?
-        var sizeValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posValue) == .success,
-              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success else {
+        let (posResult, posValue) = transport.copyAttributeValue(element, kAXPositionAttribute as String)
+        let (sizeResult, sizeValue) = transport.copyAttributeValue(element, kAXSizeAttribute as String)
+        guard posResult == .success, sizeResult == .success,
+              let position = AXValueCodec.point(from: posValue),
+              let size = AXValueCodec.size(from: sizeValue) else {
             return nil
         }
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-        AXValueGetValue(posValue as! AXValue, .cgPoint, &position)
-        AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
-
         return CGPoint(x: position.x + size.width / 2, y: position.y + size.height / 2)
     }
 }

--- a/interceptor-bridge/Sources/Domains/MenuDomain.swift
+++ b/interceptor-bridge/Sources/Domains/MenuDomain.swift
@@ -3,6 +3,15 @@ import ApplicationServices
 import AppKit
 
 final class MenuDomain: DomainHandler, @unchecked Sendable {
+    // route menu-bar AX traversal through the transport and
+    // replace the `menuBarValue as! AXUIElement` force casts with codec
+    // type-checked downcasts. Behavior unchanged.
+    private let transport: any AXTransport
+
+    init(transport: any AXTransport = LiveAXTransport()) {
+        self.transport = transport
+    }
+
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         switch command {
         case "menu":
@@ -32,39 +41,33 @@ final class MenuDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        let appElement = AXUIElementCreateApplication(pid)
-        var menuBarValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appElement, kAXMenuBarAttribute as CFString, &menuBarValue) == .success else {
+        let appElement = transport.createApplication(pid: pid)
+        let (menuBarResult, menuBarValue) = transport.copyAttributeValue(appElement, kAXMenuBarAttribute as String)
+        guard menuBarResult == .success, let menuBar = AXValueCodec.asElement(menuBarValue) else {
             completion(WireFormat.error("could not read menu bar"))
             return
         }
-        let menuBar = menuBarValue as! AXUIElement
 
-        var childrenValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(menuBar, kAXChildrenAttribute as CFString, &childrenValue) == .success,
-              let children = childrenValue as? [AXUIElement] else {
+        let (childrenResult, childrenValue) = transport.copyAttributeValue(menuBar, kAXChildrenAttribute as String)
+        guard childrenResult == .success, let children = childrenValue as? [AXUIElement] else {
             completion(WireFormat.error("could not read menu bar children"))
             return
         }
 
         var lines: [String] = []
         for menuItem in children {
-            var titleValue: CFTypeRef?
-            AXUIElementCopyAttributeValue(menuItem, kAXTitleAttribute as CFString, &titleValue)
-            let title = titleValue as? String ?? "(untitled)"
+            let (_, titleValue) = transport.copyAttributeValue(menuItem, kAXTitleAttribute as String)
+            let title = AXValueCodec.displayString(titleValue) ?? "(untitled)"
             lines.append(title)
 
-            var submenuValue: CFTypeRef?
-            if AXUIElementCopyAttributeValue(menuItem, kAXChildrenAttribute as CFString, &submenuValue) == .success,
-               let submenus = submenuValue as? [AXUIElement] {
+            let (submenuResult, submenuValue) = transport.copyAttributeValue(menuItem, kAXChildrenAttribute as String)
+            if submenuResult == .success, let submenus = submenuValue as? [AXUIElement] {
                 for submenu in submenus {
-                    var subChildrenValue: CFTypeRef?
-                    if AXUIElementCopyAttributeValue(submenu, kAXChildrenAttribute as CFString, &subChildrenValue) == .success,
-                       let subChildren = subChildrenValue as? [AXUIElement] {
+                    let (subResult, subChildrenValue) = transport.copyAttributeValue(submenu, kAXChildrenAttribute as String)
+                    if subResult == .success, let subChildren = subChildrenValue as? [AXUIElement] {
                         for child in subChildren {
-                            var childTitle: CFTypeRef?
-                            AXUIElementCopyAttributeValue(child, kAXTitleAttribute as CFString, &childTitle)
-                            let name = childTitle as? String ?? ""
+                            let (_, childTitle) = transport.copyAttributeValue(child, kAXTitleAttribute as String)
+                            let name = AXValueCodec.displayString(childTitle) ?? ""
                             if !name.isEmpty {
                                 lines.append("  \(name)")
                             }
@@ -84,38 +87,36 @@ final class MenuDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        let appElement = AXUIElementCreateApplication(pid)
-        var menuBarValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appElement, kAXMenuBarAttribute as CFString, &menuBarValue) == .success else {
+        let appElement = transport.createApplication(pid: pid)
+        let (menuBarResult, menuBarValue) = transport.copyAttributeValue(appElement, kAXMenuBarAttribute as String)
+        guard menuBarResult == .success, let menuBar = AXValueCodec.asElement(menuBarValue) else {
             completion(WireFormat.error("could not read menu bar"))
             return
         }
 
-        var currentElement: AXUIElement = menuBarValue as! AXUIElement
+        var currentElement: AXUIElement = menuBar
         var path = items
 
         while !path.isEmpty {
             let target = path.removeFirst()
-            var childrenValue: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(currentElement, kAXChildrenAttribute as CFString, &childrenValue) == .success,
-                  let children = childrenValue as? [AXUIElement] else {
+            let (childrenResult, childrenValue) = transport.copyAttributeValue(currentElement, kAXChildrenAttribute as String)
+            guard childrenResult == .success, let children = childrenValue as? [AXUIElement] else {
                 completion(WireFormat.error("could not traverse menu to: \(target)"))
                 return
             }
 
             var found = false
             for child in children {
-                var titleValue: CFTypeRef?
-                AXUIElementCopyAttributeValue(child, kAXTitleAttribute as CFString, &titleValue)
-                let title = titleValue as? String ?? ""
+                let (_, titleValue) = transport.copyAttributeValue(child, kAXTitleAttribute as String)
+                let title = AXValueCodec.displayString(titleValue) ?? ""
                 if title == target {
                     if path.isEmpty {
-                        AXUIElementPerformAction(child, kAXPressAction as CFString)
+                        _ = transport.performAction(child, kAXPressAction as String)
                         completion(WireFormat.success("invoked menu: \(items.joined(separator: " → "))"))
                         return
                     } else {
-                        var submenuValue: CFTypeRef?
-                        if AXUIElementCopyAttributeValue(child, kAXChildrenAttribute as CFString, &submenuValue) == .success,
+                        let (submenuResult, submenuValue) = transport.copyAttributeValue(child, kAXChildrenAttribute as String)
+                        if submenuResult == .success,
                            let submenus = submenuValue as? [AXUIElement], let submenu = submenus.first {
                             currentElement = submenu
                         } else {

--- a/interceptor-bridge/Sources/Domains/MonitorAxBridge.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorAxBridge.swift
@@ -45,6 +45,9 @@ final class MonitorAxBridge: @unchecked Sendable {
     ]
 
     private let lock = NSLock()
+    // observer create/add/remove/run-loop and attribute reads
+    // route through the transport (removes the `as! AXValue` casts in mergeFrame).
+    private let transport: any AXTransport = LiveAXTransport()
     private var observers: [pid_t: AXObserver] = [:]
     private var registered: [pid_t: [String]] = [:]
     private var callback: EventCallback?
@@ -92,18 +95,17 @@ final class MonitorAxBridge: @unchecked Sendable {
         }
         lock.unlock()
 
-        var newObserver: AXObserver?
-        let createStatus = AXObserverCreate(pid, MonitorAxBridge.cCallback, &newObserver)
+        let (createStatus, newObserver) = transport.observerCreate(pid: pid, callback: MonitorAxBridge.cCallback)
         guard createStatus == .success, let observer = newObserver else {
             Platform.log("MonitorAxBridge: AXObserverCreate failed for pid \(pid) → \(createStatus.rawValue)")
             return []
         }
 
-        let axApp = AXUIElementCreateApplication(pid)
+        let axApp = transport.createApplication(pid: pid)
         let refcon = Unmanaged.passUnretained(self).toOpaque()
         var accepted: [String] = []
         for note in notifications {
-            let st = AXObserverAddNotification(observer, axApp, note as CFString, refcon)
+            let st = transport.observerAddNotification(observer, axApp, note, refcon)
             if st == .success {
                 accepted.append(note)
             }
@@ -117,7 +119,7 @@ final class MonitorAxBridge: @unchecked Sendable {
         // doesn't have to cross an isolation boundary.
         CFRunLoopAddSource(
             CFRunLoopGetMain(),
-            AXObserverGetRunLoopSource(observer),
+            transport.observerGetRunLoopSource(observer),
             .defaultMode
         )
 
@@ -135,13 +137,13 @@ final class MonitorAxBridge: @unchecked Sendable {
         lock.unlock()
 
         guard let observer = observerOpt else { return }
-        let axApp = AXUIElementCreateApplication(pid)
+        let axApp = transport.createApplication(pid: pid)
         for note in registeredNotes {
-            AXObserverRemoveNotification(observer, axApp, note as CFString)
+            _ = transport.observerRemoveNotification(observer, axApp, note)
         }
         CFRunLoopRemoveSource(
             CFRunLoopGetMain(),
-            AXObserverGetRunLoopSource(observer),
+            transport.observerGetRunLoopSource(observer),
             .defaultMode
         )
     }
@@ -174,8 +176,8 @@ final class MonitorAxBridge: @unchecked Sendable {
         // element to enrich the event. We deliberately avoid reading kAXValue
         // for kAXSecureTextField — the role is read first and the value is
         // masked.
-        var pid: pid_t = 0
-        AXUIElementGetPid(element, &pid)
+        let (_, pidOpt) = transport.pid(element)
+        let pid: pid_t = pidOpt ?? 0
 
         var role: String?
         var subrole: String?
@@ -310,9 +312,8 @@ final class MonitorAxBridge: @unchecked Sendable {
     }
 
     private func readStringAttribute(_ element: AXUIElement, _ key: String, into target: inout String?) {
-        var ref: CFTypeRef?
-        let status = AXUIElementCopyAttributeValue(element, key as CFString, &ref)
-        if status == .success, let v = ref as? String {
+        let (status, ref) = transport.copyAttributeValue(element, key)
+        if status == .success, let v = AXValueCodec.displayString(ref) {
             target = v
         }
     }
@@ -320,18 +321,10 @@ final class MonitorAxBridge: @unchecked Sendable {
     private func mergeFrame(_ element: AXUIElement, into data: inout [String: Any]) {
         // kAXPositionAttribute is CGPoint, kAXSizeAttribute is CGSize.
         // Both are AXValueRefs and need AXValueGetValue to extract.
-        var posRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posRef)
-        AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
-        var origin = CGPoint.zero
-        var size = CGSize.zero
-        if let p = posRef, CFGetTypeID(p) == AXValueGetTypeID() {
-            AXValueGetValue(p as! AXValue, .cgPoint, &origin)
-        }
-        if let s = sizeRef, CFGetTypeID(s) == AXValueGetTypeID() {
-            AXValueGetValue(s as! AXValue, .cgSize, &size)
-        }
+        let (_, posRef) = transport.copyAttributeValue(element, kAXPositionAttribute as String)
+        let (_, sizeRef) = transport.copyAttributeValue(element, kAXSizeAttribute as String)
+        let origin = AXValueCodec.point(from: posRef) ?? .zero
+        let size = AXValueCodec.size(from: sizeRef) ?? .zero
         data["frame"] = [
             "x": Int(origin.x),
             "y": Int(origin.y),

--- a/interceptor-bridge/Sources/Domains/MonitorDomain.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorDomain.swift
@@ -41,6 +41,8 @@ import AVFoundation
 
 final class MonitorDomain: DomainHandler, @unchecked Sendable {
     private let lock = NSLock()
+    // the accessibility preflight routes through the transport.
+    private let axTransport: any AXTransport = LiveAXTransport()
     // Phase 5 — concurrent multi-session map. Each runtime owns its own AX /
     // workspace / input / tap bridges plus optional source state.
     var runtimes: [String: MonitorRuntime] = [:]
@@ -64,7 +66,7 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
 
     private func startSession(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         // Accessibility preflight (shared across sessions).
-        let axTrusted = AXIsProcessTrusted()
+        let axTrusted = axTransport.isProcessTrusted()
         if !axTrusted {
             var err = WireFormat.error("missing_tcc:Accessibility")
             err["remediation"] = "interceptor macos trust --accessibility-prompt"

--- a/interceptor-bridge/Sources/Domains/MonitorInputBridge.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorInputBridge.swift
@@ -29,6 +29,8 @@ final class MonitorInputBridge: @unchecked Sendable {
     typealias EventCallback = (_ event: String, _ data: [String: Any]) -> Void
 
     private let lock = NSLock()
+    // the hit-test + attribute reads route through the transport.
+    private let transport: any AXTransport = LiveAXTransport()
     private var monitors: [Any] = []
     private var callback: EventCallback?
     private var includeMouseMoved = false
@@ -217,20 +219,16 @@ final class MonitorInputBridge: @unchecked Sendable {
     }
 
     private func hitTest(at point: CGPoint, pid: pid_t, into data: inout [String: Any]) {
-        let axApp = AXUIElementCreateApplication(pid)
-        var element: AXUIElement?
-        let status = AXUIElementCopyElementAtPosition(axApp, Float(point.x), Float(point.y), &element)
+        let axApp = transport.createApplication(pid: pid)
+        let (status, element) = transport.copyElementAtPosition(axApp, x: Float(point.x), y: Float(point.y))
         guard status == .success, let el = element else { return }
 
-        var role: CFTypeRef?
-        var title: CFTypeRef?
-        var desc: CFTypeRef?
-        AXUIElementCopyAttributeValue(el, kAXRoleAttribute as CFString, &role)
-        AXUIElementCopyAttributeValue(el, kAXTitleAttribute as CFString, &title)
-        AXUIElementCopyAttributeValue(el, kAXDescriptionAttribute as CFString, &desc)
-        if let r = role as? String { data["r"] = r }
-        if let t = title as? String { data["n"] = t }
-        else if let d = desc as? String { data["n"] = d }
+        let (_, role) = transport.copyAttributeValue(el, kAXRoleAttribute as String)
+        let (_, title) = transport.copyAttributeValue(el, kAXTitleAttribute as String)
+        let (_, desc) = transport.copyAttributeValue(el, kAXDescriptionAttribute as String)
+        if let r = AXValueCodec.displayString(role) { data["r"] = r }
+        if let t = AXValueCodec.displayString(title) { data["n"] = t }
+        else if let d = AXValueCodec.displayString(desc) { data["n"] = d }
     }
 
     static func keyComboString(_ event: NSEvent) -> String {

--- a/interceptor-bridge/Sources/Domains/TextDomain.swift
+++ b/interceptor-bridge/Sources/Domains/TextDomain.swift
@@ -3,9 +3,14 @@ import ApplicationServices
 
 final class TextDomain: DomainHandler, @unchecked Sendable {
     private let refRegistry: RefRegistry
+    // route AX calls through the transport + codec (removes the
+    // `rangeValue as! AXValue` force cast) and apply central secure redaction so
+    // a secure text field never returns its contents (a security correction).
+    private let transport: any AXTransport
 
-    init(refRegistry: RefRegistry = .shared) {
+    init(refRegistry: RefRegistry = .shared, transport: any AXTransport = LiveAXTransport()) {
         self.refRegistry = refRegistry
+        self.transport = transport
     }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -28,45 +33,45 @@ final class TextDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
+        // Secure-field correction: never emit the contents of a password field.
+        if AXSecureRedaction.isSecureElement(element, transport: transport) {
+            completion(WireFormat.success(AXSecureRedaction.placeholder))
+            return
+        }
+
         let mode = action["mode"] as? String ?? "full"
 
         switch mode {
         case "selection":
-            var value: CFTypeRef?
-            if AXUIElementCopyAttributeValue(element, kAXSelectedTextAttribute as CFString, &value) == .success,
-               let text = value as? String {
+            let (result, value) = transport.copyAttributeValue(element, kAXSelectedTextAttribute as String)
+            if result == .success, let text = AXValueCodec.displayString(value) {
                 completion(WireFormat.success(text))
             } else {
                 completion(WireFormat.error("no selected text"))
             }
         case "visible":
             // Try visible character range, then fall back to full value
-            var rangeValue: CFTypeRef?
-            if AXUIElementCopyAttributeValue(element, kAXVisibleCharacterRangeAttribute as CFString, &rangeValue) == .success {
-                var range = CFRange(location: 0, length: 0)
-                AXValueGetValue(rangeValue as! AXValue, .cfRange, &range)
+            let (rangeResult, rangeValue) = transport.copyAttributeValue(element, kAXVisibleCharacterRangeAttribute as String)
+            if rangeResult == .success, var range = AXValueCodec.range(from: rangeValue) {
                 // Use parameterized attribute to get text for range
-                var textValue: CFTypeRef?
-                var cfRange = range
-                let rangeVal = AXValueCreate(.cfRange, &cfRange)!
-                if AXUIElementCopyParameterizedAttributeValue(element, kAXStringForRangeParameterizedAttribute as CFString, rangeVal, &textValue) == .success,
-                   let text = textValue as? String {
-                    completion(WireFormat.success(text))
-                    return
+                if let rangeVal = AXValueCreate(.cfRange, &range) {
+                    let (textResult, textValue) = transport.copyParameterizedAttributeValue(element, kAXStringForRangeParameterizedAttribute as String, rangeVal)
+                    if textResult == .success, let text = AXValueCodec.displayString(textValue) {
+                        completion(WireFormat.success(text))
+                        return
+                    }
                 }
             }
             // Fallback to full value
-            var fullValue: CFTypeRef?
-            if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &fullValue) == .success,
-               let text = fullValue as? String {
+            let (fullResult, fullValue) = transport.copyAttributeValue(element, kAXValueAttribute as String)
+            if fullResult == .success, let text = AXValueCodec.displayString(fullValue) {
                 completion(WireFormat.success(text))
             } else {
                 completion(WireFormat.error("no visible text"))
             }
         default: // "full"
-            var value: CFTypeRef?
-            if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success,
-               let text = value as? String {
+            let (result, value) = transport.copyAttributeValue(element, kAXValueAttribute as String)
+            if result == .success, let text = AXValueCodec.displayString(value) {
                 completion(WireFormat.success(text))
             } else {
                 completion(WireFormat.error("no text value"))

--- a/interceptor-bridge/Sources/Domains/TrustDomain.swift
+++ b/interceptor-bridge/Sources/Domains/TrustDomain.swift
@@ -46,6 +46,9 @@ struct Permission {
 
 final class TrustDomain: DomainHandler, @unchecked Sendable {
     private let microphoneProvider: MicrophoneAuthorizationProvider
+    // AXIsProcessTrusted[/WithOptions] route through the
+    // transport (the one Accessibility C-call surface).
+    private let transport: any AXTransport = LiveAXTransport()
 
     init(microphoneProvider: MicrophoneAuthorizationProvider = LiveMicrophoneAuthorizationProvider()) {
         self.microphoneProvider = microphoneProvider
@@ -206,9 +209,9 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         if prompt {
             let key = "AXTrustedCheckOptionPrompt" as CFString
             let options = [key: true] as CFDictionary
-            trusted = AXIsProcessTrustedWithOptions(options)
+            trusted = transport.isProcessTrustedWithOptions(options)
         } else {
-            trusted = AXIsProcessTrusted()
+            trusted = transport.isProcessTrusted()
         }
         return PermissionStatus.fromBool(trusted)
     }

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AXBudgetTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AXBudgetTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+// budget meter + bounded traversal.
+final class AXBudgetTests: XCTestCase {
+
+    func testNodeBudgetStopsWithReason() {
+        let b = AXBudget(maxMs: 60_000, maxNodes: 3, maxCalls: 1_000)
+        for _ in 0..<3 { XCTAssertFalse(b.shouldStop()); b.countNode() }
+        XCTAssertTrue(b.shouldStop())
+        XCTAssertEqual(b.limitHit, "max_nodes")
+        XCTAssertTrue(b.stopMarker.contains("max_nodes"))
+    }
+
+    func testCallBudgetStopsWithReason() {
+        let b = AXBudget(maxMs: 60_000, maxNodes: 1_000_000, maxCalls: 10)
+        b.countCalls(10)
+        XCTAssertTrue(b.shouldStop())
+        XCTAssertEqual(b.limitHit, "budget_exceeded")
+    }
+
+    func testDeadlineStopsWithReason() {
+        let t0 = Date()
+        let b = AXBudget(maxMs: 10, maxNodes: 1_000, maxCalls: 1_000, now: t0)
+        XCTAssertFalse(b.shouldStop(now: t0))                       // not yet
+        XCTAssertTrue(b.shouldStop(now: t0.addingTimeInterval(1)))  // 1s later
+        XCTAssertEqual(b.limitHit, "deadline_exceeded")
+    }
+
+    func testNoLimitNoMarker() {
+        let b = AXBudget(maxMs: 60_000, maxNodes: 100, maxCalls: 100)
+        b.countNode(); b.countCalls(1)
+        XCTAssertFalse(b.shouldStop())
+        XCTAssertEqual(b.stopMarker, "")
+    }
+
+    func testFirstReasonSticks() {
+        let b = AXBudget(maxMs: 0, maxNodes: 1, maxCalls: 1)
+        b.countNode()                     // hits max_nodes first
+        XCTAssertTrue(b.shouldStop())
+        XCTAssertEqual(b.limitHit, "max_nodes")
+        _ = b.shouldStop()                // deadline also blown, but reason must not change
+        XCTAssertEqual(b.limitHit, "max_nodes")
+    }
+
+    func testClamp() {
+        XCTAssertEqual(AXBudget.clamp(nil, def: 2000, hard: 10000), 2000)
+        XCTAssertEqual(AXBudget.clamp(0, def: 2000, hard: 10000), 2000)      // non-positive ⇒ default
+        XCTAssertEqual(AXBudget.clamp(500, def: 2000, hard: 10000), 500)
+        XCTAssertEqual(AXBudget.clamp(999999, def: 2000, hard: 10000), 10000) // clamp to hard cap
+    }
+
+    // Integration: the real buildTree walker must stop on the node budget when
+    // fed a wide, self-referential graph — proving the budget actually bounds an
+    // otherwise-unbounded traversal (the live Finder-timeout case). Calls the
+    // walker directly so it doesn't depend on a live NSRunningApplication.
+    func testTreeBoundsWideCyclicGraphWithoutHanging() {
+        let fake = FakeAXTransport()
+        fake.attributeResponses["AXRole"] = FakeAX.string("AXButton")   // interactive ⇒ renders
+        let kids = (0..<10).map { _ in FakeAX.element() }
+        fake.attributeResponses["AXChildren"] = FakeAX.array(kids)      // every node returns 10 children
+
+        let domain = AccessibilityDomain(transport: fake)
+        let budget = AXBudget(maxMs: 60_000, maxNodes: 30, maxCalls: 1_000_000)
+        var output = ""
+        // maxDepth huge + maxChars huge ⇒ only the node budget can stop it.
+        domain.buildTree(element: AXUIElementCreateSystemWide(), pid: 4242, depth: 0,
+                         maxDepth: 100, filter: "all", output: &output, maxChars: 100_000_000, budget: budget)
+
+        XCTAssertEqual(budget.limitHit, "max_nodes", "budget must stop the otherwise-infinite walk")
+        XCTAssertGreaterThanOrEqual(budget.nodesVisited, 30)
+        XCTAssertLessThan(budget.nodesVisited, 100, "must not blow far past the cap")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AXSecureCanaryTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AXSecureCanaryTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+// secure canary. A unique secure-field value must never appear in
+// any product output: not through the codec, the redaction helper, a typed
+// error, or the TextDomain read path.
+final class AXSecureCanaryTests: XCTestCase {
+    static let canary = "CANARY-a7f3e9c1-9d2b-4e10-secret-password"
+
+    private func containsCanary(_ obj: [String: Any]) -> Bool {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj),
+              let s = String(data: data, encoding: .utf8) else { return false }
+        return s.contains(Self.canary)
+    }
+
+    func testCodecRedactsSecureValue() {
+        let t = AXValueCodec.tag(FakeAX.string(Self.canary), secure: true)
+        XCTAssertEqual(t["kind"] as? String, "redacted")
+        XCTAssertFalse(containsCanary(t))
+    }
+
+    func testRedactionHelperReplacesSecureDisplayString() {
+        let out = AXSecureRedaction.displayString(FakeAX.string(Self.canary), secure: true)
+        XCTAssertEqual(out, AXSecureRedaction.placeholder)
+        XCTAssertNotEqual(out, Self.canary)
+    }
+
+    func testTypedErrorNeverCarriesCanary() {
+        let err = AXTypedError.errorDict("read failed", code: "secure_value_redacted")
+        XCTAssertFalse(containsCanary(err))
+    }
+
+    // The load-bearing path: TextDomain reading a secure field returns the
+    // placeholder, never the field contents.
+    func testTextDomainRedactsSecureField() {
+        let registry = RefRegistry()
+        let ref = registry.register(AXUIElementCreateSystemWide(), pid: 4242)
+
+        let fake = FakeAXTransport()
+        fake.attributeResponses["AXRole"] = FakeAX.string("AXSecureTextField")
+        fake.attributeResponses["AXValue"] = FakeAX.string(Self.canary)
+
+        let domain = TextDomain(refRegistry: registry, transport: fake)
+        let holder = TestResultHolder()
+        domain.handle("text", action: ["ref": ref, "mode": "full"]) { holder.set($0) }
+        let captured = holder.value
+
+        XCTAssertEqual(captured["data"] as? String, AXSecureRedaction.placeholder)
+        XCTAssertFalse(containsCanary(captured))
+    }
+
+    func testSecureClassificationBySubrole() {
+        XCTAssertTrue(AXSecureRedaction.isSecure(role: "AXTextField", subrole: "AXSecureTextField"))
+        XCTAssertFalse(AXSecureRedaction.isSecure(role: "AXTextField", subrole: nil))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AXTransportSeamTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AXTransportSeamTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+// the transport seam. Bulk positional value/null/error
+// order is preserved through the codec; a domain routes through the injected
+// transport; and the cannotComplete-after-effect fixture is representable.
+final class AXTransportSeamTests: XCTestCase {
+
+    func testBulkPositionalValueNullErrorOrder() {
+        let fake = FakeAXTransport()
+        fake.multiAttributeResponse = [
+            FakeAX.string("v0"),
+            FakeAX.null,
+            FakeAX.axError(.cannotComplete),
+        ]
+        let el = AXUIElementCreateSystemWide()
+        let (err, values) = fake.copyMultipleAttributeValues(el, ["a", "b", "c"], stopOnError: false)
+        XCTAssertEqual(err, .success)
+        XCTAssertEqual(values?.count, 3)
+
+        let tagged = values!.map { AXValueCodec.tag($0) }
+        XCTAssertEqual(tagged[0]["kind"] as? String, "string")
+        XCTAssertEqual(tagged[1]["kind"] as? String, "null")
+        XCTAssertEqual(tagged[2]["kind"] as? String, "ax_error")   // per-slot error, not flattened
+        XCTAssertEqual(tagged[2]["name"] as? String, "kAXErrorCannotComplete")
+    }
+
+    func testTextDomainRoutesThroughInjectedTransport() {
+        let registry = RefRegistry()
+        let ref = registry.register(AXUIElementCreateSystemWide(), pid: 4242)
+
+        let fake = FakeAXTransport()
+        fake.attributeResponses["AXRole"] = FakeAX.string("AXTextArea")   // non-secure
+        fake.attributeResponses["AXValue"] = FakeAX.string("hello world")
+
+        let domain = TextDomain(refRegistry: registry, transport: fake)
+        let holder = TestResultHolder()
+        domain.handle("text", action: ["ref": ref, "mode": "full"]) { holder.set($0) }
+        let captured = holder.value
+
+        XCTAssertEqual(captured["success"] as? Bool, true)
+        XCTAssertEqual(captured["data"] as? String, "hello world")
+        XCTAssertGreaterThan(fake.callCount, 0)   // proves it went through the seam
+    }
+
+    func testCannotCompleteAfterEffectIsRepresentable() {
+        let fake = FakeAXTransport()
+        fake.performResult = .cannotComplete
+        fake.actionEffectHappened = true
+
+        let el = AXUIElementCreateSystemWide()
+        let result = fake.performAction(el, "AXPress")
+
+        // The API reports cannotComplete even though the effect was recorded —
+        // exactly the ambiguity the verified-action engine (G3) must handle.
+        XCTAssertEqual(result, .cannotComplete)
+        XCTAssertEqual(fake.performedActions, ["AXPress"])
+    }
+
+    func testTypedErrorMapsCannotComplete() {
+        let dict = AXTypedError.from(.cannotComplete, message: "nope")
+        XCTAssertEqual(dict["success"] as? Bool, false)
+        XCTAssertEqual(dict["code"] as? String, "cannot_complete")
+        XCTAssertEqual(dict["retryable"] as? Bool, false)   // action cannotComplete: verify before retry
+        let details = dict["details"] as? [String: Any]
+        let axError = details?["axError"] as? [String: Any]
+        XCTAssertEqual(axError?["name"] as? String, "kAXErrorCannotComplete")
+    }
+
+    func testProductCodeMapping() {
+        XCTAssertEqual(AXTypedError.productCode(.attributeUnsupported), "unsupported_attribute")
+        XCTAssertEqual(AXTypedError.productCode(.actionUnsupported), "unsupported_action")
+        XCTAssertEqual(AXTypedError.productCode(.noValue), "no_value")
+        XCTAssertEqual(AXTypedError.productCode(.apiDisabled), "accessibility_unusable")
+        XCTAssertNil(AXTypedError.productCode(.success))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AXValueCodecTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AXValueCodecTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+// codec matrix. Every supported CF/AX type and every
+// unsupported/malformed value produces a tagged result without a force-cast
+// trap, and the whole matrix is acyclic + JSON-safe.
+final class AXValueCodecTests: XCTestCase {
+
+    func testString() {
+        let t = AXValueCodec.tag(FakeAX.string("hello"))
+        XCTAssertEqual(t["kind"] as? String, "string")
+        XCTAssertEqual(t["value"] as? String, "hello")
+    }
+
+    func testBoolean() {
+        let t = AXValueCodec.tag(kCFBooleanTrue)
+        XCTAssertEqual(t["kind"] as? String, "boolean")
+        XCTAssertEqual(t["value"] as? Bool, true)
+    }
+
+    func testFiniteNumber() {
+        let t = AXValueCodec.tag(FakeAX.number(NSNumber(value: 3.5)))
+        XCTAssertEqual(t["kind"] as? String, "number")
+        XCTAssertEqual(t["value"] as? Double, 3.5)
+    }
+
+    func testNonFiniteNumberIsJSONSafe() {
+        let t = AXValueCodec.tag(FakeAX.number(NSNumber(value: Double.infinity)))
+        XCTAssertEqual(t["kind"] as? String, "number")
+        XCTAssertEqual(t["finite"] as? Bool, false)
+        XCTAssertEqual(t["special"] as? String, "infinity")
+        XCTAssertNil(t["value"])   // no non-finite number leaks into JSON
+    }
+
+    func testSafeInteger() {
+        let t = AXValueCodec.tag(FakeAX.number(NSNumber(value: 42)))
+        XCTAssertEqual(t["kind"] as? String, "number")
+        XCTAssertEqual(t["value"] as? Int, 42)
+    }
+
+    func testUnsafeIntegerBecomesDecimalString() {
+        let big = Int64(9_007_199_254_740_993)   // 2^53 + 1
+        let t = AXValueCodec.tag(FakeAX.number(NSNumber(value: big)))
+        XCTAssertEqual(t["kind"] as? String, "integer")
+        XCTAssertEqual(t["value"] as? String, "9007199254740993")
+    }
+
+    func testPointSizeRectRange() {
+        let p = AXValueCodec.tag(FakeAX.point(1, 2))
+        XCTAssertEqual(p["kind"] as? String, "point")
+        XCTAssertEqual(p["x"] as? CGFloat, 1)
+
+        let s = AXValueCodec.tag(FakeAX.size(3, 4))
+        XCTAssertEqual(s["kind"] as? String, "size")
+        XCTAssertEqual(s["width"] as? CGFloat, 3)
+
+        let r = AXValueCodec.tag(FakeAX.rect(5, 6, 7, 8))
+        XCTAssertEqual(r["kind"] as? String, "rect")
+        XCTAssertEqual(r["height"] as? CGFloat, 8)
+
+        let rng = AXValueCodec.tag(FakeAX.range(10, 20))
+        XCTAssertEqual(rng["kind"] as? String, "range")
+    }
+
+    func testAXError() {
+        let t = AXValueCodec.tag(FakeAX.axError(.cannotComplete))
+        XCTAssertEqual(t["kind"] as? String, "ax_error")
+        XCTAssertEqual(t["name"] as? String, "kAXErrorCannotComplete")
+    }
+
+    func testURL() {
+        let t = AXValueCodec.tag(FakeAX.url("https://example.com/x"))
+        XCTAssertEqual(t["kind"] as? String, "url")
+        XCTAssertTrue((t["value"] as? String ?? "").contains("example.com"))
+    }
+
+    func testAttributedString() {
+        let t = AXValueCodec.tag(FakeAX.attributed("styled"))
+        XCTAssertEqual(t["kind"] as? String, "attributed_string")
+        XCTAssertEqual(t["value"] as? String, "styled")
+    }
+
+    func testNestedElementBecomesRefNeverPointer() {
+        let t = AXValueCodec.tag(FakeAX.element())
+        XCTAssertEqual(t["kind"] as? String, "element_ref")
+        XCTAssertNil(t["ref"])   // no token provider ⇒ no token, and never an address
+        // Emit a token when a provider is supplied.
+        let withToken = AXValueCodec.tag(FakeAX.element(), elementToken: { _ in "e7" })
+        XCTAssertEqual(withToken["ref"] as? String, "e7")
+    }
+
+    func testArrayOfMixedItems() {
+        let arr = FakeAX.array([FakeAX.string("a"), FakeAX.number(NSNumber(value: 1)), FakeAX.element()])
+        let t = AXValueCodec.tag(arr)
+        XCTAssertEqual(t["kind"] as? String, "array")
+        let items = t["items"] as? [[String: Any]]
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items?[0]["kind"] as? String, "string")
+        XCTAssertEqual(items?[2]["kind"] as? String, "element_ref")   // element ⇒ terminal, no cycle
+    }
+
+    func testNullAndNil() {
+        XCTAssertEqual(AXValueCodec.tag(FakeAX.null)["kind"] as? String, "null")
+        XCTAssertEqual(AXValueCodec.tag(nil)["kind"] as? String, "null")
+    }
+
+    func testUnsupportedCFType() {
+        let t = AXValueCodec.tag(NSDate() as CFTypeRef)
+        XCTAssertEqual(t["kind"] as? String, "unsupported")
+        XCTAssertNotNil(t["typeName"])
+    }
+
+    func testSecureAlwaysRedacted() {
+        let t = AXValueCodec.tag(FakeAX.string("hunter2"), secure: true)
+        XCTAssertEqual(t["kind"] as? String, "redacted")
+        XCTAssertNil(t["value"])
+    }
+
+    // The whole matrix must serialize with no throw (acyclic, JSON-safe).
+    func testEntireMatrixIsJSONSafe() {
+        let matrix: [[String: Any]] = [
+            AXValueCodec.tag(FakeAX.string("s")),
+            AXValueCodec.tag(kCFBooleanTrue),
+            AXValueCodec.tag(FakeAX.number(NSNumber(value: 3.5))),
+            AXValueCodec.tag(FakeAX.number(NSNumber(value: Double.nan))),
+            AXValueCodec.tag(FakeAX.number(NSNumber(value: Int64(9_007_199_254_740_993)))),
+            AXValueCodec.tag(FakeAX.point(1, 2)),
+            AXValueCodec.tag(FakeAX.rect(0, 0, 10, 10)),
+            AXValueCodec.tag(FakeAX.axError(.cannotComplete)),
+            AXValueCodec.tag(FakeAX.url("https://example.com")),
+            AXValueCodec.tag(FakeAX.attributed("a")),
+            AXValueCodec.tag(FakeAX.element()),
+            AXValueCodec.tag(FakeAX.array([FakeAX.string("x"), FakeAX.element()])),
+            AXValueCodec.tag(FakeAX.null),
+            AXValueCodec.tag(NSDate() as CFTypeRef),
+        ]
+        XCTAssertNoThrow(try JSONSerialization.data(withJSONObject: ["matrix": matrix]))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/FakeAXTransport.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/FakeAXTransport.swift
@@ -1,0 +1,179 @@
+import Foundation
+import ApplicationServices
+@testable import interceptor_bridge
+
+// deterministic AX transport double for unit tests.
+//
+// It fabricates only real, constructible CF values (CFString, CFNumber,
+// AXValue via AXValueCreate, kCFNull, AXUIElementCreateSystemWide) so tests need
+// no live application. It models the branches the PRD requires: per-slot bulk
+// values/nulls/errors, a recorded call count (delay stand-in), and an
+// "action happened but returned cannotComplete" fixture.
+final class FakeAXTransport: AXTransport, @unchecked Sendable {
+    // Attribute name (raw AX constant string, e.g. "AXRole") → value.
+    var attributeResponses: [String: CFTypeRef] = [:]
+    var settable: [String: Bool] = [:]
+    var multiAttributeResponse: [CFTypeRef]?
+    var parameterizedResponses: [String: CFTypeRef] = [:]
+
+    var performResult: AXError = .success
+    var setResult: AXError = .success
+    var performedActions: [String] = []
+    var setAttributes: [(String, CFTypeRef)] = []
+
+    // cannotComplete-after-effect fixture: performAction returns .cannotComplete
+    // yet the effect is recorded, so verify-before-retry logic (G3) is testable.
+    var actionEffectHappened = false
+
+    private(set) var callCount = 0
+
+    private func tick() { callCount += 1 }
+
+    func createApplication(pid: pid_t) -> AXUIElement { AXUIElementCreateSystemWide() }
+    func createSystemWide() -> AXUIElement { AXUIElementCreateSystemWide() }
+
+    func copyAttributeValue(_ element: AXUIElement, _ attribute: String) -> (AXError, CFTypeRef?) {
+        tick()
+        if let v = attributeResponses[attribute] { return (.success, v) }
+        return (.noValue, nil)
+    }
+
+    func copyMultipleAttributeValues(_ element: AXUIElement, _ attributes: [String], stopOnError: Bool) -> (AXError, [CFTypeRef]?) {
+        tick()
+        if let fixed = multiAttributeResponse { return (.success, fixed) }
+        let values = attributes.map { attributeResponses[$0] ?? (kCFNull as CFTypeRef) }
+        return (.success, values)
+    }
+
+    func copyAttributeNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        tick()
+        return (.success, Array(attributeResponses.keys))
+    }
+
+    func attributeValueCount(_ element: AXUIElement, _ attribute: String) -> (AXError, Int?) {
+        tick()
+        if let arr = attributeResponses[attribute] as? [CFTypeRef] { return (.success, arr.count) }
+        return (.noValue, nil)
+    }
+
+    func copyAttributeValues(_ element: AXUIElement, _ attribute: String, index: Int, maxValues: Int) -> (AXError, [CFTypeRef]?) {
+        tick()
+        guard let arr = attributeResponses[attribute] as? [CFTypeRef] else { return (.noValue, nil) }
+        let end = min(index + maxValues, arr.count)
+        guard index < end else { return (.success, []) }
+        return (.success, Array(arr[index..<end]))
+    }
+
+    func isAttributeSettable(_ element: AXUIElement, _ attribute: String) -> (AXError, Bool?) {
+        tick()
+        return (.success, settable[attribute] ?? false)
+    }
+
+    func setAttributeValue(_ element: AXUIElement, _ attribute: String, _ value: CFTypeRef) -> AXError {
+        tick()
+        setAttributes.append((attribute, value))
+        return setResult
+    }
+
+    func copyParameterizedAttributeNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        tick()
+        return (.success, Array(parameterizedResponses.keys))
+    }
+
+    func copyParameterizedAttributeValue(_ element: AXUIElement, _ attribute: String, _ parameter: CFTypeRef) -> (AXError, CFTypeRef?) {
+        tick()
+        if let v = parameterizedResponses[attribute] { return (.success, v) }
+        return (.noValue, nil)
+    }
+
+    func copyActionNames(_ element: AXUIElement) -> (AXError, [String]?) {
+        tick()
+        return (.success, ["AXPress"])
+    }
+
+    func copyActionDescription(_ element: AXUIElement, _ action: String) -> (AXError, String?) {
+        tick()
+        return (.success, "perform \(action)")
+    }
+
+    func performAction(_ element: AXUIElement, _ action: String) -> AXError {
+        tick()
+        performedActions.append(action)
+        if performResult == .cannotComplete && actionEffectHappened {
+            // effect happened, but the API still reported cannotComplete
+            return .cannotComplete
+        }
+        return performResult
+    }
+
+    func copyElementAtPosition(_ application: AXUIElement, x: Float, y: Float) -> (AXError, AXUIElement?) {
+        tick()
+        return (.success, AXUIElementCreateSystemWide())
+    }
+
+    func pid(_ element: AXUIElement) -> (AXError, pid_t?) {
+        tick()
+        return (.success, 4242)
+    }
+
+    func setMessagingTimeout(_ element: AXUIElement, seconds: Float) -> AXError {
+        tick()
+        return .success
+    }
+
+    func observerCreate(pid: pid_t, callback: @escaping AXObserverCallback) -> (AXError, AXObserver?) {
+        tick()
+        return (.cannotComplete, nil)   // observers are not exercised by unit tests
+    }
+
+    func observerAddNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String, _ refcon: UnsafeMutableRawPointer?) -> AXError {
+        .cannotComplete
+    }
+
+    func observerRemoveNotification(_ observer: AXObserver, _ element: AXUIElement, _ notification: String) -> AXError {
+        .cannotComplete
+    }
+
+    func observerGetRunLoopSource(_ observer: AXObserver) -> CFRunLoopSource {
+        var ctx = CFRunLoopSourceContext()
+        ctx.perform = { _ in }
+        return CFRunLoopSourceCreate(nil, 0, &ctx)!
+    }
+
+    var trusted = true
+    func isProcessTrusted() -> Bool { trusted }
+    func isProcessTrustedWithOptions(_ options: CFDictionary) -> Bool { trusted }
+}
+
+// Test helpers to fabricate real CF/AX values without a live app.
+enum FakeAX {
+    static func string(_ s: String) -> CFTypeRef { s as CFString }
+    static func number(_ n: NSNumber) -> CFTypeRef { n as CFTypeRef }
+    static func point(_ x: CGFloat, _ y: CGFloat) -> CFTypeRef {
+        var p = CGPoint(x: x, y: y)
+        return AXValueCreate(.cgPoint, &p)!
+    }
+    static func size(_ w: CGFloat, _ h: CGFloat) -> CFTypeRef {
+        var s = CGSize(width: w, height: h)
+        return AXValueCreate(.cgSize, &s)!
+    }
+    static func rect(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> CFTypeRef {
+        var r = CGRect(x: x, y: y, width: w, height: h)
+        return AXValueCreate(.cgRect, &r)!
+    }
+    static func range(_ loc: Int, _ len: Int) -> CFTypeRef {
+        var r = CFRange(location: loc, length: len)
+        return AXValueCreate(.cfRange, &r)!
+    }
+    static func axError(_ e: AXError) -> CFTypeRef {
+        var err = e
+        return AXValueCreate(.axError, &err)!
+    }
+    static func url(_ s: String) -> CFTypeRef { URL(string: s)! as CFURL }
+    static func attributed(_ s: String) -> CFTypeRef {
+        CFAttributedStringCreate(nil, s as CFString, nil)!
+    }
+    static func element() -> CFTypeRef { AXUIElementCreateSystemWide() }
+    static func array(_ items: [CFTypeRef]) -> CFTypeRef { items as CFArray }
+    static var null: CFTypeRef { kCFNull }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.22.6",
+  "version": "0.22.8",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/test/macos-parser.test.ts
+++ b/test/macos-parser.test.ts
@@ -256,4 +256,63 @@ describe("macos parser", () => {
     expect(action.jsc).toBe("run = argv => argv.join('|')")
     expect(action.args).toEqual(["alpha", "beta"])
   })
+
+  // help advertises `tree --max-chars` but the parser
+  // used to drop it. These lock the fix so the drift cannot regress.
+  test("tree --max-chars is forwarded to the bridge", () => {
+    const action = parseMacosCommand(["macos", "tree", "--app", "Finder", "--max-chars", "1000"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_tree")
+    expect(action.maxChars).toBe(1000)
+  })
+
+  test("tree without --max-chars defaults to 50000", () => {
+    const action = parseMacosCommand(["macos", "tree", "--app", "Finder"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_tree")
+    expect(action.maxChars).toBe(50000)
+  })
+
+  test("tree still forwards app/pid/filter/depth alongside max-chars", () => {
+    const action = parseMacosCommand([
+      "macos", "tree", "--pid", "4242", "--filter", "all", "--depth", "5", "--max-chars", "20000",
+    ]) as Record<string, unknown>
+    expect(action.pid).toBe(4242)
+    expect(action.filter).toBe("all")
+    expect(action.depth).toBe(5)
+    expect(action.maxChars).toBe(20000)
+  })
+
+  // traversal-bound flags reach the bridge (which clamps them).
+  test("tree forwards --max-nodes and --max-ms when present", () => {
+    const action = parseMacosCommand([
+      "macos", "tree", "--app", "Finder", "--max-nodes", "500", "--max-ms", "3000",
+    ]) as Record<string, unknown>
+    expect(action.maxNodes).toBe(500)
+    expect(action.maxMs).toBe(3000)
+  })
+
+  test("tree omits max-nodes/max-ms when absent (bridge applies defaults)", () => {
+    const action = parseMacosCommand(["macos", "tree", "--app", "Finder"]) as Record<string, unknown>
+    expect(action.maxNodes).toBeUndefined()
+    expect(action.maxMs).toBeUndefined()
+  })
+
+  // find/focused/windows now forward --pid (previously dropped).
+  test("find forwards --pid and traversal bounds", () => {
+    const action = parseMacosCommand([
+      "macos", "find", "Save", "--pid", "77", "--max-nodes", "800",
+    ]) as Record<string, unknown>
+    expect(action.type).toBe("macos_find")
+    expect(action.query).toBe("Save")
+    expect(action.pid).toBe(77)
+    expect(action.maxNodes).toBe(800)
+  })
+
+  test("focused and windows forward --pid", () => {
+    const f = parseMacosCommand(["macos", "focused", "--pid", "88"]) as Record<string, unknown>
+    expect(f.type).toBe("macos_focused")
+    expect(f.pid).toBe(88)
+    const w = parseMacosCommand(["macos", "windows", "--pid", "99"]) as Record<string, unknown>
+    expect(w.type).toBe("macos_windows")
+    expect(w.pid).toBe(99)
+  })
 })


### PR DESCRIPTION
Introduces a bounded, typed, background-first Accessibility layer for the macOS bridge, and bumps all surfaces to **0.22.8**.

## What changed
- **`AXTransport`** — one injectable seam that owns every Accessibility C call. A live implementation (the only one importing `ApplicationServices`) plus a fake for unit tests. Nine domains route through it (`AccessibilityDomain`, `TextDomain`, `MenuDomain`, `InputDomain`, `MonitorAxBridge`, `MonitorInputBridge`, `MonitorDomain`, `DisplayDomain`, `TrustDomain`) — no domain calls an AX C function directly.
- **`AXValueCodec`** — a non-trapping typed codec (checks CF type id → `AXValueGetType` → typed extraction) that replaces every `as!` / `unsafeBitCast` force cast. Output is acyclic and JSON-safe: element ref tokens, decimal-string big integers, no non-finite leaks.
- **`AXSecureRedaction`** — one central secure-field boundary. `AXSecureTextField` values are always redacted; `macos text` on a password field returns the placeholder, never the contents.
- **`AXTypedError`** — `AXError` → stable product error codes, raw code + name retained.
- **`AXBudget`** — per-command node / AX-call / wall-clock budget for `tree`/`find`, plus a per-element messaging timeout. A large or slow tree (e.g. Finder with the desktop window) now returns a **bounded partial** ending in `… (stopped: <reason>)` instead of hanging on the CLI timeout.
- **CLI** — fixes the `tree --max-chars` drift (help advertised it, parser dropped it); adds `--max-nodes` / `--max-ms`; forwards `--pid` on `find`/`focused`/`windows`.
- **Docs** — AGENTS.md recovery reflexes, a path-scoped parser-sync rule, README + ARCHITECTURE notes.

## Behavior corrections (intentional)
- Password/secure fields are now redacted in `macos text` (previously could surface contents).
- `tree`/`find` are bounded — very large trees return a partial with a stop marker rather than timing out with nothing.

## Tests
Swift unit suites (codec matrix, secure canary, transport seam, bounded traversal) + CLI parser-compatibility tests. `swift build` + `swift test` + `bun test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added limits for macOS accessibility tree and search operations using node and time controls.
  * Added PID targeting for tree, find, focused, and windows commands.
  * Added configurable output-size limits for tree results.
  * Secure text fields are now consistently redacted.
  * Accessibility results provide safer, structured output and clearer error details.

* **Bug Fixes**
  * Prevented accessibility traversal from hanging by returning bounded partial results with stop markers.

* **Documentation**
  * Updated macOS usage, troubleshooting, and contributor guidance with the new behavior and options.

* **Chores**
  * Updated the application and extension version to 0.22.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->