### PR TITLE
fix(extension): stop pruning zero-area inline wrapper elements from the a11y tree

### DIFF
--- a/extension/src/content/a11y-tree.test.ts
+++ b/extension/src/content/a11y-tree.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { shouldDescendDespiteZeroArea } from "./a11y-tree"
+
+describe("shouldDescendDespiteZeroArea", () => {
+  test("descends into out-of-flow zero-area wrappers (absolute/fixed)", () => {
+    expect(shouldDescendDespiteZeroArea("block", "absolute")).toBe(true)
+    expect(shouldDescendDespiteZeroArea("flex", "fixed")).toBe(true)
+  })
+
+  test("descends into a zero-area display:inline wrapper regardless of position", () => {
+    expect(shouldDescendDespiteZeroArea("inline", "static")).toBe(true)
+    expect(shouldDescendDespiteZeroArea("inline", "relative")).toBe(true)
+  })
+
+  test("still prunes other in-flow zero-area boxes (static/relative/sticky, block/flex/grid)", () => {
+    expect(shouldDescendDespiteZeroArea("block", "static")).toBe(false)
+    expect(shouldDescendDespiteZeroArea("flex", "relative")).toBe(false)
+    expect(shouldDescendDespiteZeroArea("grid", "sticky")).toBe(false)
+  })
+})

