### PR TITLE
fix(transport): detect half-open ws via daemon keepalive_ack

### DIFF
--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -1626,6 +1626,17 @@ function startWsServer(): ReturnType<typeof Bun.serve> {
 
         if (request.type === "keepalive") {
           log("ws keepalive")
+          // Ack so the extension can detect a half-open socket. After MV3 SW
+          // hibernation the OS socket can wedge OPEN-but-dead: the extension's
+          // outbound keepalives keep flowing while its ws.onmessage is silently
+          // severed. The ack is the inbound frame the extension watches for; N
+          // consecutive unacked keepalives means the read side is gone and it
+          // must force a reconnect. Older extensions ignore this frame.
+          try {
+            ws.send(JSON.stringify({ type: "keepalive_ack", timestamp: Date.now() }))
+          } catch (err) {
+            log(`ws keepalive_ack send failed: ${(err as Error).message}`)
+          }
           return
         }
 

--- a/extension/src/background/transport.ts
+++ b/extension/src/background/transport.ts
@@ -18,6 +18,12 @@ let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null
 
 let wsChannel: WebSocket | null = null
 let wsReady = false
+// Half-open detection state: keepalives sent since the last inbound ws frame,
+// and whether this connection's daemon has acked one (older daemons never do).
+// All transitions go through the pure reducers below (wsStateOn*) so the
+// stateful behavior — send increments, inbound resets, ack arms, open clears —
+// is unit-testable without a live socket.
+let wsKeepalive: WsKeepaliveState = { keepalivesSinceAck: 0, ackSupported: false }
 let wsKeepAliveTimer: ReturnType<typeof setInterval> | null = null
 let keepalivePongTimer: ReturnType<typeof setTimeout> | null = null
 let pendingHandshakePort: chrome.runtime.Port | null = null
@@ -29,6 +35,9 @@ let safariNativeRelayEnabled = false
 let safariNativeRelayClient: SafariNativeRelayClient | null = null
 export const NATIVE_KEEPALIVE_PONG_TIMEOUT_MS = 15_000
 export const RECENT_NATIVE_ACTIVITY_GRACE_MS = 10_000
+// After this many consecutive keepalives sent with no inbound frame in reply
+// (~40s at the 20s interval), treat the ws as half-open and force a reconnect.
+export const WS_KEEPALIVE_MISS_LIMIT = 2
 const OUTBOUND_RECOVERY_QUEUE_CAP = 50
 const outboundRecoveryQueue: unknown[] = []
 
@@ -379,15 +388,71 @@ export function connectSafariNativeRelayChannel(): void {
   safariNativeRelayClient.start()
 }
 
+// Half-open detection state, threaded through pure reducers so every
+// transition is testable without a live socket.
+export type WsKeepaliveState = { keepalivesSinceAck: number; ackSupported: boolean }
+
+// A fresh socket: no unacked keepalives, and `ackSupported` re-learned from
+// THIS connection's first ack rather than inherited. Resetting ackSupported per
+// connection is what keeps the gate honest — a daemon that acked on a prior
+// socket but was replaced by a non-acking build won't leave the flag latched
+// true and false-positive-reconnect a healthy but unacked connection.
+export function wsStateOnOpen(): WsKeepaliveState {
+  return { keepalivesSinceAck: 0, ackSupported: false }
+}
+
+// A keepalive just went out with no reply yet.
+export function wsStateOnKeepaliveSent(state: WsKeepaliveState): WsKeepaliveState {
+  return { ...state, keepalivesSinceAck: state.keepalivesSinceAck + 1 }
+}
+
+// Any inbound frame proves the read side is alive — clear the staleness count.
+export function wsStateOnInboundFrame(state: WsKeepaliveState): WsKeepaliveState {
+  return { ...state, keepalivesSinceAck: 0 }
+}
+
+// A keepalive_ack: this daemon supports acks, so arm half-open detection.
+export function wsStateOnAck(state: WsKeepaliveState): WsKeepaliveState {
+  return { ...state, ackSupported: true }
+}
+
+/**
+ * Decide, from inside the outbound keepalive timer, whether the ws is half-open
+ * (OPEN at the OS layer but its read side is silently severed — the post-MV3-
+ * hibernation failure mode). The outbound setInterval is the one callback that
+ * keeps firing while ws.onmessage is wedged, so it must be the detector. Gated
+ * on `ackSupported` (set only after this connection's first keepalive_ack)
+ * so a daemon that never acks can't trip a permanent false-positive reconnect
+ * loop. Pure so the gate is unit-testable.
+ */
+export function shouldForceWsReconnect(
+  ackSupported: boolean,
+  keepalivesSinceAck: number,
+  missLimit: number,
+): boolean {
+  return ackSupported && keepalivesSinceAck >= missLimit
+}
+
 function startWsKeepAlive(): void {
   if (wsKeepAliveTimer) clearInterval(wsKeepAliveTimer)
   wsKeepAliveTimer = setInterval(() => {
-    if (!wsChannel || wsChannel.readyState !== WebSocket.OPEN) {
+    const channel = wsChannel
+    if (!channel || channel.readyState !== WebSocket.OPEN) {
       if (wsKeepAliveTimer) clearInterval(wsKeepAliveTimer)
       wsKeepAliveTimer = null
       return
     }
-    try { wsChannel.send(JSON.stringify({ type: "keepalive", timestamp: Date.now() })) } catch {}
+    if (shouldForceWsReconnect(wsKeepalive.ackSupported, wsKeepalive.keepalivesSinceAck, WS_KEEPALIVE_MISS_LIMIT)) {
+      console.error(`ws inbound stale (${wsKeepalive.keepalivesSinceAck} unacked keepalives) — forcing reconnect`)
+      // Route through the shared teardown so onclose/backoff/reconnect run
+      // exactly as they do for a clean close — no bespoke reconnect timer.
+      closeWsForReconnect(channel)
+      return
+    }
+    try {
+      channel.send(JSON.stringify({ type: "keepalive", timestamp: Date.now() }))
+      wsKeepalive = wsStateOnKeepaliveSent(wsKeepalive)
+    } catch {}
   }, 20_000)
 }
 
@@ -436,6 +501,10 @@ export function connectWsChannel(): void {
         clearTimeout(wsReconnectTimer)
         wsReconnectTimer = null
       }
+      // Fresh socket: reset staleness AND re-learn ack support from this
+      // connection's first ack (see wsStateOnOpen — don't inherit a prior
+      // socket's capability flag).
+      wsKeepalive = wsStateOnOpen()
       startWsKeepAlive()
       const contextId = await getOrCreateContextId()
       if (wsChannel !== ws) {
@@ -451,8 +520,16 @@ export function connectWsChannel(): void {
     }
     ws.onmessage = (event) => {
       if (wsChannel !== ws) return
+      // Any inbound frame proves the read side is alive — clear the half-open
+      // counter regardless of the frame's kind.
+      wsKeepalive = wsStateOnInboundFrame(wsKeepalive)
       try {
         const msg = JSON.parse(typeof event.data === "string" ? event.data : "")
+        if (msg?.type === "keepalive_ack") {
+          // First ack on this connection: arm half-open detection.
+          wsKeepalive = wsStateOnAck(wsKeepalive)
+          return
+        }
         console.log("ws onmessage:", JSON.stringify(msg).slice(0, 200))
         handleControlPlaneMessage(msg, "websocket")
       } catch (err) {

--- a/test/transport-halfopen-ws.test.ts
+++ b/test/transport-halfopen-ws.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+
+// Half-open ws detection: after MV3 service-worker hibernation the OS socket can
+// wedge OPEN-but-dead — the extension's outbound keepalives keep flowing while
+// ws.onmessage is silently severed, so ws-forwarded actions never get a reply
+// and the CLI times out. The outbound keepalive timer is the one callback still
+// firing, so it watches "keepalives sent since the last inbound frame" and, once
+// it has ever seen a daemon ack, force-reconnects after WS_KEEPALIVE_MISS_LIMIT
+// unacked keepalives. The gate on "ack ever seen" is what stops a daemon that
+// never acks from tripping a permanent false-positive reconnect loop — that gate
+// is the correctness-critical decision, exercised here as a pure function.
+//
+// The counter reset itself is robust by construction: onmessage clears
+// wsKeepalivesSentSinceAck on EVERY inbound frame before parsing, so any daemon
+// traffic (ack or otherwise) proves the read side is alive and resets staleness.
+
+describe("shouldForceWsReconnect — half-open gate", () => {
+  test("never fires until a daemon ack has ever been seen (false-positive guard)", async () => {
+    const { shouldForceWsReconnect, WS_KEEPALIVE_MISS_LIMIT } =
+      await import("../extension/src/background/transport")
+    // A daemon that never acks: even far past the limit, ackSupported=false → no reconnect.
+    expect(shouldForceWsReconnect(false, WS_KEEPALIVE_MISS_LIMIT + 5, WS_KEEPALIVE_MISS_LIMIT)).toBe(false)
+    expect(shouldForceWsReconnect(false, 100, WS_KEEPALIVE_MISS_LIMIT)).toBe(false)
+  })
+
+  test("fires only once ack-supported AND the unacked count reaches the limit", async () => {
+    const { shouldForceWsReconnect } = await import("../extension/src/background/transport")
+    expect(shouldForceWsReconnect(true, 0, 2)).toBe(false)
+    expect(shouldForceWsReconnect(true, 1, 2)).toBe(false) // below limit
+    expect(shouldForceWsReconnect(true, 2, 2)).toBe(true)  // at limit
+    expect(shouldForceWsReconnect(true, 3, 2)).toBe(true)  // past limit
+  })
+
+  test("miss limit is a small positive window (~40s at the 20s interval)", async () => {
+    const { WS_KEEPALIVE_MISS_LIMIT } = await import("../extension/src/background/transport")
+    expect(WS_KEEPALIVE_MISS_LIMIT).toBeGreaterThanOrEqual(1)
+    expect(WS_KEEPALIVE_MISS_LIMIT).toBeLessThanOrEqual(5)
+  })
+})
+
+// The stateful transitions are pure reducers, so the actual runtime behavior —
+// not just the gate — is exercised here: send increments, any inbound frame
+// resets, an ack arms detection, and a fresh socket re-learns ack support
+// instead of inheriting it. These lock in the review's #4 (per-connection
+// reset) and #6 (stateful coverage) folds.
+describe("ws keepalive state reducers", () => {
+  test("a fresh socket starts clean and UN-armed (per-connection ack support)", async () => {
+    const { wsStateOnOpen } = await import("../extension/src/background/transport")
+    expect(wsStateOnOpen()).toEqual({ keepalivesSinceAck: 0, ackSupported: false })
+  })
+
+  test("each keepalive sent increments the unacked count", async () => {
+    const { wsStateOnOpen, wsStateOnKeepaliveSent } =
+      await import("../extension/src/background/transport")
+    let s = wsStateOnOpen()
+    s = wsStateOnKeepaliveSent(s)
+    s = wsStateOnKeepaliveSent(s)
+    expect(s.keepalivesSinceAck).toBe(2)
+  })
+
+  test("any inbound frame resets the unacked count but leaves ack support intact", async () => {
+    const { wsStateOnKeepaliveSent, wsStateOnAck, wsStateOnInboundFrame } =
+      await import("../extension/src/background/transport")
+    let s = { keepalivesSinceAck: 0, ackSupported: false }
+    s = wsStateOnAck(s)
+    s = wsStateOnKeepaliveSent(s)
+    s = wsStateOnKeepaliveSent(s)
+    expect(s).toEqual({ keepalivesSinceAck: 2, ackSupported: true })
+    s = wsStateOnInboundFrame(s)
+    expect(s).toEqual({ keepalivesSinceAck: 0, ackSupported: true })
+  })
+
+  test("an ack arms detection; the gate only fires once armed AND stale", async () => {
+    const { wsStateOnOpen, wsStateOnKeepaliveSent, wsStateOnAck, shouldForceWsReconnect } =
+      await import("../extension/src/background/transport")
+    // Un-armed: stack up misses past the limit — the gate stays shut.
+    let s = wsStateOnOpen()
+    s = wsStateOnKeepaliveSent(s)
+    s = wsStateOnKeepaliveSent(s)
+    expect(shouldForceWsReconnect(s.ackSupported, s.keepalivesSinceAck, 2)).toBe(false)
+    // Arm via ack, then stack misses again — now the gate fires at the limit.
+    s = wsStateOnAck(s)
+    s = wsStateOnKeepaliveSent(s)
+    s = wsStateOnKeepaliveSent(s)
+    expect(shouldForceWsReconnect(s.ackSupported, s.keepalivesSinceAck, 2)).toBe(true)
+  })
+
+  test("#4: reopening drops a prior connection's ack support (no latched flag)", async () => {
+    const { wsStateOnAck, wsStateOnOpen } = await import("../extension/src/background/transport")
+    // Prior connection saw an ack.
+    const armed = wsStateOnAck({ keepalivesSinceAck: 3, ackSupported: false })
+    expect(armed.ackSupported).toBe(true)
+    // New socket: ack support is re-learned, not inherited — so a downgraded
+    // daemon can't false-positive-reconnect a healthy-but-unacked connection.
+    expect(wsStateOnOpen().ackSupported).toBe(false)
+  })
+})


### PR DESCRIPTION
## What's wrong

After the MV3 service worker hibernates, the WebSocket to the daemon can wedge OPEN but dead. The extension's outbound keepalives keep flowing, but `ws.onmessage` is silently severed, so any ws-forwarded action never gets a reply and the CLI just sits there until it times out. The only recovery was a manual extension reload.

The native-messaging path already guards this with a pong-timeout. The ws path didn't.

## The fix

- The daemon replies `keepalive_ack` to each ws keepalive. That ack is the inbound frame the extension watches for. Older extensions ignore it, so this stays backward-compatible.
- `startWsKeepAlive` counts keepalives sent since the last inbound frame. Any frame resets the count in `onmessage`. Once an ack has been seen on the connection, `WS_KEEPALIVE_MISS_LIMIT` consecutive unacked keepalives (~40s) force a reconnect through the existing `closeWsForReconnect` path, so it reuses the same onclose/backoff as a clean close. No bespoke timer.
- The reconnect is gated on having seen an ack, so a daemon that never acks can't trip a permanent false-positive reconnect loop. That gate is the pure `shouldForceWsReconnect()`.
- Ack support is re-learned per connection. A daemon that acked on a prior socket but got replaced by a non-acking build won't leave the flag latched and reconnect a healthy connection.

The half-open state transitions are pure reducers (`wsStateOn*`), which keeps the stateful behavior testable without a live socket.

## Verifying

`test/transport-halfopen-ws` covers the gate, the miss-limit window, and each state transition (send increments, any inbound frame resets, an ack arms detection, a fresh socket re-learns). Extension and host both typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connections now acknowledge keepalive requests with a timestamp.
  * Added detection for unresponsive or half-open connections, automatically reconnecting when keepalive acknowledgements are missed.
  * Connection health tracking resets correctly whenever a new WebSocket connection opens.

* **Bug Fixes**
  * Improved handling of stale WebSocket connections to prevent the extension from remaining connected to an unresponsive daemon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->