### PR TITLE
fix(screenshot): auto-fallback DOM-render to pixel + right-size CLI timeout

### DIFF
--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -63,7 +63,6 @@ const ACTION_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   ios_shot: 30_000,
   ios_backup: 30_000,
   ios_axtree: 30_000,
-  screenshot: 45_000,
   binary_sink_save: 600_000,
   screenshot_background: 45_000,
   canvas_read: 45_000,
@@ -75,8 +74,24 @@ const ACTION_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   ocr: 60_000,
 }
 
-function pickTimeoutForAction(actionType: string): number {
-  return ACTION_TIMEOUT_OVERRIDES_MS[actionType] ?? INTERCEPTOR_TIMEOUT_MS
+// Every screenshot gets a ceiling aligned with the daemon's REQUEST_TIMEOUT_MS
+// (180s), not the flat 45s. The service worker bounds its own stages (the
+// DOM-render path has a 30s budget; the pixel path has per-strip guards), so
+// the CLI only needs to out-wait the SW's worst case without racing it:
+//  - `--pixel`/`--pixel --full` scrolls + captures + stitches strip-by-strip
+//    (~1.1s/strip, Chrome-rate-limited) with no single 30s cap.
+//  - the DEFAULT (DOM-render) path can auto-fall-back to the pixel path when
+//    the native renderer fails on a heavy page, so a plain `screenshot` can
+//    also run DOM-render (≤30s) THEN a full pixel capture. A 45s ceiling would
+//    race that combined path and surface the generic transport timeout it was
+//    meant to prevent, so all screenshots share the long ceiling.
+const SCREENSHOT_TIMEOUT_MS = 175_000
+
+export function pickTimeoutForAction(action: Action): number {
+  if (action.type === "screenshot") {
+    return SCREENSHOT_TIMEOUT_MS
+  }
+  return ACTION_TIMEOUT_OVERRIDES_MS[action.type] ?? INTERCEPTOR_TIMEOUT_MS
 }
 
 // Branch the timeout hint on `macos_*` so bridge commands don't get a
@@ -155,7 +170,7 @@ export function sendCommand(rawAction: Action, tabId?: number, contextId?: strin
       // wrote <= 0: socket buffer full — keep pendingWrite, retry on drain.
     }
 
-    const timeoutMs = pickTimeoutForAction(action.type)
+    const timeoutMs = pickTimeoutForAction(action)
     const timer = setTimeout(() => {
       if (!resolved) {
         resolved = true
@@ -226,7 +241,7 @@ export function sendCommandWs(rawAction: Action, tabId?: number, contextId?: str
     const shortId = id.slice(0, 8)
     process.stderr.write(`[${shortId}] →ws ${action.type}\n`)
 
-    const timeoutMs = pickTimeoutForAction(action.type)
+    const timeoutMs = pickTimeoutForAction(action)
     const timer = setTimeout(() => {
       reject(new Error(`timeout: no response for '${action.type}' after ${timeoutMs / 1000}s via WebSocket.`))
     }, timeoutMs)

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -2,7 +2,7 @@ import { sendToContentScript } from "../content-bridge"
 import { sendToOffscreen } from "../offscreen"
 import { installScreenshotCorsRule, uninstallScreenshotCorsRule } from "./screenshot-cors"
 
-type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
+type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number; fallbackEligible?: boolean }
 
 const CAPTURE_TIMEOUT_MS = 5000
 const DOM_RENDER_TIMEOUT_MS = 30_000
@@ -226,7 +226,12 @@ async function handleDomRenderScreenshot(
     }
 
     if (!renderResult || !renderResult.success || !renderResult.data) {
-      return { success: false, error: renderResult?.error || "dom render returned no data" }
+      // The genuine render failure (content script couldn't rasterize — e.g. the
+      // serialized foreignObject SVG won't decode on a heavy page). ONLY this
+      // branch is eligible for the pixel fallback; the earlier returns (tab not
+      // found, restricted page) and the timeout return above are actionable
+      // errors a pixel retry can't fix, so they are NOT tagged.
+      return { success: false, error: renderResult?.error || "dom render returned no data", fallbackEligible: true }
     }
 
     let dataUrl = renderResult.data.dataUrl
@@ -604,6 +609,61 @@ async function handleOcr(
   }
 }
 
+// ─── Auto-fallback planning (pure) ────────────────────────────────────────────
+
+// Decide whether a failed DOM-render screenshot should retry via the pixel
+// path, and if so, shape the pixel request. Pure so it's unit-testable without
+// chrome. Returns null when NO fallback should happen.
+//
+// The pixel path is a DIFFERENT capture mechanism that can only honor a subset
+// of the request, so the fallback is gated tightly:
+//  - Only on a genuine render failure (domResult.fallbackEligible) — not on
+//    tab-not-found / restricted-page / timeout errors, which a pixel retry
+//    can't fix and would only mask behind extra latency.
+//  - Only for a whole-page capture. region/clip/selector are DOM-render-only
+//    concepts; element/ref crops resolve against the DOM, and the pixel path
+//    can't honor `ref` at all and would crop an off-screen element against the
+//    wrong (viewport) origin — a wrong image reported as success.
+//
+// When it does fall back it reconstructs an EXPLICIT full-page pixel request
+// (the default DOM-render screenshot is whole-page by contract, so the fallback
+// must be too — `full: true` selects the strip-and-stitch path, not a viewport
+// grab) carrying only the fields the pixel path honors. Options the pixel path
+// can't apply (`--scale` and DOM-only fields) are dropped and named in the note.
+export function planPixelFallback(
+  action: { type: string; [key: string]: unknown },
+  domResult: ActionResult
+): { pixelAction: { type: string; [key: string]: unknown }; note: string } | null {
+  const isWholePageCapture = !(
+    action.region || action.clip || action.selector ||
+    action.element !== undefined || action.ref !== undefined
+  )
+  if (!domResult.fallbackEligible || !isWholePageCapture) return null
+
+  const droppedOpts: string[] = []
+  if (action.scale !== undefined) droppedOpts.push("--scale")
+
+  const pixelAction: { type: string; [key: string]: unknown } = {
+    type: "screenshot",
+    pixel: true,
+    full: true,
+  }
+  // Match the DOM-render defaults (PNG, quality 92) when the caller pinned
+  // neither — otherwise the pixel path's own defaults (JPEG, quality 50) would
+  // silently downgrade a whole-page capture that the DOM path would have
+  // returned as a lossless PNG. A caller who asked for jpeg/webp or a specific
+  // quality still gets exactly that; only the unspecified case changes.
+  pixelAction.format = action.format !== undefined ? action.format : "png"
+  pixelAction.quality = action.quality !== undefined ? action.quality : 92
+  if (action.target_max_long_edge !== undefined) pixelAction.target_max_long_edge = action.target_max_long_edge
+  if (action.save !== undefined) pixelAction.save = action.save
+
+  const note = droppedOpts.length
+    ? `dom-render (${domResult.error}) → pixel [dropped: ${droppedOpts.join(", ")}]`
+    : `dom-render (${domResult.error}) → pixel`
+  return { pixelAction, note }
+}
+
 // ─── Public dispatcher ────────────────────────────────────────────────────────
 
 export async function handleScreenshotActions(
@@ -629,7 +689,26 @@ export async function handleScreenshotActions(
       if (action.pixel === true) {
         return handlePixelScreenshot(action, tabId)
       }
-      return handleDomRenderScreenshot(action, tabId)
+      const domResult = await handleDomRenderScreenshot(action, tabId)
+      if (domResult.success) return domResult
+
+      // Auto-fallback: the native DOM renderer fails outright on some heavy
+      // real pages (the serialized foreignObject SVG won't decode → an
+      // image-load error). Rather than surface a dead end, transparently retry
+      // via the pixel (captureVisibleTab) path so the default command still
+      // produces an image. Gating + request-shaping is pure logic in
+      // planPixelFallback so it stays testable without chrome mocks.
+      const plan = planPixelFallback(action, domResult)
+      if (!plan) return domResult
+
+      const pixelResult = await handlePixelScreenshot(plan.pixelAction, tabId)
+      if (pixelResult.success && pixelResult.data) {
+        (pixelResult.data as Record<string, unknown>).fallback = plan.note
+        return pixelResult
+      }
+      // Pixel also failed — return the original DOM-render error (the primary
+      // path the caller asked for), noting the pixel fallback was tried.
+      return { success: false, error: `${domResult.error} (pixel fallback also failed: ${pixelResult.error})` }
     }
   }
   return { success: false, error: `unknown screenshot action: ${action.type}` }

--- a/test/screenshot-pixel-fallback.test.ts
+++ b/test/screenshot-pixel-fallback.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { planPixelFallback } from "../extension/src/background/capabilities/screenshot"
+
+// planPixelFallback decides whether a failed DOM-render screenshot retries via
+// the pixel path, and shapes that request. These tests lock in the gating +
+// request-shaping fixes from the code review:
+//  #1 full-page must be preserved (pixel fallback sets full:true)
+//  #2 element/ref must NOT fall back (pixel can't honor them)
+//  #4 only a genuine render failure (fallbackEligible) falls back
+//  #5 --scale is dropped and named in the note
+
+const RENDER_FAIL = { success: false, error: "dom render failed: image load failed", fallbackEligible: true }
+
+describe("planPixelFallback", () => {
+  test("#4: only falls back on a genuine render failure (fallbackEligible)", () => {
+    // An actionable error (tab not found / restricted) is NOT eligible.
+    const notEligible = { success: false, error: "tab 5 not found" }
+    expect(planPixelFallback({ type: "screenshot" }, notEligible)).toBeNull()
+    // Eligible render failure → plan produced.
+    expect(planPixelFallback({ type: "screenshot" }, RENDER_FAIL)).not.toBeNull()
+  })
+
+  test("#1: whole-page fallback reconstructs an explicit FULL-page pixel request", () => {
+    const plan = planPixelFallback({ type: "screenshot" }, RENDER_FAIL)
+    expect(plan).not.toBeNull()
+    expect(plan!.pixelAction).toMatchObject({ type: "screenshot", pixel: true, full: true })
+  })
+
+  test("#2: element/ref/region/clip/selector captures do NOT fall back", () => {
+    for (const scoped of [
+      { type: "screenshot", ref: "e5" },
+      { type: "screenshot", element: 3 },
+      { type: "screenshot", region: { x: 0, y: 0, width: 10, height: 10 } },
+      { type: "screenshot", clip: { x: 0, y: 0, width: 10, height: 10 } },
+      { type: "screenshot", selector: ".foo" },
+    ]) {
+      expect(planPixelFallback(scoped, RENDER_FAIL)).toBeNull()
+    }
+  })
+
+  test("#5: --scale is dropped and named in the fallback note", () => {
+    const plan = planPixelFallback({ type: "screenshot", scale: 2 }, RENDER_FAIL)
+    expect(plan).not.toBeNull()
+    expect(plan!.pixelAction.scale).toBeUndefined() // pixel path can't honor it
+    expect(plan!.note).toContain("dropped: --scale")
+  })
+
+  test("pixel-honored options are carried through; note has no 'dropped' when none dropped", () => {
+    const plan = planPixelFallback(
+      { type: "screenshot", format: "jpeg", quality: 80, target_max_long_edge: 1568, save: true },
+      RENDER_FAIL
+    )
+    expect(plan).not.toBeNull()
+    expect(plan!.pixelAction).toMatchObject({
+      pixel: true, full: true, format: "jpeg", quality: 80, target_max_long_edge: 1568, save: true,
+    })
+    expect(plan!.note).not.toContain("dropped")
+    expect(plan!.note).toContain("→ pixel")
+  })
+
+  test("the DOM-render error is preserved in the note (reason isn't lost)", () => {
+    const plan = planPixelFallback({ type: "screenshot" }, RENDER_FAIL)
+    expect(plan!.note).toContain("image load failed")
+  })
+
+  test("F1: unspecified format/quality default to the DOM path's PNG@92 (no silent downgrade)", () => {
+    // A bare `screenshot` that render-fails must fall back to a lossless PNG,
+    // not the pixel path's native JPEG@50 — the caller relied on DOM defaults.
+    const plan = planPixelFallback({ type: "screenshot" }, RENDER_FAIL)
+    expect(plan).not.toBeNull()
+    expect(plan!.pixelAction.format).toBe("png")
+    expect(plan!.pixelAction.quality).toBe(92)
+  })
+
+  test("F1: an explicit format/quality still wins over the PNG@92 default", () => {
+    const jpeg = planPixelFallback({ type: "screenshot", format: "jpeg", quality: 60 }, RENDER_FAIL)
+    expect(jpeg!.pixelAction.format).toBe("jpeg")
+    expect(jpeg!.pixelAction.quality).toBe(60)
+    // format without quality: honor the format, still supply the DOM default quality.
+    const webp = planPixelFallback({ type: "screenshot", format: "webp" }, RENDER_FAIL)
+    expect(webp!.pixelAction.format).toBe("webp")
+    expect(webp!.pixelAction.quality).toBe(92)
+  })
+})

--- a/test/transport-timeout-pick.test.ts
+++ b/test/transport-timeout-pick.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { pickTimeoutForAction, INTERCEPTOR_TIMEOUT_MS } from "../cli/transport"
+
+// pickTimeoutForAction chooses the CLI-side transport timeout per action.
+// EVERY screenshot gets a long ceiling aligned with the daemon's request
+// timeout: the --pixel path has no single SW cap, and the default DOM-render
+// path can auto-fall-back to the pixel path (DOM ≤30s THEN a full pixel
+// capture), so a 35s ceiling would race the combined fallback path. The SW
+// bounds its own stages; the CLI only needs to out-wait the worst case.
+
+describe("pickTimeoutForAction", () => {
+  const isLongCeiling = (t: number) => t > 35_000 && t < 180_000
+
+  test("default screenshot gets the long ceiling (can auto-fall-back to pixel)", () => {
+    expect(isLongCeiling(pickTimeoutForAction({ type: "screenshot" }))).toBe(true)
+    expect(isLongCeiling(pickTimeoutForAction({ type: "screenshot", pixel: false }))).toBe(true)
+  })
+
+  test("--pixel and --pixel --full get the long ceiling", () => {
+    expect(isLongCeiling(pickTimeoutForAction({ type: "screenshot", pixel: true }))).toBe(true)
+    expect(isLongCeiling(pickTimeoutForAction({ type: "screenshot", pixel: true, full: true }))).toBe(true)
+  })
+
+  test("the screenshot ceiling stays under the daemon's 180s request timeout", () => {
+    // Otherwise the CLI would outlive the daemon's own response and mask it.
+    expect(pickTimeoutForAction({ type: "screenshot" })).toBeLessThan(180_000)
+  })
+
+  test("macos overrides unchanged", () => {
+    expect(pickTimeoutForAction({ type: "macos_listen" })).toBe(60_000)
+    expect(pickTimeoutForAction({ type: "macos_vad" })).toBe(60_000)
+  })
+
+  test("unlisted actions fall back to the default timeout", () => {
+    expect(pickTimeoutForAction({ type: "tab_list" })).toBe(INTERCEPTOR_TIMEOUT_MS)
+  })
+})


### PR DESCRIPTION
Two gaps in the default screenshot path.

## Auto-fallback when the DOM renderer fails

The native DOM renderer returns a dead-end error when the serialized foreignObject SVG won't decode, which happens on some heavy real pages. Rather than surface that as a failure, the dispatcher now transparently retries via the pixel (`captureVisibleTab`) path so the default command still produces an image.

The gating and request shaping live in a pure `planPixelFallback()`, so it's tightly scoped:

- Only on a genuine render failure, tagged `fallbackEligible` on that branch. Not tab-not-found, restricted-page, or timeout errors, which a pixel retry can't fix and would only mask behind extra latency.
- Only for whole-page captures. region/clip/selector/element/ref are DOM-render-only concepts, and the pixel path would crop against the wrong origin and return a wrong image reported as success.
- It reconstructs an explicit full-page pixel request (`full:true`, the strip-and-stitch path), carries the options the pixel path can honor, and drops `--scale`, naming it in the fallback note.
- It defaults format/quality to the DOM path's PNG at quality 92 when the caller pinned neither. Without this, the pixel path's own defaults (JPEG at 50) would silently downgrade a capture that the DOM path would have returned lossless. An explicit `--format` or `--quality` still wins.

## Right-size the CLI timeout

A flat 45s keyed on the `screenshot` type cut a legit `--pixel --full` on a tall page mid-capture while the service worker kept working. Every screenshot now shares a 175s ceiling aligned with the daemon's 180s request timeout. This is required because the default path can auto-escalate to pixel (DOM up to 30s, then a full pixel capture).

## Verifying

`test/screenshot-pixel-fallback` covers the gating, request shaping, and the PNG@92 default. `test/transport-timeout-pick` covers the ceiling. Extension and host both typecheck clean.
