### PR TITLE
chore: ignore bun standalone-compile build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 .build/
+# Orphaned temp files (~98MB each) from interrupted `bun build --compile` runs
+*.bun-build
 .claude/worktrees/
 dist/
 extension/dist/


### PR DESCRIPTION
Orphaned `.bun-build` temp files (~98MB each) from interrupted `bun build --compile` runs were showing up as untracked. This ignores them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file exclusions to prevent temporary build artifacts from being included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->