### PR TITLE
fix(windows): stop skills adopt --force deleting a case-colliding skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ extension/dist/
 extension/dist-safari/
 daemon/interceptor-daemon
 daemon/*.exe
+# Live images moved aside by build.sh's prepare_windows_outputs (Windows locks a
+# running .exe against write/delete but allows rename). Reaped on a later build.
+daemon/*.exe.old-*
 daemon/.generated/
 *.log
 /tmp/

--- a/README.md
+++ b/README.md
@@ -1358,6 +1358,18 @@ The skill packages mirror the surface split:
 - [`.agents/skills/interceptor/`](.agents/skills/interceptor/) — thin index skill: surface decision table + pointers. Kept as a compatibility shim for one release.
 - `.agents/skills/interceptor-windows/` — **reserved path, not yet created.** Slot for the future Windows surface; do not create until the surface ships.
 
+`interceptor skills adopt` links these into whichever AI runtimes it detects, and `interceptor skills status` reports one state per skill per runtime:
+
+| State | Meaning | What `adopt` does |
+|---|---|---|
+| `linked` | Symlink (junction on Windows) already resolves to this pack's skill | nothing |
+| `missing` | Nothing at that path | creates the link |
+| `foreign` | A symlink pointing somewhere else, or a dangling one | replaces it — `ln -sfn` semantics destroy no data |
+| `stale-copy` | A real directory, e.g. a physical copy from an older install | skipped; `--force` replaces it |
+| `name-collision` | A directory whose name differs from the skill's **only by case** | skipped, and **`--force` will not touch it either** |
+
+`name-collision` exists because Windows and default-configured APFS are case-insensitive: `lstat` on `skills/interceptor` happily resolves an unrelated `skills/Interceptor/` that another author hand-wrote, which `--force` would then delete. `readdir` reports the true casing, so the two are distinguishable. Rename or remove the existing directory yourself if you want this pack's skill linked there.
+
 ## Architecture Notes
 
 No CDP is used for any default operation on the browser surface. Network capture is done by monkey-patching `fetch`/`XHR` in the page's JavaScript context — operating fully in user-space rather than via the debugger protocol. The macOS surface uses Apple-blessed APIs only (Accessibility, ScreenCaptureKit, AVFoundation, Speech, Vision, NaturalLanguage, OSLogStore, NSAppleScript, container runtime). Both surfaces multiplex over the same `interceptor` daemon Unix socket — see [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full transport diagram.

--- a/cli/commands/skills.ts
+++ b/cli/commands/skills.ts
@@ -9,7 +9,10 @@
  * in the wild: a ~/.codex/skills/interceptor copy six weeks behind the pkg).
  *
  * Per-skill selection, whole-folder links: one symlink per skill directory.
- * A real directory at the destination is NEVER replaced without --force.
+ * A real directory at the destination is NEVER replaced without --force, and a
+ * directory whose name differs from the skill's only by case is never replaced
+ * at all — on a case-insensitive filesystem that destination belongs to someone
+ * else (see classifyLink / "name-collision").
  */
 
 import {
@@ -25,7 +28,7 @@ const SKILLS_REFRESH_MARKER_DARWIN = "/Library/Application Support/Interceptor/.
 const HINT_FLAG_FILE = join(tmpdir(), "interceptor-skills-hint.flag")
 const HINT_WINDOW_MS = 24 * 60 * 60 * 1000
 
-export type LinkState = "linked" | "stale-copy" | "foreign" | "missing"
+export type LinkState = "linked" | "stale-copy" | "foreign" | "name-collision" | "missing"
 
 export type SkillTarget = {
   id: string
@@ -110,10 +113,33 @@ export function detectedTargets(home = homedir(), env: Record<string, string | u
 
 // ── classification ────────────────────────────────────────────────────────────
 
+/**
+ * The name the destination directory actually holds on disk, or null when
+ * nothing there matches. Windows and default-configured APFS are
+ * case-INSENSITIVE, so `lstat(".../skills/interceptor")` happily resolves an
+ * on-disk `Interceptor/` belonging to someone else. `readdir` reports the true
+ * casing, which is the only way to tell the two apart.
+ */
+function onDiskEntryName(targetDir: string, skillName: string): string | null {
+  try {
+    const entries = readdirSync(targetDir)
+    if (entries.includes(skillName)) return skillName
+    const lower = skillName.toLowerCase()
+    return entries.find(e => e.toLowerCase() === lower) ?? null
+  } catch {
+    return null
+  }
+}
+
 export function classifyLink(targetDir: string, skillName: string, srcDir: string): LinkState {
   const dst = join(targetDir, skillName)
   let st
   try { st = lstatSync(dst) } catch { return "missing" }
+  // A hit whose real casing differs is a DIFFERENT skill that the filesystem
+  // merely folded onto our name. We never created it (link names always come
+  // from the pack's own readdir), so we must not unlink or delete it.
+  const actual = onDiskEntryName(targetDir, skillName)
+  if (actual && actual !== skillName) return "name-collision"
   if (st.isSymbolicLink()) {
     try {
       if (realpathSync(dst) === realpathSync(srcDir)) return "linked"
@@ -130,6 +156,8 @@ export type AdoptResult = {
   target: string
   skill: string
   action: "linked" | "already-linked" | "skipped" | "replaced-copy" | "error"
+  /** Pre-adopt classification. Two skips are not the same: only "stale-copy" is --force-able. */
+  state?: LinkState
   detail?: string
 }
 
@@ -192,6 +220,16 @@ export function adoptSkill(target: SkillTarget, skill: SkillInfo, force: boolean
   try {
     mkdirSync(target.dir, { recursive: true })
     if (state === "linked") return { target: target.id, skill: skill.name, action: "already-linked" }
+    if (state === "name-collision") {
+      // Not force-overridable by design: on a case-insensitive filesystem the
+      // colliding directory is another author's skill, and --force would rmSync
+      // hand-edited work with no recovery path.
+      const actual = onDiskEntryName(target.dir, skill.name)
+      return {
+        target: target.id, skill: skill.name, action: "skipped", state,
+        detail: `${join(target.dir, actual ?? skill.name)} already exists with different casing — a separate skill, not a stale copy of '${skill.name}'. Not replaced (not even with --force). Rename or remove it yourself if you want this one linked.`,
+      }
+    }
     if (state === "foreign") {
       // ln -sfn semantics: replacing a symlink (even one pointing elsewhere)
       // destroys no data — the target directory is untouched.
@@ -199,7 +237,7 @@ export function adoptSkill(target: SkillTarget, skill: SkillInfo, force: boolean
     } else if (state === "stale-copy") {
       if (!force) {
         return {
-          target: target.id, skill: skill.name, action: "skipped",
+          target: target.id, skill: skill.name, action: "skipped", state,
           detail: `${dst} is a real directory (stale copy?) — re-run with --force to replace it with a link`,
         }
       }
@@ -260,7 +298,9 @@ export function maybeEmitSkillsHint(argv: string[], env: Record<string, string |
     if (!summary.packDir || summary.targets.length === 0) return
     const gaps: string[] = []
     for (const t of summary.targets) {
-      const unlinked = Object.entries(t.states).filter(([, st]) => st !== "linked")
+      // name-collision is excluded: `adopt` will never link it, so counting it
+      // here would nag every 24h about something the suggested command can't fix.
+      const unlinked = Object.entries(t.states).filter(([, st]) => st !== "linked" && st !== "name-collision")
       if (unlinked.length > 0) {
         gaps.push(`${t.id}: ${unlinked.length} of ${t.total} not linked`)
       }
@@ -337,6 +377,10 @@ export function runSkillsCommand(filtered: string[], jsonMode: boolean): null {
       console.log(`${t.id} (${t.dir}): ${t.linked}/${t.total} linked`)
       for (const [name, st] of Object.entries(t.states)) {
         console.log(`  ${st === "linked" ? "✓" : st === "missing" ? "·" : "!"} ${name}: ${st}`)
+        if (st === "name-collision") {
+          const actual = onDiskEntryName(t.dir, name)
+          console.log(`      '${actual}' already occupies this name (case-only difference) — adopt leaves it alone, --force included`)
+        }
       }
     }
     return null
@@ -424,8 +468,11 @@ export function runSkillsCommand(filtered: string[], jsonMode: boolean): null {
         const mark = r.action === "error" ? "✗" : r.action === "skipped" ? "!" : "✓"
         console.log(`${mark} ${r.target}/${r.skill}: ${r.action}${r.detail ? ` — ${r.detail}` : ""}`)
       }
-      const skipped = results.filter(r => r.action === "skipped").length
-      if (skipped) console.log(`\n${skipped} destination(s) were real directories — re-run with --force to replace them with links.`)
+      const staleCopies = results.filter(r => r.action === "skipped" && r.state === "stale-copy").length
+      const collisions = results.filter(r => r.action === "skipped" && r.state === "name-collision").length
+      if (staleCopies) console.log(`\n${staleCopies} destination(s) were real directories — re-run with --force to replace them with links.`)
+      // Deliberately not offered as a --force candidate: --force refuses these.
+      if (collisions) console.log(`\n${collisions} destination(s) collide with an existing skill by case only. --force will not touch them — rename or remove the existing directory first.`)
     }
     if (results.some(r => r.action === "error")) process.exit(1)
     return null

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -435,7 +435,7 @@ Meta:
   interceptor help [<command>|--all]         Concise help / one command's contract / the full reference
   interceptor manifest                       Machine-readable capability manifest (verbs, flags, returns, skills)
   interceptor skills list                    Skill packs shipped with this install + adoption state
-  interceptor skills status                  Per-runtime link state (linked / stale-copy / foreign / missing)
+  interceptor skills status                  Per-runtime link state (linked / stale-copy / foreign / name-collision / missing)
   interceptor skills show <name>             One skill's purpose + which text verb returns what
   interceptor skills adopt [names…] [--into claude,codex,agents] [--all] [--force]
                                              Symlink skill packs into AI runtimes (junctions on Windows)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -249,6 +249,55 @@ build_macos() {
   bun build daemon/index.ts --compile --target=bun-darwin-arm64 --outfile=daemon/interceptor-daemon
 }
 
+# Windows keeps a mandatory write lock on a running .exe, so `bun build
+# --compile` over a live binary fails with a bare EPERM. This MUST run before the
+# first compile: build_host writes the CLI first (bun appends .exe on a Windows
+# host), so a locked daemon would otherwise leave a freshly-built CLI beside a
+# stale daemon — a half-updated pair that reads as a clean build (`set -e` does
+# exit 1, but the CLI on disk is already new, and the two then disagree on
+# protocol).
+#
+# taskkill is NOT the remedy: the daemon is a browser-launched native-messaging
+# host, so the browser respawns it within a second (measured — five kills in a
+# row never yielded an unlocked window). What DOES work is what Inno's Restart
+# Manager path does: the lock forbids write and delete but permits RENAME, so the
+# live image is moved aside and the compile writes a fresh file at the original
+# path. The sidelined copy keeps running until its browser drops it, and is
+# ignored by git (dist/ is wholly ignored; daemon/*.exe.old-* is an explicit rule
+# because daemon/*.exe does NOT match a .exe.old-NNN suffix).
+prepare_windows_outputs() {
+  local out bak stuck=()
+  for out in dist/interceptor.exe daemon/interceptor-daemon.exe; do
+    [[ -f "$out" ]] || continue
+    # Append zero bytes: opens for write without changing content. A running
+    # image refuses it; nothing else here does.
+    if (printf '' >> "$out") 2>/dev/null; then
+      continue
+    fi
+    # Reap earlier sidelined copies whose holder has since exited. Done BEFORE
+    # the rename below so the glob cannot match the copy we are about to create;
+    # still-locked ones simply refuse deletion and are left for the next run.
+    rm -f "${out}.old-"* 2>/dev/null || true
+    bak="${out}.old-$$"
+    if mv "$out" "$bak" 2>/dev/null; then
+      echo "  note: $out was locked by a running process — moved aside to $bak"
+    else
+      stuck+=("$out")
+    fi
+  done
+  if [[ ${#stuck[@]} -eq 0 ]]; then
+    return 0
+  fi
+  echo "" >&2
+  echo "ERROR: Windows build target(s) are locked and could not be moved aside:" >&2
+  for out in "${stuck[@]}"; do echo "  $out" >&2; done
+  echo "" >&2
+  echo "       Close the browser that owns the native-messaging host (the daemon is" >&2
+  echo "       respawned on demand, so taskkill alone will not free it), then re-run." >&2
+  echo "       Stopped before compiling so you don't get a new CLI beside a stale daemon." >&2
+  exit 1
+}
+
 build_windows_arch() {
   local arch="$1"
   local bun_target stage identity_flag
@@ -302,6 +351,16 @@ build_bridge() {
   echo "Building interceptor-bridge (macOS native)..."
   bash scripts/build-bridge.sh
 }
+
+# Preflight before any bundling: a locked .exe is a user-fixable condition, and
+# there is no point spending an extension build to discover it. The trigger is the
+# host target (the default) plus --all, because build_host is what writes
+# dist/interceptor.exe and daemon/interceptor-daemon.exe on a Windows host. The
+# windows-x64 / windows-arm64 targets stage into dist/windows/<arch>/ instead and
+# are not covered here.
+if [[ "$BUILD_ALL" == "1" || "$TARGET" == "host" ]]; then
+  prepare_windows_outputs
+fi
 
 if [[ "$BUILD_ALL" == "1" ]]; then
   build_extension

--- a/test/skills-adopt.test.ts
+++ b/test/skills-adopt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, lstatSync, realpathSync, symlinkSync } from "node:fs"
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, lstatSync, realpathSync, symlinkSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -18,6 +18,32 @@ function makeSkill(name: string): SkillInfo {
 
 function target(): SkillTarget {
   return { id: "claude", label: "Claude Code", parent: join(root, ".claude"), dir: targetDir }
+}
+
+/**
+ * Directory link matching what adoptSkill creates. Bare symlinkSync needs
+ * Developer Mode or elevation on Windows and otherwise throws EPERM; junctions
+ * need neither, which is why the implementation uses them there.
+ */
+function link(src: string, dst: string): void {
+  symlinkSync(src, dst, process.platform === "win32" ? "junction" : undefined)
+}
+
+/**
+ * Probed, not inferred from process.platform: macOS APFS is case-insensitive by
+ * default but can be formatted case-sensitive, and Linux can mount either way.
+ */
+function caseInsensitiveFs(): boolean {
+  const probe = join(root, "CaseProbe")
+  mkdirSync(probe, { recursive: true })
+  try {
+    lstatSync(join(root, "caseprobe"))
+    return true
+  } catch {
+    return false
+  } finally {
+    rmSync(probe, { recursive: true, force: true })
+  }
 }
 
 beforeEach(() => {
@@ -51,7 +77,7 @@ describe("classifyLink", () => {
   test("linked when symlink resolves to the pack skill", () => {
     const s = makeSkill("a")
     mkdirSync(targetDir, { recursive: true })
-    symlinkSync(s.dir, join(targetDir, "a"))
+    link(s.dir, join(targetDir, "a"))
     expect(classifyLink(targetDir, "a", s.dir)).toBe("linked")
   })
 
@@ -59,7 +85,7 @@ describe("classifyLink", () => {
     const s = makeSkill("a")
     const other = makeSkill("b")
     mkdirSync(targetDir, { recursive: true })
-    symlinkSync(other.dir, join(targetDir, "a"))
+    link(other.dir, join(targetDir, "a"))
     expect(classifyLink(targetDir, "a", s.dir)).toBe("foreign")
   })
 
@@ -68,6 +94,32 @@ describe("classifyLink", () => {
     mkdirSync(join(targetDir, "a"), { recursive: true })
     writeFileSync(join(targetDir, "a", "SKILL.md"), "old copy")
     expect(classifyLink(targetDir, "a", s.dir)).toBe("stale-copy")
+  })
+
+  test("name-collision when the on-disk entry differs only by case", () => {
+    const s = makeSkill("interceptor")
+    // Someone else's skill, capital I. On Windows / default APFS the lstat for
+    // ".../interceptor" resolves this directory; readdir reports the true name.
+    mkdirSync(join(targetDir, "Interceptor"), { recursive: true })
+    writeFileSync(join(targetDir, "Interceptor", "SKILL.md"), "hand-authored, unstaged")
+    const state = classifyLink(targetDir, "interceptor", s.dir)
+    if (caseInsensitiveFs()) {
+      expect(state).toBe("name-collision")
+    } else {
+      // Case-sensitive FS: the two names never collide, so nothing is at ours.
+      expect(state).toBe("missing")
+    }
+  })
+
+  test("exact-case match still classifies normally when a case variant exists too", () => {
+    const s = makeSkill("a")
+    mkdirSync(targetDir, { recursive: true })
+    link(s.dir, join(targetDir, "a"))
+    // Only meaningful where both can coexist; skip where the FS folds them.
+    if (!caseInsensitiveFs()) {
+      mkdirSync(join(targetDir, "A"), { recursive: true })
+    }
+    expect(classifyLink(targetDir, "a", s.dir)).toBe("linked")
   })
 })
 
@@ -90,7 +142,7 @@ describe("adoptSkill", () => {
     const s = makeSkill("a")
     const other = makeSkill("b")
     mkdirSync(targetDir, { recursive: true })
-    symlinkSync(other.dir, join(targetDir, "a"))
+    link(other.dir, join(targetDir, "a"))
     const r = adoptSkill(target(), s, false)
     expect(r.action).toBe("linked")
     expect(realpathSync(join(targetDir, "a"))).toBe(realpathSync(s.dir))
@@ -112,6 +164,28 @@ describe("adoptSkill", () => {
     const r = adoptSkill(target(), s, true)
     expect(r.action).toBe("replaced-copy")
     expect(lstatSync(join(targetDir, "a")).isSymbolicLink()).toBe(true)
+  })
+
+  test("--force NEVER deletes a case-only collision (another author's skill)", () => {
+    if (!caseInsensitiveFs()) return
+    const s = makeSkill("interceptor")
+    mkdirSync(join(targetDir, "Interceptor"), { recursive: true })
+    writeFileSync(join(targetDir, "Interceptor", "SKILL.md"), "hand-authored, unstaged")
+    const r = adoptSkill(target(), s, true)
+    expect(r.action).toBe("skipped")
+    expect(r.state).toBe("name-collision")
+    // The precious file survives — this is the whole point of the state.
+    expect(readFileSync(join(targetDir, "Interceptor", "SKILL.md"), "utf-8")).toBe("hand-authored, unstaged")
+  })
+
+  test("skip detail distinguishes a --force-able stale copy from a collision", () => {
+    const stale = makeSkill("a")
+    mkdirSync(join(targetDir, "a"), { recursive: true })
+    expect(adoptSkill(target(), stale, false).detail).toContain("--force")
+    if (!caseInsensitiveFs()) return
+    const collide = makeSkill("interceptor")
+    mkdirSync(join(targetDir, "Interceptor"), { recursive: true })
+    expect(adoptSkill(target(), collide, true).detail).toContain("not even with --force")
   })
 })
 


### PR DESCRIPTION
`interceptor skills adopt --force` deleted a skill it did not own, on Windows and on any case-insensitive macOS volume. This adds a link state that `--force` refuses, and a build fix for the lock that made this hard to iterate on.

## The bug

The pack ships a skill named `interceptor` (lowercase). I had an unrelated, hand-written `~/.claude/skills/Interceptor/` (capital I). Windows resolves paths case-insensitively, so `lstatSync(".../skills/interceptor")` returned my `Interceptor` directory. `classifyLink` saw a real directory and called it `stale-copy`, `status` printed the `skills adopt` hint, the skip detail said "re-run with --force to replace it", and `--force` then ran `rmSync(dst, { recursive: true })` over eight hand-edited files.

APFS is case-insensitive by default, so my read is that this is not Windows-only, though I could not test it there. `lstat` cannot distinguish the two directories. `readdir` reports the true casing, which is the only way to tell them apart.

## The fix

`classifyLink` gains a `name-collision` state: it compares the `readdir` entry's real casing against the requested skill name, and `adoptSkill` refuses that state **even with `--force`**. The reasoning is that on a case-folding filesystem the colliding directory belongs to someone else, so there is no correct forced behaviour - only rename or remove it yourself.

Three smaller things follow:

- The adopt summary splits its two skip reasons apart. It used to offer `--force` for every skip, including the one `--force` now refuses.
- The 24h skills hint stops counting `name-collision`, since the command it suggests will never fix it.
- `status` prints a second line explaining the state, because "name-collision" alone does not tell you what to do.

No `process.platform` anywhere in the new code. The tests probe the filesystem at runtime with a `CaseProbe` directory rather than guessing from the platform, since APFS can be formatted case-sensitive and Linux can be mounted either way.

## Windows build lock

Separate problem, same branch. `bash scripts/build.sh --target=windows` died with a bare `EPERM` whenever the daemon was running. Windows holds a mandatory lock on a running `.exe`, and `build_windows` compiles the CLI first, so the run left a fresh CLI beside a stale daemon. `set -e` exits 1, but the two binaries on disk then disagree on protocol - it reads as a clean build.

`taskkill` is not the remedy, and I tested that before writing the fix: the daemon is a browser-launched native-messaging host, so the browser respawns it. Five consecutive kills polled at one-second intervals never produced an unlocked moment.

Inno's Restart Manager takes the other route, and it works. The lock forbids write and delete but permits **rename**, so `prepare_windows_outputs` moves the live image aside to `daemon/interceptor-daemon.exe.old-<pid>` and the compile writes a fresh file at the original path. The sidelined copy should keep serving its browser until that browser drops it, and a later build reaps it; I confirmed the rename and the fresh compile, not the full lifetime of the displaced image. It runs as a preflight before the extension builds too, since a locked binary is user-fixable and there is no point spending three bundles to discover it.

`daemon/*.exe.old-*` needs its own `.gitignore` rule - `daemon/*.exe` does not match a `.exe.old-NNN` suffix. I checked that with `git status --untracked-files=all` rather than assuming.

## Testing

On this branch, against `upstream/main`:

- `bun test test/skills-adopt.test.ts` - 16 pass, 0 fail. Four are new, including one asserting a hand-authored file survives `--force`.
- Full suite - 55 failures, down from 61 on `upstream/main`. Zero introduced; the six that clear are three `classifyLink`/`adoptSkill` failures plus their `EPERM: symlink` errors. The existing suite called bare `symlinkSync`, which needs Developer Mode or elevation on Windows - the same thing `adoptSkill` uses junctions to avoid. The tests now use junctions to match the implementation.
- `bunx tsc --noEmit`, `bash -n scripts/*.sh`, `bash scripts/audit-capability-blind.sh` - all clean.

The 55 remaining failures are pre-existing on `upstream/main` and all macOS-toolchain-on-Windows artifacts (`plutil` missing, keychain, the iOS suites, the `install.sh` dry-run tests). I have no macOS machine to check that on, so I expect CI to be green on macos-15 but have not run it there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer skill adoption and status reporting, including detection of case-only name collisions.
  * Protected existing skill data from replacement when destination names collide, even with forced adoption.
  * Added distinct reporting for stale copies and name collisions.

* **Bug Fixes**
  * Improved Windows builds by safely handling locked executables and preventing incomplete updates.

* **Documentation**
  * Expanded guidance for adopting and checking skill links, including collision and stale-copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->