### PR TITLE
fix(cli): tab close/switch id is the first non-flag argument

### DIFF
--- a/cli/commands/tabs.ts
+++ b/cli/commands/tabs.ts
@@ -136,22 +136,28 @@ export async function parseTabsCommand(filtered: string[]): Promise<Action | nul
           if (filtered.includes("--activate")) action.active = true
           return action
         }
-        case "close":
-          // Strict digits: parseInt would partial-parse '12abc' to 12 and turn
-          // a typo'd id into a close of a different (or the active) tab.
-          if (filtered[2] !== undefined && !/^\d+$/.test(filtered[2])) {
-            console.error(`error: tab close requires a numeric tab ID, got '${filtered[2]}'`)
+        case "close": {
+          // The id is the first non-flag argument (`tab close --json` is a
+          // valid no-arg close). Strict digits beyond that: parseInt would
+          // partial-parse '12abc' to 12 and turn a typo'd id into a close of
+          // a different (or the active) tab.
+          const closeId = filtered.slice(2).find(a => !a.startsWith("-"))
+          if (closeId !== undefined && !/^\d+$/.test(closeId)) {
+            console.error(`error: tab close requires a numeric tab ID, got '${closeId}'`)
             process.exit(1)
           }
-          return filtered[2]
-            ? { type: "tab_close", tabId: parseInt(filtered[2]) }
+          return closeId
+            ? { type: "tab_close", tabId: parseInt(closeId) }
             : { type: "tab_close" }
-        case "switch":
-          if (filtered[2] === undefined || !/^\d+$/.test(filtered[2])) {
-            console.error(`error: tab switch requires a numeric tab ID${filtered[2] !== undefined ? `, got '${filtered[2]}'` : ""}`)
+        }
+        case "switch": {
+          const switchId = filtered.slice(2).find(a => !a.startsWith("-"))
+          if (switchId === undefined || !/^\d+$/.test(switchId)) {
+            console.error(`error: tab switch requires a numeric tab ID${switchId !== undefined ? `, got '${switchId}'` : ""}`)
             process.exit(1)
           }
-          return { type: "tab_switch", tabId: parseInt(filtered[2]) }
+          return { type: "tab_switch", tabId: parseInt(switchId) }
+        }
         default:
           console.error("error: unknown tab subcommand. Use: new, close, switch")
           process.exit(1)

--- a/test/tab-id-args.test.ts
+++ b/test/tab-id-args.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, mock, spyOn, test } from "bun:test"
+import { parseTabsCommand } from "../cli/commands/tabs"
+
+// Pins the tab close/switch id-argument contract: the id is the first
+// non-flag argument (so `tab close --json` stays a valid no-arg close),
+// and a present-but-non-numeric id is a hard CLI error, never a
+// partial-parse or a silent fall-through to the active tab.
+describe("tab close/switch id parsing", () => {
+  test("close with no id is a bare tab_close", async () => {
+    expect(await parseTabsCommand(["tab", "close"])).toEqual({ type: "tab_close" })
+  })
+
+  test("close with only flags is a bare tab_close (--json form)", async () => {
+    expect(await parseTabsCommand(["tab", "close", "--json"])).toEqual({ type: "tab_close" })
+  })
+
+  test("close finds the id around flags", async () => {
+    expect(await parseTabsCommand(["tab", "close", "123", "--json"])).toEqual({ type: "tab_close", tabId: 123 })
+    expect(await parseTabsCommand(["tab", "close", "--json", "123"])).toEqual({ type: "tab_close", tabId: 123 })
+  })
+
+  test("switch takes the first non-flag id", async () => {
+    expect(await parseTabsCommand(["tab", "switch", "456", "--json"])).toEqual({ type: "tab_switch", tabId: 456 })
+  })
+
+  test("non-numeric ids are a hard error, not a partial parse", async () => {
+    const exit = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`)
+    }) as never)
+    const err = spyOn(console, "error").mockImplementation(mock(() => {}))
+    try {
+      await expect(parseTabsCommand(["tab", "close", "12abc"])).rejects.toThrow("exit 1")
+      await expect(parseTabsCommand(["tab", "close", "abc", "--json"])).rejects.toThrow("exit 1")
+      await expect(parseTabsCommand(["tab", "switch", "--json"])).rejects.toThrow("exit 1")
+    } finally {
+      exit.mockRestore()
+      err.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
Follow-up to #138's hardening: the strict tab-id validation rejected `tab close --json` (valid no-arg close) because the flag landed in the id position. The id is now the first non-flag argument; parser tests pin the forms (`close`, `close --json`, `close 123 --json`, `close --json 123`, `switch 456 --json`, and the hard-error cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)