### PR TITLE
Release 0.22.9 — tab close/switch target the requested tab id

### DIFF
--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -1699,6 +1699,10 @@ async function handleCanvasActions(action, tabId) {
 function activeTabKey(group) {
   return group ? `activeTabId:${group}` : "activeTabId";
 }
+function sessionArea3() {
+  const storage = chrome.storage;
+  return storage.session ?? chrome.storage.local;
+}
 async function handleTabActions(action, tabId) {
   switch (action.type) {
     case "tab_create": {
@@ -1722,7 +1726,7 @@ async function handleTabActions(action, tabId) {
                   updateProps.active = true;
                 const updated = await chrome.tabs.update(candidate.id, updateProps);
                 await waitForTabLoad(candidate.id);
-                await chrome.storage.session.set({ [activeTabKey(group)]: candidate.id });
+                await sessionArea3().set({ [activeTabKey(group)]: candidate.id });
                 return {
                   success: true,
                   data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, group, reused: true }
@@ -1736,7 +1740,7 @@ async function handleTabActions(action, tabId) {
       const newTab = await chrome.tabs.create({ url: targetUrl, active: shouldActivate });
       if (newTab.id) {
         const groupId = group ? await addTabToNamedGroup(newTab.id, group, action.groupColor) : await addTabToInterceptorGroup(newTab.id);
-        await chrome.storage.session.set({ [activeTabKey(group)]: newTab.id });
+        await sessionArea3().set({ [activeTabKey(group)]: newTab.id });
         return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, group, reused: false } };
       }
       return { success: true, data: { tabId: newTab.id, url: newTab.url, reused: false } };
@@ -1745,16 +1749,15 @@ async function handleTabActions(action, tabId) {
       const closedId = action.tabId || tabId;
       await chrome.tabs.remove(closedId);
       const keys = ["activeTabId", typeof action.group === "string" ? activeTabKey(action.group) : null].filter((k) => !!k);
-      const stored = await chrome.storage.session.get(keys);
+      const stored = await sessionArea3().get(keys);
       for (const key of keys) {
         if (stored[key] === closedId)
-          await chrome.storage.session.remove(key);
+          await sessionArea3().remove(key);
       }
       return { success: true };
     }
     case "tab_switch": {
       await chrome.tabs.update(action.tabId, { active: true });
-      await chrome.storage.session.set({ activeTabId: action.tabId });
       return { success: true };
     }
     case "tab_list": {
@@ -4352,6 +4355,13 @@ function needsTab(type) {
   return !NO_TAB_ACTIONS.has(type);
 }
 
+// extension/src/background/resolve-tab.ts
+function resolveWorkingTabId(msgTabId, actionTabId) {
+  if (typeof actionTabId === "number" && !Number.isNaN(actionTabId))
+    return actionTabId;
+  return msgTabId;
+}
+
 // extension/src/background/message-dispatch.ts
 var MESSAGE_QUEUE_CAP = 50;
 var messageQueue = [];
@@ -4420,7 +4430,7 @@ async function handleDaemonMessage(msg) {
     viaWs: respondViaWs
   });
   const action = msg.action;
-  let tabId = msg.tabId;
+  let tabId = resolveWorkingTabId(msg.tabId, action.tabId);
   const fail = (error) => {
     clearTimeout(requestTimer);
     pendingRequests.delete(msg.id);
@@ -4457,8 +4467,6 @@ async function handleDaemonMessage(msg) {
   if (!tabId && needsTab(action.type)) {
     const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
     tabId = activeTab?.id;
-    if (tabId)
-      setActiveTabId(tabId);
   }
   if (!tabId && needsTab(action.type)) {
     fail("no active tab");

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
Version bump + rebuilt extension bundles for the tab-targeting fix line (PR #138 + maintainer hardening).

- `tab close <id>` / `tab switch <id>` act on the requested tab, not the active tab (thanks @Brasidus, #138)
- Explicit ids beat `--tab`; validation and effect always target the same tab
- No pre-gate auto-target persist — a gate-rejected request can't poison subsequent commands
- CLI rejects non-numeric tab ids
- Tab handlers use the session-or-local storage fallback (MV2 Electron parity)

Bumps `package.json`, `extension/manifest.json`, `extension/dist-mv2/manifest.json` to 0.22.9; commits the rebuilt `dist-mv2` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active-tab state handling across tab creation, closing, and switching.
  * Ensured actions target the explicitly selected tab when provided.
  * Added more reliable session storage with a fallback for environments without session storage.

* **Chores**
  * Updated the extension version to 0.22.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->