### PR TITLE
fix(stealth): de-brand MAIN-world globals, guards, and Trusted-Types policies (#178)

### DIFF
--- a/extension/src/background/capabilities/binary-sink.ts
+++ b/extension/src/background/capabilities/binary-sink.ts
@@ -1,3 +1,4 @@
+import { IK_SINK_TT_POLICY, SINK_TT_POLICY_NAME } from "../../inject-keys"
 import { runWithCspStripBypass } from "./evaluate"
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
@@ -20,8 +21,9 @@ async function executeNormalize(
   const results = await chrome.scripting.executeScript({
     target: { tabId },
     world,
-    args: [code],
-    func: async (sourceCode: string) => {
+    args: [code, IK_SINK_TT_POLICY, SINK_TT_POLICY_NAME],
+    func: async (sourceCode: string, ttKey: string, ttName: string) => {
+      const TT = Symbol.for(ttKey)
       async function normalize(value: unknown): Promise<{
         url: string
         size: number
@@ -109,12 +111,12 @@ async function executeNormalize(
         const w = window as any
         let evalSource: any = sourceCode
         if (w.trustedTypes) {
-          if (!w.__interceptor_sink_tt_policy) {
-            w.__interceptor_sink_tt_policy = w.trustedTypes.createPolicy("interceptor-binary-sink", {
+          if (!w[TT]) {
+            w[TT] = w.trustedTypes.createPolicy(ttName, {
               createScript: (s: string) => s
             })
           }
-          evalSource = w.__interceptor_sink_tt_policy.createScript(sourceCode)
+          evalSource = w[TT].createScript(sourceCode)
         }
         const value = (0, eval)(evalSource as string)
         return { success: true, data: await normalize(value) }

--- a/extension/src/background/capabilities/canvas.ts
+++ b/extension/src/background/capabilities/canvas.ts
@@ -1,3 +1,4 @@
+import { IK_CANVAS_OBSERVER } from "../../inject-keys"
 import { sendNetDirect } from "../content-bridge"
 import { sendToOffscreen } from "../offscreen"
 
@@ -57,7 +58,7 @@ async function executeInMainWorld<T>(
   return results[0]?.result as T
 }
 
-function hostCanvasSignals(limit = 20) {
+function hostCanvasSignals(limit = 20, obsKey?: string) {
   const canvases = Array.from(document.querySelectorAll("canvas"))
   const max = Number.isFinite(limit) && limit > 0 ? limit : 20
   const safeSlice = <T>(arr: T[]): T[] => arr.slice(0, max)
@@ -108,7 +109,7 @@ function hostCanvasSignals(limit = 20) {
     })
   )
 
-  const observer = (window as any).__interceptorCanvasObserver || null
+  const observer = (obsKey ? (window as any)[Symbol.for(obsKey)] : null) || null
   const excalidrawScene = parseLocalStorageJson("excalidraw")
   const docsSemanticMirror = !!docsTextboxSummary.exists
   const observerReasons: string[] = Array.isArray(observer?.partialCoverageReasons) ? observer.partialCoverageReasons.slice() : []
@@ -221,7 +222,7 @@ function canvasAccessibleText(canvasIndex: number) {
   }
 }
 
-function canvasObserverSummary(limit = 100, kinds?: string[], canvasIndex?: number) {
+function canvasObserverSummary(limit = 100, kinds?: string[], canvasIndex?: number, obsKey?: string) {
   function normalize(kind: unknown): string {
     return String(kind || "").trim()
   }
@@ -249,7 +250,7 @@ function canvasObserverSummary(limit = 100, kinds?: string[], canvasIndex?: numb
     return typeof canvasId === "string" && canvasId ? canvasId : null
   }
 
-  const observer = (window as any).__interceptorCanvasObserver || null
+  const observer = (obsKey ? (window as any)[Symbol.for(obsKey)] : null) || null
   if (!observer || !Array.isArray(observer.log)) {
     return {
       installed: false,
@@ -276,7 +277,7 @@ function canvasObserverSummary(limit = 100, kinds?: string[], canvasIndex?: numb
   }
 }
 
-function canvasObserverObjectsSummary(limit = 100, kind?: string, canvasIndex?: number) {
+function canvasObserverObjectsSummary(limit = 100, kind?: string, canvasIndex?: number, obsKey?: string) {
   function normalize(value: unknown): string {
     return String(value || "").trim()
   }
@@ -294,7 +295,7 @@ function canvasObserverObjectsSummary(limit = 100, kind?: string, canvasIndex?: 
     return typeof canvasId === "string" && canvasId ? canvasId : null
   }
 
-  const observer = (window as any).__interceptorCanvasObserver || null
+  const observer = (obsKey ? (window as any)[Symbol.for(obsKey)] : null) || null
   if (!observer || !Array.isArray(observer.objects)) {
     return {
       installed: false,
@@ -451,7 +452,7 @@ export async function handleCanvasActions(
 
     case "canvas_status": {
       const list = await executeInMainWorld<CanvasListEntry[]>(tabId, walkCanvasElements)
-      const host = await executeInMainWorld<ReturnType<typeof hostCanvasSignals>>(tabId, hostCanvasSignals, [action.limit as number | undefined])
+      const host = await executeInMainWorld<ReturnType<typeof hostCanvasSignals>>(tabId, hostCanvasSignals, [action.limit as number | undefined, IK_CANVAS_OBSERVER])
       return {
         success: true,
         data: {
@@ -470,7 +471,7 @@ export async function handleCanvasActions(
       const data = await executeInMainWorld<ReturnType<typeof canvasObserverSummary>>(
         tabId,
         canvasObserverSummary,
-        [action.limit as number | undefined, action.kinds as string[] | undefined, action.canvasIndex as number | undefined]
+        [action.limit as number | undefined, action.kinds as string[] | undefined, action.canvasIndex as number | undefined, IK_CANVAS_OBSERVER]
       )
       return { success: true, data }
     }
@@ -479,7 +480,7 @@ export async function handleCanvasActions(
       const data = await executeInMainWorld<ReturnType<typeof canvasObserverObjectsSummary>>(
         tabId,
         canvasObserverObjectsSummary,
-        [action.limit as number | undefined, action.kind as string | undefined, action.canvasIndex as number | undefined]
+        [action.limit as number | undefined, action.kind as string | undefined, action.canvasIndex as number | undefined, IK_CANVAS_OBSERVER]
       )
       return { success: true, data }
     }

--- a/extension/src/background/capabilities/evaluate.ts
+++ b/extension/src/background/capabilities/evaluate.ts
@@ -1,3 +1,4 @@
+import { IK_TT_POLICY, TT_POLICY_NAME } from "../../inject-keys"
 import { waitForTabLoad } from "../content-bridge"
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
@@ -74,8 +75,9 @@ async function executeEval(
   const results = await chrome.scripting.executeScript({
     target: { tabId },
     world,
-    args: [code],
-    func: async (c: string) => {
+    args: [code, IK_TT_POLICY, TT_POLICY_NAME],
+    func: async (c: string, ttKey: string, ttName: string) => {
+      const TT = Symbol.for(ttKey)
       function clone(v: unknown): unknown {
         if (v === null || v === undefined) return v
         const t = typeof v
@@ -91,21 +93,21 @@ async function executeEval(
         const w = window as any
         let source = c
         if (w.trustedTypes) {
-          if (!w.__interceptor_tt_policy) {
+          if (!w[TT]) {
             try {
-              w.__interceptor_tt_policy = w.trustedTypes.createPolicy("interceptor-eval", {
+              w[TT] = w.trustedTypes.createPolicy(ttName, {
                 createScript: (s: string) => s
               })
             } catch {
               try {
-                w.__interceptor_tt_policy = w.trustedTypes.createPolicy("interceptor-eval-" + Date.now(), {
+                w[TT] = w.trustedTypes.createPolicy(ttName + "-" + Date.now(), {
                   createScript: (s: string) => s
                 })
               } catch {}
             }
           }
-          if (w.__interceptor_tt_policy) {
-            source = w.__interceptor_tt_policy.createScript(c)
+          if (w[TT]) {
+            source = w[TT].createScript(c)
           }
         }
         let r: unknown = (0, eval)(source as string)

--- a/extension/src/inject-canvas.ts
+++ b/extension/src/inject-canvas.ts
@@ -1,5 +1,7 @@
-if (!(window as any).__interceptor_canvas_installed) {
-  ;(window as any).__interceptor_canvas_installed = true
+import { K_CANVAS, K_CANVAS_OBSERVER, K_CANVAS_WRAPPED, K_GETCTX_WRAPPED } from "./inject-keys"
+
+if (!(window as any)[K_CANVAS]) {
+  ;(window as any)[K_CANVAS] = true
 
   type CanvasLike = HTMLCanvasElement | OffscreenCanvas
   type CanvasObserverEntry = Record<string, unknown> & { t: number; kind: string; canvasId?: string }
@@ -181,8 +183,8 @@ if (!(window as any).__interceptor_canvas_installed) {
   }
 
   function patch2DPrototype(proto: CanvasRenderingContext2D | any): void {
-    if (!proto || proto.__interceptor_canvas_wrapped) return
-    proto.__interceptor_canvas_wrapped = true
+    if (!proto || (proto as any)[K_CANVAS_WRAPPED]) return
+    ;(proto as any)[K_CANVAS_WRAPPED] = true
 
     const wrap = (name: string, handler: (ctx: CanvasRenderingContext2D, args: unknown[], out: unknown) => void) => {
       const orig = proto[name]
@@ -380,10 +382,10 @@ if (!(window as any).__interceptor_canvas_installed) {
   }
 
   function patchGetContext(Ctor: any, label: string): void {
-    if (!Ctor || !Ctor.prototype || Ctor.prototype.__interceptor_canvas_get_context_wrapped) return
+    if (!Ctor || !Ctor.prototype || (Ctor.prototype as any)[K_GETCTX_WRAPPED]) return
     const orig = Ctor.prototype.getContext
     if (typeof orig !== "function") return
-    Ctor.prototype.__interceptor_canvas_get_context_wrapped = true
+    ;(Ctor.prototype as any)[K_GETCTX_WRAPPED] = true
     Ctor.prototype.getContext = function (type: string, ...rest: unknown[]) {
       const ctx = orig.call(this, type, ...rest)
       const canvasId = registerCanvas(this)
@@ -411,5 +413,5 @@ if (!(window as any).__interceptor_canvas_installed) {
   patchGetContext((window as any).HTMLCanvasElement, "HTMLCanvasElement")
   patchGetContext((window as any).OffscreenCanvas, "OffscreenCanvas")
 
-  ;(window as any).__interceptorCanvasObserver = observer
+  ;(window as any)[K_CANVAS_OBSERVER] = observer
 }

--- a/extension/src/inject-keys.test.ts
+++ b/extension/src/inject-keys.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import {
+  IK_BEACON, IK_BROADCAST, IK_CANVAS, IK_CANVAS_OBSERVER, IK_CANVAS_WRAPPED,
+  IK_GETCTX_WRAPPED, IK_NET, IK_SINK_TT_POLICY, IK_TT_POLICY, IK_WS,
+  K_BEACON, K_BROADCAST, K_CANVAS, K_CANVAS_OBSERVER, K_CANVAS_WRAPPED,
+  K_GETCTX_WRAPPED, K_NET, K_TT_POLICY, K_WS,
+  SINK_TT_POLICY_NAME, STAGED_BYTES_PREFIX, TT_NET_POLICY_NAME, TT_POLICY_NAME,
+} from "./inject-keys"
+
+// The whole fix (issue #178) rests on one cross-context invariant: the inject
+// scripts (which `import` the symbol) and the background executeScript functions
+// (which re-derive it from the STRING with Symbol.for, because they run with no
+// lexical scope) must resolve to the SAME symbol. If that ever drifts, the canvas
+// observer read returns undefined and eval loses its Trusted-Types policy —
+// silently, with no type error. These tests pin the invariant.
+
+describe("inject-keys cross-context invariant", () => {
+  const pairs: [string, symbol][] = [
+    [IK_NET, K_NET], [IK_CANVAS, K_CANVAS], [IK_WS, K_WS],
+    [IK_BROADCAST, K_BROADCAST], [IK_BEACON, K_BEACON], [IK_TT_POLICY, K_TT_POLICY],
+    [IK_CANVAS_OBSERVER, K_CANVAS_OBSERVER], [IK_CANVAS_WRAPPED, K_CANVAS_WRAPPED],
+    [IK_GETCTX_WRAPPED, K_GETCTX_WRAPPED],
+  ]
+
+  test("Symbol.for(string) re-derivation equals the imported symbol", () => {
+    // This is exactly what the executeScript bodies do: Symbol.for(keyArg).
+    for (const [str, sym] of pairs) expect(Symbol.for(str)).toBe(sym)
+  })
+
+  test("write via imported symbol, read via re-derived string — round-trips", () => {
+    // inject-canvas.ts writes window[K_CANVAS_OBSERVER]; canvas.ts reads
+    // window[Symbol.for(IK_CANVAS_OBSERVER)]. Simulate both sides on one object.
+    const win: Record<PropertyKey, unknown> = {}
+    const observer = { partialCoverageReasons: ["x"] }
+    win[K_CANVAS_OBSERVER] = observer // inject side
+    const readBack = win[Symbol.for(IK_CANVAS_OBSERVER)] // background executeScript side
+    expect(readBack).toBe(observer)
+  })
+
+  test("IK_SINK_TT_POLICY re-derivation is stable (binary-sink has no exported symbol)", () => {
+    expect(Symbol.for(IK_SINK_TT_POLICY)).toBe(Symbol.for(IK_SINK_TT_POLICY))
+    expect(Symbol.for(IK_SINK_TT_POLICY)).not.toBe(K_TT_POLICY) // sink policy is distinct from eval policy
+  })
+
+  test("all registry strings are distinct", () => {
+    const all = [IK_NET, IK_CANVAS, IK_WS, IK_BROADCAST, IK_BEACON, IK_TT_POLICY,
+      IK_SINK_TT_POLICY, IK_CANVAS_OBSERVER, IK_CANVAS_WRAPPED, IK_GETCTX_WRAPPED]
+    expect(new Set(all).size).toBe(all.length)
+  })
+})
+
+describe("inject-keys are not page-detectable by name", () => {
+  test("symbol-keyed props are excluded from all string enumeration", () => {
+    const win: Record<PropertyKey, unknown> = {}
+    win[K_NET] = true
+    win[K_CANVAS_OBSERVER] = {}
+    win[K_TT_POLICY] = {}
+    expect(Object.keys(win)).toEqual([])
+    expect(Object.getOwnPropertyNames(win)).toEqual([])
+    expect(JSON.stringify(win)).toBe("{}")
+    // the exact one-liner from the PoC in issue #178
+    expect(Object.keys(win).some((k) => k.startsWith("__interceptor"))).toBe(false)
+    for (const k in win) throw new Error(`for..in leaked ${String(k)}`)
+  })
+
+  test("registry strings and policy names carry no vendor name", () => {
+    const strings = [IK_NET, IK_CANVAS, IK_WS, IK_BROADCAST, IK_BEACON, IK_TT_POLICY,
+      IK_SINK_TT_POLICY, IK_CANVAS_OBSERVER, IK_CANVAS_WRAPPED, IK_GETCTX_WRAPPED,
+      TT_POLICY_NAME, TT_NET_POLICY_NAME, SINK_TT_POLICY_NAME, STAGED_BYTES_PREFIX]
+    for (const s of strings) expect(s.toLowerCase()).not.toContain("interceptor")
+  })
+})

--- a/extension/src/inject-keys.ts
+++ b/extension/src/inject-keys.ts
@@ -1,0 +1,63 @@
+// Realm-shared, non-enumerable keys and unbranded string constants for the
+// MAIN-world install guards, the canvas-observer channel, and the Trusted-Types
+// policies. See issue #178.
+//
+// Why symbols instead of string-named properties: inject-net.ts and
+// inject-canvas.ts run in the page's MAIN world, so any string-named property
+// they set on `window` / `navigator` / a prototype is enumerable by the page
+// (`Object.keys`, `for...in`, `JSON.stringify`, `getOwnPropertyNames`) and lets
+// a site fingerprint the extension in one line. Symbol-keyed properties are
+// excluded from all of those. This is hardening, not invisibility:
+// `Object.getOwnPropertySymbols(window)` still lists them and exposes their
+// descriptions, so the registry strings below are deliberately opaque rather
+// than vendor-branded — a generic name grep no longer matches.
+//
+// Why `Symbol.for` (the global registry) instead of `Symbol()`: a MAIN-world
+// content script can execute more than once in the same realm (re-injection,
+// same-document navigation). Each execution is a fresh module instance, so the
+// "already installed" guard must resolve to the SAME symbol across executions.
+// `Symbol.for(s)` returns one shared symbol per string `s`, process-wide; a bare
+// `Symbol()` would mint a new one each time and silently defeat every guard
+// (double-wrapped prototypes, double-counted events).
+//
+// Cross-context note: the canvas observer and the Trusted-Types policy are also
+// read/created from background code injected via `chrome.scripting.executeScript`.
+// That function is serialised with `Function.prototype.toString()` and recompiled
+// in the page with NO lexical scope, so an imported binding is a free identifier
+// there and throws `ReferenceError`. Those call sites import the STRING constant
+// (e.g. `IK_CANVAS_OBSERVER`), pass it through executeScript `args`, and re-derive
+// the symbol with `Symbol.for()` inside the function body. The strings here are
+// the single source of truth for both sides.
+
+// Registry strings — opaque, stable, no vendor name.
+export const IK_NET = "z9n0";
+export const IK_CANVAS = "z9c0";
+export const IK_WS = "z9w0";
+export const IK_BROADCAST = "z9b0";
+export const IK_BEACON = "z9k0";
+export const IK_TT_POLICY = "z9t0";
+export const IK_SINK_TT_POLICY = "z9t1";
+export const IK_CANVAS_OBSERVER = "z9o0";
+export const IK_CANVAS_WRAPPED = "z9r0";
+export const IK_GETCTX_WRAPPED = "z9r1";
+
+// Symbols for the files that can `import` (inject-net.ts, inject-canvas.ts).
+export const K_NET = Symbol.for(IK_NET);
+export const K_CANVAS = Symbol.for(IK_CANVAS);
+export const K_WS = Symbol.for(IK_WS);
+export const K_BROADCAST = Symbol.for(IK_BROADCAST);
+export const K_BEACON = Symbol.for(IK_BEACON);
+export const K_TT_POLICY = Symbol.for(IK_TT_POLICY);
+export const K_CANVAS_OBSERVER = Symbol.for(IK_CANVAS_OBSERVER);
+export const K_CANVAS_WRAPPED = Symbol.for(IK_CANVAS_WRAPPED);
+export const K_GETCTX_WRAPPED = Symbol.for(IK_GETCTX_WRAPPED);
+
+// Unbranded Trusted-Types policy names. Policy names are observable via CSP
+// violation reports, so keep them non-attributable too.
+export const TT_POLICY_NAME = "tt-e";
+export const TT_NET_POLICY_NAME = "tt-n";
+export const SINK_TT_POLICY_NAME = "tt-s";
+
+// Prefix for the ephemeral staged-bytes global (binary sink). Stays a string
+// because it is used as a property-name string passed across executeScript calls.
+export const STAGED_BYTES_PREFIX = "z9s_";

--- a/extension/src/inject-net.ts
+++ b/extension/src/inject-net.ts
@@ -1,7 +1,9 @@
-if ((window as any).__interceptor_net_installed) {
+import { K_BEACON, K_BROADCAST, K_NET, K_TT_POLICY, K_WS, TT_NET_POLICY_NAME, TT_POLICY_NAME } from "./inject-keys"
+
+if ((window as any)[K_NET]) {
   // already patched — skip
 } else {
-  (window as any).__interceptor_net_installed = true
+  (window as any)[K_NET] = true
 
   // Trust overrides — must run before any page bundle captures native getters.
   // Pages tag synthetic events with `event.__interceptor_trust = true` to claim
@@ -30,20 +32,20 @@ if ((window as any).__interceptor_net_installed) {
 
   if ((window as any).trustedTypes?.createPolicy) {
     try {
-      (window as any).trustedTypes.createPolicy("interceptor-net", {
+      (window as any).trustedTypes.createPolicy(TT_NET_POLICY_NAME, {
         createHTML: (input: string) => input,
         createScriptURL: (input: string) => input,
         createScript: (input: string) => input,
       })
     } catch {}
-    if (!(window as any).__interceptor_tt_policy) {
+    if (!(window as any)[K_TT_POLICY]) {
       try {
-        (window as any).__interceptor_tt_policy = (window as any).trustedTypes.createPolicy("interceptor-eval", {
+        (window as any)[K_TT_POLICY] = (window as any).trustedTypes.createPolicy(TT_POLICY_NAME, {
           createScript: (input: string) => input,
         })
       } catch {
         try {
-          (window as any).__interceptor_tt_policy = (window as any).trustedTypes.createPolicy("interceptor-eval-" + Date.now(), {
+          (window as any)[K_TT_POLICY] = (window as any).trustedTypes.createPolicy(TT_POLICY_NAME + "-" + Date.now(), {
             createScript: (input: string) => input,
           })
         } catch {}
@@ -52,7 +54,10 @@ if ((window as any).__interceptor_net_installed) {
   }
 
   type OverrideRule = { urlPattern: string; queryAddOrReplace?: Record<string, string | number | boolean>; queryRemove?: string[] }
-  const overrideRules: OverrideRule[] = (window as any).__interceptor_override_rules = []
+  // NB: kept as a closure-local. The window property (`__interceptor_override_rules`)
+  // this used to publish was vestigial — every read below goes through this const —
+  // and it was a page-visible tell, so it is no longer assigned to `window`.
+  const overrideRules: OverrideRule[] = []
 
   document.addEventListener("__interceptor_set_overrides", ((e: CustomEvent) => {
     overrideRules.length = 0
@@ -690,8 +695,8 @@ if ((window as any).__interceptor_net_installed) {
 	  }
 
   const OriginalWebSocket = (window as any).WebSocket as typeof WebSocket | undefined
-  if (OriginalWebSocket && !(window as any).__interceptor_ws_installed) {
-    ;(window as any).__interceptor_ws_installed = true
+  if (OriginalWebSocket && !(window as any)[K_WS]) {
+    ;(window as any)[K_WS] = true
     let wsSeq = 0
     const InterceptorWebSocket = function (this: WebSocket, url: string | URL, protocols?: string | string[]) {
       const socketId = `ws-${Date.now()}-${++wsSeq}`
@@ -788,8 +793,8 @@ if ((window as any).__interceptor_net_installed) {
   }
 
   const originalBeacon = navigator.sendBeacon?.bind(navigator)
-  if (originalBeacon && !(navigator as Navigator & { __interceptor_beacon_installed?: boolean }).__interceptor_beacon_installed) {
-    ;(navigator as Navigator & { __interceptor_beacon_installed?: boolean }).__interceptor_beacon_installed = true
+  if (originalBeacon && !(navigator as any)[K_BEACON]) {
+    ;(navigator as any)[K_BEACON] = true
     navigator.sendBeacon = function (url: string | URL, data?: BodyInit | null): boolean {
       const resolvedUrl = typeof url === "string" ? url : url.toString()
       try {
@@ -820,8 +825,8 @@ if ((window as any).__interceptor_net_installed) {
   }
 
   const OriginalBroadcastChannel = (window as any).BroadcastChannel as typeof BroadcastChannel | undefined
-  if (OriginalBroadcastChannel && !(window as any).__interceptor_broadcast_installed) {
-    ;(window as any).__interceptor_broadcast_installed = true
+  if (OriginalBroadcastChannel && !(window as any)[K_BROADCAST]) {
+    ;(window as any)[K_BROADCAST] = true
     let bcSeq = 0
     const InterceptorBroadcastChannel = function (this: BroadcastChannel, name: string) {
       const channelId = `bc-${Date.now()}-${++bcSeq}`

--- a/test/stealth-no-branded-globals.test.ts
+++ b/test/stealth-no-branded-globals.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+
+// Regression guard for issue #178. The MAIN-world bundles must not ship any
+// page-visible identifier that names the extension. We build the actual entry
+// points and grep the emitted JS, so re-introducing a branded window/navigator
+// property, prototype flag, or Trusted-Types policy name fails the suite even if
+// it type-checks. Builds in-memory (no dependency on a prior `bun run build`).
+
+const ROOT = new URL("../", import.meta.url).pathname
+const ENTRYPOINTS = [
+  "extension/src/inject-net.ts",
+  "extension/src/inject-canvas.ts",
+  "extension/src/background.ts",
+]
+
+// The exact identifiers this PR removed. Deliberately NOT the CustomEvent channel
+// names (`__interceptor_net`, `__interceptor_headers`, `__interceptor_set_overrides`,
+// …) — those are page-visible too but are a separate, deferred fix (#178), so they
+// are expected to remain and must not be asserted against here.
+const FORBIDDEN = [
+  "__interceptor_net_installed",
+  "__interceptor_ws_installed",
+  "__interceptor_broadcast_installed",
+  "__interceptor_beacon_installed",
+  "__interceptor_canvas_installed",
+  "__interceptor_tt_policy",
+  "__interceptor_sink_tt_policy",
+  "__interceptor_override_rules",
+  "__interceptorCanvasObserver",
+  "__interceptor_canvas_wrapped",
+  "__interceptor_canvas_get_context_wrapped",
+  "interceptor-eval",
+  "interceptor-net",
+  "interceptor-binary-sink",
+]
+
+async function bundle(entry: string): Promise<string> {
+  const result = await Bun.build({ entrypoints: [ROOT + entry], target: "browser" })
+  expect(result.success).toBe(true)
+  let out = ""
+  for (const o of result.outputs) out += await o.text()
+  return out
+}
+
+describe("no branded page-visible identifiers in built bundles (#178)", () => {
+  for (const entry of ENTRYPOINTS) {
+    test(`${entry} is de-branded`, async () => {
+      const js = await bundle(entry)
+      const hits = FORBIDDEN.filter((id) => js.includes(id))
+      expect(hits).toEqual([])
+    })
+  }
+
+  test("the one-line detector string does not appear as a guard name", async () => {
+    // A page's generic check greps window keys for "__interceptor". After this fix
+    // the only "__interceptor" strings left in inject-net are the deferred event
+    // NAMES, never an enumerable window/navigator property assignment.
+    const js = await bundle("extension/src/inject-net.ts")
+    // guard-shaped assignments look like `<obj>.__interceptor..._installed = true`
+    expect(/\.__interceptor\w*_installed\b/.test(js)).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #178 (partial: globals, guards, and Trusted-Types policies. The event channel is deferred, see below).

## What this does

The MAIN-world scripts identified themselves by name. Install guards, the canvas-observer channel, and the three Trusted-Types policies all used literal `__interceptor` / `interceptor-` strings on `window`, `navigator`, and patched prototypes, so a page could detect the extension in one line:

```js
Object.keys(window).some(k => k.startsWith("__interceptor"))   // was: true
```

This moves the guards, the canvas-observer key, and the prototype-patch flags to `Symbol.for()` keys with opaque, non-branded registry strings, and renames the three policies to non-attributable names. Symbol-keyed properties are excluded from `Object.keys`, `for...in`, `JSON.stringify`, and `getOwnPropertyNames`, so the one-line string check no longer matches.

## Files

- `extension/src/inject-keys.ts` (new): the shared registry strings, symbols, and policy names, with the rationale inline.
- `inject-net.ts`: `net` / `ws` / `broadcast` / `beacon` install guards and the eval Trusted-Types policy move to symbols; the two policy names are unbranded. The vestigial `window.__interceptor_override_rules` assignment is dropped (only the closure-local `const` was ever read).
- `inject-canvas.ts`: the install guard, the observer handle, and the two prototype-patch flags move to symbols.
- `background/capabilities/canvas.ts`, `evaluate.ts`, `binary-sink.ts`: these read/create the observer and policies inside `chrome.scripting.executeScript` functions, which are serialised with `Function.prototype.toString()` and recompiled in the page with no lexical scope. An imported binding is a free identifier there, so each site imports the registry STRING, passes it through `executeScript` args, and re-derives the symbol with `Symbol.for()` in the function body. Same string, same symbol as the inject scripts.

## Scope and honesty

This is hardening, not invisibility. `Object.getOwnPropertySymbols(window)` still lists the keys and their descriptions, so a detector that hard-codes the opaque strings can still match. The win is removing the generic vendor-name grep, which is what any off-the-shelf detector uses.

Deferred to a follow-up, called out in #178: the branded `CustomEvent` channel names (`__interceptor_net`, `__interceptor_headers`, `__interceptor_set_overrides`, and the rest). Renaming them keeps them guessable, and the read/write exposure they carry needs a per-session random namespace shared between the inject scripts and the content script. That is an architectural change and your call on the approach, so it is not in this PR.

ISOLATED-world state is left as is: `content.ts`, `ref-registry.ts`, `net-buffer.ts`, and the staged-bytes key are not page-visible.

## Verification

- `bun run typecheck` clean.
- `bun test` 1028 pass / 11 skip / 0 fail.
- Built bundles (`inject-net.js`, `inject-canvas.js`, `background.js`) contain no branded page-visible identifiers, and `Symbol.for` is inlined into the inject bundles.

The cross-context paths (canvas capture, eval) run through real `executeScript` serialisation, which the unit tests do not exercise. I am running a live re-probe in a reloaded browser (one-line detection returns false, canvas capture and eval still work) and will post the result as a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved protection for evaluated scripts and dynamically created content using shared Trusted Types policies.
  * Reduced exposure of internal interception state by replacing descriptive global properties with protected shared keys.
  * Preserved existing network, WebSocket, messaging, and canvas interception behavior while improving installation safeguards.
  * Added safeguards and regression coverage to help prevent identifiable internal markers from appearing in the extension’s runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->