### PR TITLE
feat(click): click by CSS selector

### DIFF
--- a/cli/commands/actions.ts
+++ b/cli/commands/actions.ts
@@ -25,6 +25,25 @@ export function parseActionsCommand(filtered: string[]): Action {
   switch (cmd) {
     case "click": {
       const useOs = hasTrustedFlag(filtered)
+      // Click by CSS SELECTOR.
+      //
+      // `click` resolved only a11y refs/indices, while `query` locates elements
+      // by selector and returns no ref. On any page whose a11y tree comes back
+      // empty the tool could therefore SEE an element and be unable to click
+      // it — the two halves never met. Observed on perplexity.ai answer pages,
+      // where the tree is empty while `query "button span"` finds the control
+      // exactly.
+      const selIdx = filtered.indexOf("--selector")
+      if (selIdx !== -1 && filtered[selIdx + 1]) {
+        const nthIdx = filtered.indexOf("--nth")
+        const nth = nthIdx !== -1 ? Number(filtered[nthIdx + 1]) : 0
+        return {
+          type: "click_selector",
+          selector: filtered[selIdx + 1],
+          nth: Number.isFinite(nth) ? nth : 0,
+          ...parseAt(filtered),
+        }
+      }
       const target = parseElementTarget(filtered[1])
       const at = parseAt(filtered)
       if (useOs) {

--- a/cli/manifest.ts
+++ b/cli/manifest.ts
@@ -132,7 +132,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   { name: "attr", surface: "browser", usage: "interceptor attr e<ref> <name> | attr set e<ref> <name> <value>", summary: "Get/set an attribute", returns: "Attribute value." },
   { name: "style", surface: "browser", usage: "interceptor style e<ref> <property> | style inject --css \"<rules>\" | style remove <handle>", summary: "Computed style / stylesheet injection", returns: "Computed value, or an injection handle." },
   // ── actions ─────────────────────────────────────────────────────────────────
-  { name: "click", surface: "browser", usage: "interceptor click e<ref>", summary: "Click an element", returns: "ok / error." },
+  { name: "click", surface: "browser", usage: "interceptor click e<ref> | --selector <css> [--nth N]", summary: "Click an element by a11y ref, index, or CSS selector", returns: "ok / error." },
   { name: "type", surface: "browser", usage: "interceptor type e<ref> <text…>", summary: "Type into a field", returns: "ok / error." },
   { name: "select", surface: "browser", usage: "interceptor select e<ref> <value>", summary: "Select an option", returns: "ok / error." },
   { name: "keys", surface: "browser", usage: "interceptor keys <combo>", summary: "Send a keyboard shortcut", returns: "ok / error." },

--- a/cli/normalize.ts
+++ b/cli/normalize.ts
@@ -38,7 +38,10 @@ const GLOBAL_VALUE_FLAGS = ["--frame"]
 
 const COMPOUND = ["--filter", "--keys", "--limit", "--timeout", "--tree-format"]
 const STATE = ["--depth", "--filter", "--limit", "--max-chars", "--role"]
-const ACTIONS = ["--at", "--duration", "--from", "--steps", "--to"]
+// --selector/--nth take VALUES. Without them declared here the normalizer
+// treats them as booleans and strips their operands, so
+// `click --selector button --nth 4` arrives with selector === "--nth".
+const ACTIONS = ["--at", "--duration", "--from", "--nth", "--selector", "--steps", "--to"]
 const NAV = ["--amount", "--ms", "--timeout"]
 const NET = ["--filter", "--format", "--limit", "--out", "--since", "--pattern", "--patterns", "--type"]
 const SCREENSHOT = ["--clip", "--element", "--filter", "--format", "--kind", "--limit", "--quality", "--ref", "--region", "--scale", "--selector", "--target-max-long-edge", "--threshold"]

--- a/extension/dist-mv2/content.js
+++ b/extension/dist-mv2/content.js
@@ -1804,6 +1804,33 @@ async function handleClick(action) {
   }
   return { success: true, data: clickMsg };
 }
+async function handleClickSelector(action) {
+  const selector = String(action.selector ?? "");
+  if (!selector)
+    return { success: false, error: "click_selector: no selector given" };
+  let matches;
+  try {
+    matches = document.querySelectorAll(selector);
+  } catch {
+    return { success: false, error: `click_selector: invalid CSS selector ${JSON.stringify(selector)}` };
+  }
+  const nth = typeof action.nth === "number" ? action.nth : 0;
+  const el = matches[nth];
+  if (!el) {
+    return {
+      success: false,
+      error: `click_selector: ${selector} matched ${matches.length} element(s); no index ${nth}`
+    };
+  }
+  scrollIntoViewIfNeeded(el);
+  dispatchClickSequence(el, action.x, action.y);
+  const mutated = await waitForMutation(200);
+  const msg = `clicked ${selector}[${nth}] of ${matches.length}`;
+  if (!mutated) {
+    return { success: true, data: msg, warning: "no DOM change after click — the site may require trusted events" };
+  }
+  return { success: true, data: msg };
+}
 async function handleDblclick(action) {
   const el = resolveElement(action.index, action.ref);
   if (!el)
@@ -4665,6 +4692,8 @@ async function executeAction(action) {
         return getPageState(action.full);
       case "click":
         return handleClick(action);
+      case "click_selector":
+        return handleClickSelector(action);
       case "dblclick":
         return handleDblclick(action);
       case "rightclick":

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -8,7 +8,7 @@ import { pruneStaleRefs } from "./content/ref-registry"
 import { buildA11yTree } from "./content/a11y-tree"
 import { getPageState } from "./content/state"
 import { dispatchClickSequence, dispatchKeySequence, resolveElement, waitForDomStable } from "./content/input-simulation"
-import { handleClick, handleDblclick, handleRightclick, handleClickAt, handleWhatAt } from "./content/actions/click"
+import { handleClick, handleClickSelector, handleDblclick, handleRightclick, handleClickAt, handleWhatAt } from "./content/actions/click"
 import { handleInputText, handleSelectOption, handleCheck } from "./content/actions/type"
 import { handleScroll, handleScrollAbsolute, handleScrollTo, handleGetPageDimensions } from "./content/actions/scroll"
 import { handleWait, handleWaitFor, handleWaitStable } from "./content/actions/wait"
@@ -81,6 +81,7 @@ async function executeAction(action: Action): Promise<ActionResult> {
     switch (action.type) {
       case "get_state":           return getPageState(action.full as boolean)
       case "click":               return handleClick(action)
+      case "click_selector":      return handleClickSelector(action)
       case "dblclick":            return handleDblclick(action)
       case "rightclick":          return handleRightclick(action)
       case "drag":                return handleDrag(action)

--- a/extension/src/content/actions/click.ts
+++ b/extension/src/content/actions/click.ts
@@ -18,6 +18,46 @@ export async function handleClick(action: Action): Promise<ActionResult> {
   return { success: true, data: clickMsg }
 }
 
+/**
+ * Click by CSS selector.
+ *
+ * The gap this closes: `handleClick` resolves only a11y refs and indices, so a
+ * page whose accessibility tree is empty is unclickable even when `query`
+ * locates the element perfectly. That is not hypothetical — perplexity.ai
+ * answer pages return an empty tree while `query "button span"` finds the
+ * sources control exactly, so the sources panel could be seen and never opened.
+ *
+ * `nth` disambiguates rather than guessing: a selector matching several
+ * elements is a caller error to surface, not one to silently resolve to the
+ * first match, so the count comes back in the error.
+ */
+export async function handleClickSelector(action: Action): Promise<ActionResult> {
+  const selector = String(action.selector ?? "")
+  if (!selector) return { success: false, error: "click_selector: no selector given" }
+  let matches: NodeListOf<Element>
+  try {
+    matches = document.querySelectorAll(selector)
+  } catch {
+    return { success: false, error: `click_selector: invalid CSS selector ${JSON.stringify(selector)}` }
+  }
+  const nth = typeof action.nth === "number" ? action.nth : 0
+  const el = matches[nth] as HTMLElement | undefined
+  if (!el) {
+    return {
+      success: false,
+      error: `click_selector: ${selector} matched ${matches.length} element(s); no index ${nth}`,
+    }
+  }
+  scrollIntoViewIfNeeded(el)
+  dispatchClickSequence(el, action.x as number | undefined, action.y as number | undefined)
+  const mutated = await waitForMutation(200)
+  const msg = `clicked ${selector}[${nth}] of ${matches.length}`
+  if (!mutated) {
+    return { success: true, data: msg, warning: "no DOM change after click — the site may require trusted events" }
+  }
+  return { success: true, data: msg }
+}
+
 export async function handleDblclick(action: Action): Promise<ActionResult> {
   const el = resolveElement(action.index as number | undefined, action.ref as string | undefined)
   if (!el) return { success: false, error: `stale element [${action.index}] — run interceptor state to refresh` }


### PR DESCRIPTION
`click` resolves only accessibility refs and indices, while `query` locates elements by selector and returns no ref. On a page whose a11y tree comes back empty, the tool can therefore **see** an element and be unable to click it — the two halves never meet.

I hit this on perplexity.ai answer pages, which return an empty a11y tree while their own artifacts pages do not, so it reads as page-specific rather than a site being unsupported. `query "button span"` finds the "N sources" control there exactly; before this change that control could be located and never pressed.

```
interceptor click --selector "button span" --nth 4
```

`--nth` disambiguates rather than guessing: a selector matching several elements is a caller error worth surfacing, so the match count comes back in the error rather than silently resolving to the first hit. An invalid selector is reported as invalid rather than throwing.

One non-obvious part: `--selector` and `--nth` also had to be declared as VALUE flags for the actions group in `normalize.ts`. Without that the normalizer treats them as booleans and strips their operands, so `click --selector button --nth 4` reaches the extension with `selector === "--nth"` — the feature arrives intact and fails on its arguments.

Rebased on 0.22.38. `bun run typecheck` clean, `scripts/build.sh` clean, `dist-mv2` rebuilt per the existing convention. Verified end to end: a page reporting 10 sources exposed 0 external anchors before the click and 10 after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for clicking page elements using CSS selectors.
  - Select a specific matching element with an optional index.
  - Elements are scrolled into view and clicked with standard interaction behavior.

- **Bug Fixes**
  - Added clear feedback for missing or invalid selectors and unavailable matches.
  - Reports when a click does not trigger a detectable page update.

- **Documentation**
  - Updated click command guidance to include selector-based usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->