### PR TITLE
Fix daemon runtime ownership under sandboxing

### DIFF
--- a/cli/daemon-spawn.ts
+++ b/cli/daemon-spawn.ts
@@ -5,6 +5,7 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { IS_WIN, SOCKET_PATH, PID_PATH } from "../shared/platform"
+import { isProcessAlive } from "../shared/process-liveness"
 export const MACOS_PKG_DAEMON_PATH = "/Library/Application Support/Interceptor/interceptor-daemon"
 
 export type DaemonBinaryCandidateOptions = {
@@ -90,7 +91,7 @@ export async function ensureDaemon(): Promise<void> {
       const pidContent = readFileSync(PID_PATH, "utf-8").trim()
       const pid = parseInt(pidContent.split("\n")[0])
       if (!isNaN(pid)) {
-        try { process.kill(pid, 0); daemonAlive = true } catch { daemonAlive = false }
+        daemonAlive = isProcessAlive(pid)
       }
     } catch {}
   }

--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -7,6 +7,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs"
+import { isProcessAlive } from "../../shared/process-liveness"
 import { spawnSync } from "node:child_process"
 import { IS_WIN, SOCKET_PATH, PID_PATH, transportLabel } from "../../shared/platform"
 import { skillsStatusSummary } from "../commands/skills"
@@ -84,7 +85,7 @@ export function readStatusSnapshot(): StatusSnapshot {
       daemonPid = parseInt(lines[0])
       transport = lines[1] || transportLabel()
       if (!isNaN(daemonPid)) {
-        try { process.kill(daemonPid, 0); daemonAlive = true } catch { daemonAlive = false }
+        daemonAlive = isProcessAlive(daemonPid)
       }
     } catch {}
   }
@@ -111,7 +112,7 @@ export function readStatusSnapshot(): StatusSnapshot {
     try {
       bridgePid = parseInt(readFileSync(BRIDGE_PID_PATH, "utf-8").trim())
       if (!isNaN(bridgePid)) {
-        try { process.kill(bridgePid, 0); bridgeAlive = true } catch { bridgeAlive = false }
+        bridgeAlive = isProcessAlive(bridgePid)
       }
     } catch {}
   }

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -20,7 +20,7 @@ import {
 import { chooseOutboundTransport, isRelayPing, relaySlotAfterClose, validateContextRouting } from "./outbound-routing"
 import { claimContextId, type ContextSocket } from "./context-registration"
 import { formatBridgeUnavailableError, getBridgeRecoveryActions, getBridgeRecoveryLayout } from "./bridge-recovery"
-import { clearDaemonRuntimeFiles, clearLockFile, decideDaemonStartupRole, decideSingletonGate, defaultLifecycleDeps, readPidState, spawnDetachedStandaloneDaemon, writeLockFile } from "./lifecycle"
+import { clearDaemonRuntimeFiles, clearOwnedDaemonRuntimeFiles, decideDaemonStartupRole, decideSingletonGate, defaultLifecycleDeps, readPidState, spawnDetachedStandaloneDaemon, writeLockFile } from "./lifecycle"
 import { VERSION } from "../cli/version"
 import { CdpManager, CDP_ACTION_TYPES } from "./cdp/manager"
 import { CDP_CONTEXT_PREFIX } from "../shared/cdp-app"
@@ -1777,18 +1777,14 @@ function gracefulShutdown(signal: string) {
     socketServer = null
   }
   if (wsServer) wsServer.stop(true)
-  try { unlinkSync(SOCKET_PATH) } catch {}
-  try { unlinkSync(PID_PATH) } catch {}
-  try { clearLockFile(LOCK_PATH) } catch {}
+  clearOwnedDaemonRuntimeFiles(lifecycleDeps(), `${signal} shutdown`)
   log("shutdown complete")
   process.exit(0)
 }
 
 process.on("exit", (code) => {
   log(`exiting with code ${code}`)
-  try { unlinkSync(SOCKET_PATH) } catch {}
-  try { unlinkSync(PID_PATH) } catch {}
-  try { clearLockFile(LOCK_PATH) } catch {}
+  clearOwnedDaemonRuntimeFiles(lifecycleDeps(), `exit ${code}`)
 })
 process.on("SIGTERM", () => gracefulShutdown("SIGTERM"))
 process.on("SIGINT", () => gracefulShutdown("SIGINT"))

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -8,6 +8,7 @@ import { dirname } from "node:path"
 import { validateBinarySinkPath, binarySinkIntegrityError } from "./binary-sink"
 import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-loader"
 import { IS_WIN, SOCKET_PATH, IPC_PORT, PID_PATH, LOCK_PATH, LOG_PATH, EVENTS_PATH, WS_PORT, EVENTS_MAX_SIZE, MAX_UPLOAD_FRAME_BYTES, transportLabel } from "../shared/platform"