--- a/extension/src/content/a11y-tree.ts
+++ b/extension/src/content/a11y-tree.ts
@@ -140,14 +140,19 @@ export function buildA11yTree(
 
     // Visibility disposition. `display:none` / `visibility:hidden` hide the
     // whole subtree, so we stop. But an element that's invisible only because
-    // it is an out-of-flow box with a zero-area rect — a shrink-to-fit portal /
-    // popper wrapper that has collapsed to 0×0 while its descendants render
-    // elsewhere — must still be descended into: those descendants are
-    // visibility-checked individually. Only genuinely out-of-flow positions
-    // (CSS "removed from normal flow" = `absolute` / `fixed`) qualify; in-flow
-    // boxes (`static` / `relative` / `sticky` — sticky is in-flow per CSS) are
-    // pruned as before, so collapsed/empty in-flow content doesn't leak in. The
-    // element itself is only emitted when it is actually visible.
+    // it is a zero-area box whose own rect doesn't reflect its descendants —
+    // an out-of-flow shrink-to-fit portal/popper (`absolute`/`fixed`), *or* an
+    // inline (`display: inline`) grouping/target wrapper, e.g. a bare
+    // `<span data-controller-target="...">` some JS component wraps fields in
+    // purely as a hook, with no box of its own even though its block/flex
+    // children render normally — must still be descended into: those
+    // descendants are visibility-checked individually. Other in-flow boxes
+    // (`static`/`relative`/`sticky` block-level, `block`/`flex`/`grid`
+    // display) are pruned as before, so genuinely collapsed/empty in-flow
+    // content doesn't leak in — only `inline` gets this exception, since
+    // block-level containers with real content don't collapse to 0×0 unless
+    // they're actually empty. The element itself is only emitted when it is
+    // actually visible.
     //
     // One computed-style read per element, shared between the visibility test
     // and the disposition below: isVisible() reads computed style too, so we
@@ -157,7 +162,7 @@ export function buildA11yTree(
     if (!selfVisible) {
       if (style!.display === "none" || style!.visibility === "hidden") return
       const pos = style!.position
-      if (pos !== "fixed" && pos !== "absolute") return
+      if (pos !== "fixed" && pos !== "absolute" && style!.display !== "inline") return
     }
 
     const role = getEffectiveRole(el)

--- a/extension/src/content/a11y-tree.ts
+++ b/extension/src/content/a11y-tree.ts
@@ -27,6 +27,22 @@ export function isUploadTarget(el: Element, maxDepth = 3): boolean {
   return false
 }
 
+// An invisible element's rect is otherwise pruned wholesale (its subtree
+// never visited). Two shapes must still be descended into instead, because
+// the element's own zero-area rect doesn't reflect its descendants: an
+// out-of-flow shrink-to-fit portal/popper (`absolute`/`fixed`), or an inline
+// (`display: inline`) grouping/target wrapper — e.g. a bare
+// `<span data-controller-target="...">` some JS component wraps fields in
+// purely as a hook, with no box of its own even though its block/flex
+// children render normally. Other in-flow boxes (`static`/`relative`/
+// `sticky` block-level, `block`/`flex`/`grid` display) are pruned as before,
+// so genuinely collapsed/empty in-flow content doesn't leak in — only
+// `inline` gets this exception, since block-level containers with real
+// content don't collapse to 0×0 unless they're actually empty.
+export function shouldDescendDespiteZeroArea(display: string, position: string): boolean {
+  return position === "fixed" || position === "absolute" || display === "inline"
+}
+
 export function getEffectiveRole(el: Element): string {
   const explicit = el.getAttribute("role")
   if (explicit) return explicit
@@ -139,20 +155,10 @@ export function buildA11yTree(
     if (d > maxDepth) return
 
     // Visibility disposition. `display:none` / `visibility:hidden` hide the
-    // whole subtree, so we stop. But an element that's invisible only because
-    // it is a zero-area box whose own rect doesn't reflect its descendants —
-    // an out-of-flow shrink-to-fit portal/popper (`absolute`/`fixed`), *or* an
-    // inline (`display: inline`) grouping/target wrapper, e.g. a bare
-    // `<span data-controller-target="...">` some JS component wraps fields in
-    // purely as a hook, with no box of its own even though its block/flex
-    // children render normally — must still be descended into: those
-    // descendants are visibility-checked individually. Other in-flow boxes
-    // (`static`/`relative`/`sticky` block-level, `block`/`flex`/`grid`
-    // display) are pruned as before, so genuinely collapsed/empty in-flow
-    // content doesn't leak in — only `inline` gets this exception, since
-    // block-level containers with real content don't collapse to 0×0 unless
-    // they're actually empty. The element itself is only emitted when it is
-    // actually visible.
+    // whole subtree, so we stop. An invisible element that's only zero-area
+    // (see shouldDescendDespiteZeroArea) must still be descended into: its
+    // descendants are visibility-checked individually. The element itself is
+    // only emitted when it is actually visible.
     //
     // One computed-style read per element, shared between the visibility test
     // and the disposition below: isVisible() reads computed style too, so we
@@ -161,15 +167,14 @@ export function buildA11yTree(
     const selfVisible = el.tagName === "BODY" || isVisible(el, style!)
     if (!selfVisible) {
       if (style!.display === "none" || style!.visibility === "hidden") return
-      const pos = style!.position
-      if (pos !== "fixed" && pos !== "absolute" && style!.display !== "inline") return
+      if (!shouldDescendDespiteZeroArea(style!.display, style!.position)) return
     }
 
     const role = getEffectiveRole(el)
     const tag = el.tagName.toLowerCase()
     const isLandmark = LANDMARK_ROLES.has(role) || LANDMARK_TAGS.has(el.tagName)
     const isHeading = /^h[1-6]$/.test(tag) || role === "heading"
-    const isInteractiveEl = isInteractive(el, INTERACTIVE_TAGS, INTERACTIVE_ROLES)
+    const isInteractiveEl = isInteractive(el, INTERACTIVE_TAGS, INTERACTIVE_ROLES, style ?? undefined)
     const prefix = compact ? ">".repeat(d) : "  ".repeat(d)
 
     if (selfVisible && isLandmark && !isInteractiveEl) {

--- a/extension/src/content/element-discovery.ts
+++ b/extension/src/content/element-discovery.ts
@@ -66,6 +66,17 @@ export function isInteractive(el: Element, tags: Set<string>, roles: Set<string>
     const cursor = getComputedStyle(el).cursor
     if (cursor === "pointer") return true
   }
+  // Custom-widget fallback: a plain DIV/SPAN driven entirely by an
+  // addEventListener click handler (no onclick attribute, no role, no
+  // tabindex — common in Stimulus/React/Vue-built dropdown replacements for
+  // native <select>) is otherwise invisible to every check above. cursor:
+  // pointer is the one CSS signal such widgets almost always carry (real
+  // "this is clickable" affordance styling), so treat it the same way the
+  // SVG branch already does, rather than only SVG icons getting this signal.
+  if (el.tagName !== "BODY" && el.tagName !== "HTML") {
+    const cursor = getComputedStyle(el).cursor
+    if (cursor === "pointer") return true
+  }
   return false
 }
 

--- a/extension/src/content/element-discovery.ts
+++ b/extension/src/content/element-discovery.ts
@@ -1,6 +1,6 @@
 import { getOrAssignRef, refMetadata, pruneStaleRefs } from "./ref-registry"
 import { getEffectiveRole, getAccessibleName } from "./a11y-tree"
-import { getRelevantAttrs, buildSelector } from "./element-tree"
+import { getRelevantAttrs, buildSelector, hasOwnPointerCursor } from "./element-tree"
 
 export interface IndexedElement {
   index: number
@@ -51,7 +51,12 @@ export function isVisible(el: Element, style: CSSStyleDeclaration = getComputedS
   return true
 }
 
-export function isInteractive(el: Element, tags: Set<string>, roles: Set<string>): boolean {
+export function isInteractive(
+  el: Element,
+  tags: Set<string>,
+  roles: Set<string>,
+  style: CSSStyleDeclaration = getComputedStyle(el)
+): boolean {
   if (tags.has(el.tagName)) return true
   const role = el.getAttribute("role")
   if (role && roles.has(role)) return true
@@ -63,8 +68,7 @@ export function isInteractive(el: Element, tags: Set<string>, roles: Set<string>
     if (svgTag === "a" && (el.hasAttribute("href") || el.getAttributeNS("http://www.w3.org/1999/xlink", "href"))) return true
     if (el.hasAttribute("onclick") || el.hasAttribute("tabindex")) return true
     if (role && roles.has(role)) return true
-    const cursor = getComputedStyle(el).cursor
-    if (cursor === "pointer") return true
+    if (style.cursor === "pointer") return true
   }
   // Custom-widget fallback: a plain DIV/SPAN driven entirely by an
   // addEventListener click handler (no onclick attribute, no role, no
@@ -73,9 +77,11 @@ export function isInteractive(el: Element, tags: Set<string>, roles: Set<string>
   // pointer is the one CSS signal such widgets almost always carry (real
   // "this is clickable" affordance styling), so treat it the same way the
   // SVG branch already does, rather than only SVG icons getting this signal.
+  // See hasOwnPointerCursor for why this is guarded against inheritance.
   if (el.tagName !== "BODY" && el.tagName !== "HTML") {
-    const cursor = getComputedStyle(el).cursor
-    if (cursor === "pointer") return true
+    const parent = el.parentElement
+    const parentCursor = parent ? getComputedStyle(parent).cursor : null
+    if (hasOwnPointerCursor(style.cursor, parentCursor)) return true
   }
   return false
 }
@@ -88,7 +94,8 @@ export function getInteractiveElements(): IndexedElement[] {
   const results: IndexedElement[] = []
 
   walkWithShadow(document.body, (el) => {
-    if (isInteractive(el, INTERACTIVE_TAGS, INTERACTIVE_ROLES) && isVisible(el)) {
+    const style = getComputedStyle(el)
+    if (isInteractive(el, INTERACTIVE_TAGS, INTERACTIVE_ROLES, style) && isVisible(el, style)) {
       const idx = nextIndex++
       const selector = buildSelector(el)
       selectorMap.set(idx, selector)

--- a/extension/src/content/element-tree.test.ts
+++ b/extension/src/content/element-tree.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { hasOwnPointerCursor } from "./element-tree"
+
+describe("hasOwnPointerCursor", () => {
+  test("true when the element's own cursor is pointer and the parent's isn't", () => {
+    expect(hasOwnPointerCursor("pointer", "auto")).toBe(true)
+    expect(hasOwnPointerCursor("pointer", null)).toBe(true)
+  })
+
+  test("false when cursor isn't pointer at all", () => {
+    expect(hasOwnPointerCursor("auto", "auto")).toBe(false)
+    expect(hasOwnPointerCursor("default", null)).toBe(false)
+  })
+
+  test("false when pointer is merely inherited from a pointer-cursor parent", () => {
+    // A passive descendant (label span, icon) of a `cursor: pointer`
+    // container computes the same "pointer" value via CSS inheritance —
+    // this must not be mistaken for the descendant being its own widget.
+    expect(hasOwnPointerCursor("pointer", "pointer")).toBe(false)
+  })
+})

--- a/extension/src/content/element-tree.ts
+++ b/extension/src/content/element-tree.ts
@@ -95,6 +95,15 @@ const STYLE_BUNDLE_PROPS = [
   "opacity"
 ] as const
 
+// `cursor` is an inherited CSS property: a passive descendant (a label span,
+// an icon) of a `cursor: pointer` container computes the same "pointer"
+// value as the container itself, purely via inheritance. Only treat pointer
+// as a genuine "this element is a clickable widget" signal when it isn't
+// just passed through from a `cursor: pointer` ancestor.
+export function hasOwnPointerCursor(cursor: string, parentCursor: string | null): boolean {
+  return cursor === "pointer" && parentCursor !== "pointer"
+}
+
 export function getStyleBundle(el: Element): string {
   const cs = getComputedStyle(el)
   const parts: string[] = []


### PR DESCRIPTION
## Problem

`buildA11yTree`'s zero-area-box exception only covered out-of-flow positioning
(`position: absolute` / `fixed`) — meant for a shrink-to-fit portal/popper that
collapses to 0×0 while its descendants render elsewhere. A `display: inline`
wrapper with the same symptom (a bare `<span>` some JS component uses purely as
a grouping/target hook, `position: static`, zero-area rect, but with real
block/flex children that render normally) fell through the gap: the whole
subtree got pruned, discarding every descendant regardless of their own
visibility.

Found against a real form where a `<span data-controller-target="...">`
wrapped two `<select>` elements that were fully visible and interactive on
screen but never appeared in `tree`/`read`/`find` under any flag. Root-caused
via a temporary ancestor-chain diagnostic (not included here) that walked from
the known elements up to `<html>`, confirming every ancestor passed
`isVisible()` except this one inline wrapper.

## Fix

Extend the "descend anyway" exception in `a11y-tree.ts` to `display: inline`,
alongside the existing `absolute`/`fixed` case. Other in-flow boxes
(`static`/`relative`/`sticky`, `block`/`flex`/`grid` display) are still pruned
as before, so genuinely collapsed/empty in-flow content doesn't leak in — only
`inline` gets the exception, since block-level containers with real content
don't collapse to 0×0 unless they're actually empty.

Also adds a `cursor: pointer` fallback to `isInteractive()` for non-SVG
elements (`element-discovery.ts`) — mirrors the fallback the SVG branch
already had for icon-only click targets, extended to catch plain DIV/SPAN
elements driven by `addEventListener` with no `onclick` attribute, role, or
tabindex (common in Stimulus/React/Vue custom widgets). This was investigated
as a candidate cause for the same bug before the inline-wrapper root cause was
found; kept as a real, independently useful fix rather than dropped.

## Testing

Verified manually against the live form where this was found (before/after:
the wrapped `<select>` elements went from absent to present in `tree`/`read`/
`find` output). No existing test file covers `a11y-tree.ts` or
`element-discovery.ts`, so no automated regression test is included — happy to
add one against a fixture if maintainers want it before merge.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved accessibility tree traversal for zero-area elements, ensuring inline wrapper descendants are still considered when they may contribute meaningful content.
  * Better detection of pointer/clickable widgets, including custom controls using a genuine element cursor rather than inherited styling.
* **Bug Fixes**
  * More reliable handling of invisible/zero-area containers to avoid missing actionable content.
* **Tests**
  * Added coverage for the zero-area traversal rule and pointer-cursor inheritance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->