### PR TITLE
fix(tabs): pin tab_create to a normal window + tolerate group failures

### DIFF
--- a/extension/src/background/capabilities/tabs.ts
+++ b/extension/src/background/capabilities/tabs.ts
@@ -19,6 +19,29 @@ function sessionArea(): chrome.storage.StorageArea {
   return storage.session ?? chrome.storage.local
 }
 
+// Resolve a normal (groupable) window to birth a new tab in: the focused normal
+// window, else the first normal window, else create one. Without an explicit
+// windowId, chrome.tabs.create opens in whatever window last had focus — which
+// may be a popup, devtools, or app window, and tabs there can't be grouped
+// (chrome.tabs.group rejects with "Tabs can only be moved to and from normal
+// windows"). Returns undefined when chrome.windows is unavailable (MV2/Electron)
+// so the caller falls back to chrome.tabs.create's default placement.
+export async function resolveNormalWindowId(focusNew: boolean): Promise<number | undefined> {
+  if (!chrome.windows || typeof chrome.windows.getAll !== "function") return undefined
+  try {
+    const normal = await chrome.windows.getAll({ windowTypes: ["normal"] })
+    const existing = normal.find(w => w.focused)?.id ?? normal[0]?.id
+    if (existing !== undefined) return existing
+    if (typeof chrome.windows.create === "function") {
+      const created = await chrome.windows.create({ focused: focusNew })
+      return created?.id
+    }
+  } catch {
+    // fall through — let chrome.tabs.create pick a window
+  }
+  return undefined
+}
+
 export async function handleTabActions(
   action: { type: string; [key: string]: unknown },
   tabId: number
@@ -87,7 +110,14 @@ export async function handleTabActions(
       // --activate` is the explicit opt-in). Callers pass `action.active:
       // true` only when the new tab is genuinely meant to be foregrounded.
       const shouldActivate = (action.active as boolean | undefined) === true
-      const newTab = await chrome.tabs.create({ url: targetUrl, active: shouldActivate })
+      // Pin creation to a normal window so the tab is groupable (see
+      // resolveNormalWindowId). undefined windowId → chrome.tabs.create's default.
+      const targetWindowId = await resolveNormalWindowId(shouldActivate)
+      const newTab = await chrome.tabs.create({
+        url: targetUrl,
+        active: shouldActivate,
+        ...(targetWindowId !== undefined ? { windowId: targetWindowId } : {})
+      })
       if (newTab.id) {
         const groupId = group
           ? await addTabToNamedGroup(newTab.id, group, action.groupColor)

--- a/extension/src/background/tab-group.ts
+++ b/extension/src/background/tab-group.ts
@@ -6,6 +6,26 @@ function hasTabGroupApi(): boolean {
   return !!chrome.tabGroups && typeof chrome.tabGroups.query === "function"
 }
 
+/**
+ * True when a tab lives in a normal (groupable) window. Tab groups are
+ * window-scoped and chrome.tabs.group rejects with "Tabs can only be moved to
+ * and from normal windows" for popup/devtools/app windows. Grouping is a UX
+ * nicety, not a hard requirement — so when we can't confirm a normal window
+ * (lookup throws, or chrome.windows is unavailable in MV2/Electron) we assume
+ * groupable and let the guarded chrome.tabs.group call be the final arbiter.
+ */
+async function isTabInNormalWindow(tabId: number): Promise<boolean> {
+  if (!chrome.windows || typeof chrome.windows.get !== "function") return true
+  try {
+    const tab = await chrome.tabs.get(tabId)
+    if (tab.windowId === undefined) return true
+    const win = await chrome.windows.get(tab.windowId)
+    return win.type === undefined || win.type === "normal"
+  } catch {
+    return true
+  }
+}
+
 // --- Named per-agent groups ------------------------------------------------
 // Registry of label -> live groupId, mirrored to chrome.storage.session
 // ("namedTabGroups"). session lifetime matches tab-group-id lifetime exactly:
@@ -116,20 +136,28 @@ async function addTabToNamedGroupSerialized(
   colorOverride?: unknown
 ): Promise<number> {
   if (!hasTabGroupApi() || typeof chrome.tabs.group !== "function") return -1
+  // Skip grouping for non-normal windows rather than let chrome.tabs.group
+  // throw out of tab_create. The tab is still fully functional ungrouped.
+  if (!(await isTabInNormalWindow(tabId))) return -1
   let groupId = await ensureNamedGroup(label)
-  if (groupId === -1) {
-    groupId = await chrome.tabs.group({ tabIds: tabId })
-    const color = typeof colorOverride === "string" && (VALID_COLORS as readonly string[]).includes(colorOverride)
-      ? normalizeColor(colorOverride)
-      : colorForLabel(label)
-    await chrome.tabGroups.update(groupId, {
-      title: groupTitleFor(label),
-      color: color as `${chrome.tabGroups.Color}`,
-    })
-    namedGroups.set(label, groupId)
-    await persistNamedGroups()
-  } else {
-    await chrome.tabs.group({ tabIds: tabId, groupId })
+  try {
+    if (groupId === -1) {
+      groupId = await chrome.tabs.group({ tabIds: tabId })
+      const color = typeof colorOverride === "string" && (VALID_COLORS as readonly string[]).includes(colorOverride)
+        ? normalizeColor(colorOverride)
+        : colorForLabel(label)
+      await chrome.tabGroups.update(groupId, {
+        title: groupTitleFor(label),
+        color: color as `${chrome.tabGroups.Color}`,
+      })
+      namedGroups.set(label, groupId)
+      await persistNamedGroups()
+    } else {
+      await chrome.tabs.group({ tabIds: tabId, groupId })
+    }
+  } catch (err) {
+    console.warn(`addTabToNamedGroup: skipping group '${label}' (tab=${tabId}):`, err)
+    return -1
   }
   return groupId
 }
@@ -231,15 +259,25 @@ export function addTabToInterceptorGroup(tabId: number): Promise<number> {
 async function addTabToInterceptorGroupSerialized(tabId: number): Promise<number> {
   let groupId = await ensureInterceptorGroup()
   if (groupId === -1 && (!hasTabGroupApi() || typeof chrome.tabs.group !== "function")) return -1
-  if (groupId === -1) {
-    groupId = await chrome.tabs.group({ tabIds: tabId })
-    await chrome.tabGroups.update(groupId, {
-      title: getTabGroupTitle(),
-      color: getTabGroupColor() as `${chrome.tabGroups.Color}`,
-    })
-    interceptorGroupId = groupId
-  } else {
-    await chrome.tabs.group({ tabIds: tabId, groupId })
+  // Skip grouping for non-normal windows rather than let chrome.tabs.group
+  // throw out of tab_create. The tab is still fully functional ungrouped.
+  if (!(await isTabInNormalWindow(tabId))) return -1
+  try {
+    if (groupId === -1) {
+      groupId = await chrome.tabs.group({ tabIds: tabId })
+      await chrome.tabGroups.update(groupId, {
+        title: getTabGroupTitle(),
+        color: getTabGroupColor() as `${chrome.tabGroups.Color}`,
+      })
+      interceptorGroupId = groupId
+    } else {
+      await chrome.tabs.group({ tabIds: tabId, groupId })
+    }
+  } catch (err) {
+    // Cross-window group mismatch or transient failure — grouping is a UX
+    // nicety, so keep tab_create successful and skip the group.
+    console.warn(`addTabToInterceptorGroup: skipping group (tab=${tabId}):`, err)
+    return -1
   }
   return groupId
 }

--- a/test/tab-create-normal-window.test.ts
+++ b/test/tab-create-normal-window.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { resolveNormalWindowId } from "../extension/src/background/capabilities/tabs"
+
+// resolveNormalWindowId is the primary half of the tab_create fix: it pins a new
+// tab to a groupable *normal* window so chrome.tabs.group won't reject with
+// "Tabs can only be moved to and from normal windows". The tab-group resilience
+// suite covers the second half (grouping tolerates failure); this covers the
+// window selection itself — focused-normal preference, normal[0] fallback, the
+// create-a-window path, and the MV2/Electron and error-path undefined returns
+// (which make the caller fall back to chrome.tabs.create's default placement).
+
+const g = globalThis as unknown as { chrome?: unknown }
+let savedChrome: unknown
+
+type WindowStub = { id?: number; focused?: boolean }
+
+function installChromeMock(opts: {
+  windows?: "absent" | "no-getall"
+  getAll?: WindowStub[] | (() => never)
+  create?: WindowStub | (() => never)
+}) {
+  const calls = { getAll: 0, create: 0, createArgs: undefined as unknown }
+  let windows: unknown
+  if (opts.windows === "absent") {
+    windows = undefined
+  } else if (opts.windows === "no-getall") {
+    windows = {} // present but getAll not a function
+  } else {
+    windows = {
+      async getAll() {
+        calls.getAll++
+        if (typeof opts.getAll === "function") return (opts.getAll as () => never)()
+        return opts.getAll ?? []
+      },
+      ...(opts.create !== undefined
+        ? {
+            async create(args: unknown) {
+              calls.create++
+              calls.createArgs = args
+              if (typeof opts.create === "function") return (opts.create as () => never)()
+              return opts.create
+            },
+          }
+        : {}),
+    }
+  }
+  ;(g as { chrome: unknown }).chrome = { windows }
+  return calls
+}
+
+beforeEach(() => { savedChrome = g.chrome })
+afterEach(() => { (g as { chrome: unknown }).chrome = savedChrome })
+
+describe("resolveNormalWindowId", () => {
+  test("prefers the focused normal window", async () => {
+    installChromeMock({ getAll: [{ id: 1 }, { id: 2, focused: true }, { id: 3 }] })
+    expect(await resolveNormalWindowId(false)).toBe(2)
+  })
+
+  test("falls back to the first normal window when none is focused", async () => {
+    installChromeMock({ getAll: [{ id: 5 }, { id: 7 }] })
+    expect(await resolveNormalWindowId(false)).toBe(5)
+  })
+
+  test("creates a normal window when none exists, honoring the focus intent", async () => {
+    const calls = installChromeMock({ getAll: [], create: { id: 99 } })
+    expect(await resolveNormalWindowId(true)).toBe(99)
+    expect(calls.create).toBe(1)
+    expect(calls.createArgs).toEqual({ focused: true })
+  })
+
+  test("a background create is unfocused", async () => {
+    const calls = installChromeMock({ getAll: [], create: { id: 42 } })
+    await resolveNormalWindowId(false)
+    expect(calls.createArgs).toEqual({ focused: false })
+  })
+
+  test("returns undefined on MV2/Electron (chrome.windows absent) — default placement", async () => {
+    installChromeMock({ windows: "absent" })
+    expect(await resolveNormalWindowId(false)).toBeUndefined()
+  })
+
+  test("returns undefined when chrome.windows.getAll is not a function", async () => {
+    installChromeMock({ windows: "no-getall" })
+    expect(await resolveNormalWindowId(false)).toBeUndefined()
+  })
+
+  test("returns undefined when getAll throws (never propagates)", async () => {
+    installChromeMock({ getAll: () => { throw new Error("getAll blew up") } })
+    expect(await resolveNormalWindowId(false)).toBeUndefined()
+  })
+
+  test("returns undefined when create throws for an empty window list", async () => {
+    installChromeMock({ getAll: [], create: () => { throw new Error("create blew up") } })
+    expect(await resolveNormalWindowId(true)).toBeUndefined()
+  })
+})

--- a/test/tab-group-resilience.test.ts
+++ b/test/tab-group-resilience.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import {
+  addTabToInterceptorGroup,
+  addTabToNamedGroup,
+} from "../extension/src/background/tab-group"
+
+// tab_create must survive a grouping failure — grouping is a UX nicety, not a
+// hard requirement. Two failure modes are covered here:
+//   1. The new tab landed in a non-normal window (popup/devtools/app). Tab
+//      groups are window-scoped; chrome.tabs.group would reject with "Tabs can
+//      only be moved to and from normal windows". We must SKIP (return -1),
+//      never throw.
+//   2. chrome.tabs.group throws anyway (cross-window group mismatch, transient
+//      failure). Same contract: return -1, don't propagate.
+// Both the default (interceptor) group path and the named per-agent group path
+// must honour this — the named path is new upstream surface our original fix
+// never covered.
+
+type WindowType = "normal" | "popup" | "app" | "devtools"
+
+const g = globalThis as unknown as { chrome?: unknown }
+let savedChrome: unknown
+
+// Build a minimal chrome mock. `windowType` controls what chrome.windows.get
+// reports for the tab's window; `groupThrows` forces chrome.tabs.group to fail.
+function installChromeMock(opts: {
+  windowType: WindowType
+  groupThrows?: boolean
+}) {
+  const calls = { group: 0, update: 0 }
+  ;(g as { chrome: unknown }).chrome = {
+    tabs: {
+      get: async (_id: number) => ({ id: _id, windowId: 1 }),
+      async group() {
+        calls.group++
+        if (opts.groupThrows) throw new Error("Tabs can only be moved to and from normal windows")
+        return 4242
+      },
+    },
+    tabGroups: {
+      query: async () => [], // no existing group -> create path
+      get: async () => { throw new Error("no such group") },
+      async update() { calls.update++ },
+    },
+    windows: {
+      get: async (_id: number) => ({ id: _id, type: opts.windowType }),
+    },
+    storage: {}, // session area absent -> persistNamedGroups no-ops
+  }
+  return calls
+}
+
+beforeEach(() => { savedChrome = g.chrome })
+afterEach(() => { (g as { chrome: unknown }).chrome = savedChrome })
+
+describe("tab grouping resilience — default (interceptor) group", () => {
+  test("non-normal window: skips grouping without calling chrome.tabs.group", async () => {
+    const calls = installChromeMock({ windowType: "popup" })
+    const result = await addTabToInterceptorGroup(101)
+    expect(result).toBe(-1)
+    expect(calls.group).toBe(0)
+  })
+
+  test("chrome.tabs.group throwing is swallowed to -1 (tab_create survives)", async () => {
+    const calls = installChromeMock({ windowType: "normal", groupThrows: true })
+    const result = await addTabToInterceptorGroup(102)
+    expect(result).toBe(-1)
+    expect(calls.group).toBe(1) // it tried, then swallowed the throw
+  })
+
+  test("normal window, group succeeds: returns the group id", async () => {
+    installChromeMock({ windowType: "normal" })
+    const result = await addTabToInterceptorGroup(103)
+    expect(result).toBe(4242)
+  })
+})
+
+describe("tab grouping resilience — named per-agent group", () => {
+  test("non-normal window: skips grouping without calling chrome.tabs.group", async () => {
+    const calls = installChromeMock({ windowType: "devtools" })
+    const result = await addTabToNamedGroup(201, "ai1")
+    expect(result).toBe(-1)
+    expect(calls.group).toBe(0)
+  })
+
+  test("chrome.tabs.group throwing is swallowed to -1 (tab_create survives)", async () => {
+    const calls = installChromeMock({ windowType: "normal", groupThrows: true })
+    const result = await addTabToNamedGroup(202, "ai2")
+    expect(result).toBe(-1)
+    expect(calls.group).toBe(1)
+  })
+
+  test("normal window, group succeeds: returns the group id", async () => {
+    installChromeMock({ windowType: "normal" })
+    const result = await addTabToNamedGroup(203, "ai3")
+    expect(result).toBe(4242)
+  })
+})


### PR DESCRIPTION
## What's wrong

`tab_create` crashed with "Tabs can only be moved to and from normal windows". Without an explicit `windowId`, `chrome.tabs.create` opens the tab in whatever window last had focus. If that's a popup, devtools, or app window, `chrome.tabs.group` rejects, because tab groups only exist in normal windows.

## The fix

1. `tab_create` resolves a normal (groupable) window up front (the focused normal window, else the first, else it creates one) and passes that `windowId` to `chrome.tabs.create`.

2. Both group paths now skip grouping (return -1) instead of throwing when the tab is in a non-normal window, and wrap `chrome.tabs.group` in try/catch so a cross-window mismatch or a transient failure keeps `tab_create` successful. Grouping is a UX nicety, not a hard requirement. This covers both the default Interceptor group and the named per-agent group path.

A shared `isTabInNormalWindow` guard assumes groupable when `chrome.windows` is unavailable, so MV2/Electron falls back to default placement.

## Verifying

`test/tab-create-normal-window` covers window resolution: the focused-normal preference, the first-normal fallback, the create-a-window path, and the MV2 and error paths that return undefined. `test/tab-group-resilience` covers both grouping failure modes on both group paths. Extension typechecks clean.