+import { isProcessAlive } from "../shared/process-liveness"
 import {
   MONITOR_EVENT_NAMES,
   appendSessionEvent,
@@ -69,8 +70,7 @@ function isBridgeAlive(): boolean {
   try {
     const pid = parseInt(readFileSync(BRIDGE_PID_PATH, "utf-8").trim())
     if (isNaN(pid)) return false
-    process.kill(pid, 0)
-    return true
+    return isProcessAlive(pid)
   } catch { return false }
 }
 

--- a/daemon/lifecycle.ts
+++ b/daemon/lifecycle.ts
@@ -123,6 +123,21 @@ export function clearDaemonRuntimeFiles(deps: Pick<LifecycleDeps, "unlinkSync" |
   try { deps.unlinkSync(deps.lockPath) } catch {}
 }
 
+export function clearOwnedDaemonRuntimeFiles(
+  deps: Pick<LifecycleDeps, "existsSync" | "readFileSync" | "unlinkSync" | "kill" | "currentPid" | "pidPath" | "lockPath" | "socketPath" | "isWin" | "log">,
+  reason: string,
+): boolean {
+  const state = readPidState(deps)
+  if (state.status !== "current") {
+    const owner = state.pid === null ? state.status : `${state.status} pid ${state.pid}`
+    deps.log(`preserving daemon runtime files: ${reason}; owner is ${owner}`)
+    return false
+  }
+
+  clearDaemonRuntimeFiles(deps, reason)
+  return true
+}
+
 export function decideDaemonStartupRole(standalone: boolean, state: PidState): StartupDecision {
   if (state.status === "alive") {
     return standalone ? { action: "exit", pid: state.pid } : { action: "relay", pid: state.pid }

--- a/daemon/lifecycle.ts
+++ b/daemon/lifecycle.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs"
 import { spawn } from "node:child_process"
+import { isProcessAlive } from "../shared/process-liveness"
 
 export type PidState =
   | { status: "missing"; pid: null }
@@ -106,12 +107,9 @@ export function readPidState(deps: Pick<LifecycleDeps, "existsSync" | "readFileS
   if (!pid) return { status: "invalid", pid: null }
   if (pid === deps.currentPid) return { status: "current", pid }
 
-  try {
-    deps.kill(pid, 0)
-    return { status: "alive", pid }
-  } catch {
-    return { status: "stale", pid }
-  }
+  return isProcessAlive(pid, deps.kill)
+    ? { status: "alive", pid }
+    : { status: "stale", pid }
 }
 
 export function clearDaemonRuntimeFiles(deps: Pick<LifecycleDeps, "unlinkSync" | "pidPath" | "lockPath" | "socketPath" | "isWin" | "log">, reason: string): void {

--- a/shared/process-liveness.ts
+++ b/shared/process-liveness.ts
@@ -1,0 +1,13 @@
+export type KillProbe = (pid: number, signal: 0) => void
+
+export function isProcessAlive(
+  pid: number,
+  killProbe: KillProbe = process.kill.bind(process),
+): boolean {
+  try {
+    killProbe(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | undefined)?.code === "EPERM"
+  }
+}

--- a/test/daemon-lifecycle.test.ts
+++ b/test/daemon-lifecycle.test.ts
@@ -64,6 +64,17 @@ describe("daemon lifecycle helpers", () => {
     expect(readPidState(deps)).toEqual({ status: "stale", pid: 222 })
   })
 
+  test("treats a permission-denied pid probe as a live daemon", () => {
+    const deps = makeDeps({
+      kill() {
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" })
+      },
+    }) as LifecycleDeps & { files: Map<string, string> }
+    deps.files.set(deps.pidPath, "222\n")
+
+    expect(readPidState(deps)).toEqual({ status: "alive", pid: 222 })
+  })
+
   test("clears stale pid and socket files on non-Windows platforms", () => {
     const deps = makeDeps() as LifecycleDeps & { files: Map<string, string>; unlinked: string[] }
     deps.files.set(deps.pidPath, "222\n")

--- a/test/daemon-lifecycle.test.ts
+++ b/test/daemon-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   clearDaemonRuntimeFiles,
+  clearOwnedDaemonRuntimeFiles,
   decideDaemonStartupRole,
   decideSingletonGate,
   parseDaemonPidFile,
@@ -73,6 +74,34 @@ describe("daemon lifecycle helpers", () => {
     expect(deps.unlinked).toEqual([deps.socketPath, deps.pidPath, deps.lockPath])
     expect(deps.files.has(deps.pidPath)).toBe(false)
     expect(deps.files.has(deps.socketPath)).toBe(false)
+  })
+
+  test("clears runtime files when the current daemon owns them", () => {
+    const deps = makeDeps() as LifecycleDeps & { files: Map<string, string>; unlinked: string[] }
+    deps.files.set(deps.pidPath, `${deps.currentPid}\n`)
+    deps.files.set(deps.socketPath, "")
+    deps.files.set(deps.lockPath, "{}")
+
+    expect(clearOwnedDaemonRuntimeFiles(deps, "shutdown")).toBe(true)
+    expect(deps.unlinked).toEqual([deps.socketPath, deps.pidPath, deps.lockPath])
+  })
+
+  test("preserves replacement daemon files when an older process exits", () => {
+    const deps = makeDeps() as LifecycleDeps & {
+      files: Map<string, string>
+      unlinked: string[]
+      alive: Set<number>
+    }
+    deps.files.set(deps.pidPath, "222\n")
+    deps.files.set(deps.socketPath, "")
+    deps.files.set(deps.lockPath, "{}")
+    deps.alive.add(222)
+
+    expect(clearOwnedDaemonRuntimeFiles(deps, "late exit")).toBe(false)
+    expect(deps.unlinked).toEqual([])
+    expect(deps.files.has(deps.socketPath)).toBe(true)
+    expect(deps.files.has(deps.pidPath)).toBe(true)
+    expect(deps.files.has(deps.lockPath)).toBe(true)
   })
 
   test("native mode relays to an existing live singleton", () => {

--- a/test/process-liveness.test.ts
+++ b/test/process-liveness.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { isProcessAlive } from "../shared/process-liveness"
+
+function errorWithCode(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code })
+}
+
+describe("process liveness probe", () => {
+  test("returns true when signal zero succeeds", () => {
+    expect(isProcessAlive(123, () => {})).toBe(true)
+  })
+
+  test("treats EPERM as alive because the process exists but is protected", () => {
+    expect(isProcessAlive(123, () => { throw errorWithCode("EPERM") })).toBe(true)
+  })
+
+  test("treats ESRCH as dead", () => {
+    expect(isProcessAlive(123, () => { throw errorWithCode("ESRCH") })).toBe(false)
+  })
+})


### PR DESCRIPTION
## What changed

- Preserve daemon socket, PID, and lock files when an older daemon exits after a replacement singleton has taken ownership.
- Treat `EPERM` from signal-zero process probes as evidence that the process exists, across daemon startup, CLI auto-start, and status rendering.
- Add regression coverage for runtime-file ownership and protected-process liveness.

## Why

Inside a sandboxed client, `process.kill(pid, 0)` can return `EPERM` for a healthy daemon. The CLI interpreted that as dead and removed the live singleton's runtime files. Separately, an older daemon's exit handlers could remove files already owned by its replacement. Together these behaviors disconnected otherwise healthy browser contexts.

## Impact

Sandboxed clients retain their connection to the live singleton, and daemon replacement no longer destroys another process's runtime state.

## Validation

- `bun run typecheck`
- Full test suite: 944 passed, 11 skipped, 0 failed
- Rebuilt and ad-hoc signed CLI and daemon
- Verified a live Chrome reconnect cycle with two contexts, including the isolated `interceptor-test` context
- `PreflightIsolation.sh` passed after the reconnect interval
