### PR TITLE
fix(macos/photos): --size never reaches the bridge, making export's JPEG path unreachable

### DIFF
--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -1783,7 +1783,7 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
       // remap to album_type. --limit/--offset must be int-typed because
       // PhotosDomain casts them with `as? Int` (verified — string casts
       // silently drop the value, causing accidental full-library fetches).
-      for (const flag of ["--level","--name","--media","--subtype","--since","--until","--where","--out","--size","--asset","--file","--album","--token"]) {
+      for (const flag of ["--level","--name","--media","--subtype","--since","--until","--where","--out","--asset","--file","--album","--token","--format"]) {
         const val = flagVal(filtered, flag)
         if (val !== undefined) action[flag.replace(/^--/, "").replace(/-/g, "_")] = val
       }
@@ -1791,6 +1791,11 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
       if (pType !== undefined) action.album_type = pType
       const pLimit = flagInt(filtered, "--limit"); if (pLimit !== undefined) action.limit = pLimit
       const pOffset = flagInt(filtered, "--offset"); if (pOffset !== undefined) action.offset = pOffset
+      // Same `as? Int` trap the --limit/--offset comment above describes: PhotosDomain
+      // reads --size with `as? Int`, so passing it as a string silently drops it. That
+      // made export's resize+JPEG branch unreachable from the CLI (it always fell
+      // through to the raw-original branch) and pinned thumbnail to its 256px default.
+      const pSize = flagInt(filtered, "--size"); if (pSize !== undefined) action.size = pSize
       if (filtered.includes("--favorite")) action.favorite = true
       if (filtered.includes("--hidden")) action.hidden = true
       if (filtered.includes("--burst")) action.burst = true

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -635,6 +635,8 @@ macOS Bridge (full install only):
   interceptor macos contacts status|request|containers|groups|list|contact|me|find|create|update|delete|vcard|import-vcard|current-token|changes
   interceptor macos contacts find "<query>" | --email <addr> | --phone <num>
   interceptor macos photos status|request|albums|album|assets|asset|export|export-video|export-live|thumbnail|favorite|hide|delete|add-to-album|remove-from-album|import|import-video|current-token|changes
+  interceptor macos photos export <id> --out <path> [--size N] [--format jpeg|png]   Originals are HEIC; --format transcodes
+  interceptor macos photos thumbnail <id> [--size N] [--out <path>]                  --out writes a file; without it, returns a base64 dataUrl
   interceptor macos location status|request|request-temporary-accuracy|current|monitor|significant|visits|heading|geocode|reverse|distance|postal-geocode
   interceptor macos location current                                              (one-shot CLLocationManager.requestLocation)
   interceptor macos location reverse <lat,lng>

--- a/interceptor-bridge/Sources/Domains/PhotosDomain.swift
+++ b/interceptor-bridge/Sources/Domains/PhotosDomain.swift
@@ -309,6 +309,12 @@ final class PhotosDomain: DomainHandler, @unchecked Sendable {
         guard let id = action["id"] as? String, let outPath = action["out"] as? String else {
             completion(WireFormat.error("photos.export: <id> and --out required")); return
         }
+        // Validated up front, before the asset fetch, so an unsupported value reports itself
+        // rather than hiding behind a "not found" from an unrelated bad id.
+        let wantFormat = (action["format"] as? String)?.lowercased()
+        if let want = wantFormat, want != "jpeg", want != "png" {
+            completion(WireFormat.error("photos.export: --format must be jpeg or png (got \(want))")); return
+        }
         let result = PHAsset.fetchAssets(withLocalIdentifiers: [id], options: nil)
         guard let a = result.firstObject else { completion(WireFormat.error("photos.export: not found")); return }
         let outURL = URL(fileURLWithPath: (outPath as NSString).expandingTildeInPath)
@@ -341,11 +347,32 @@ final class PhotosDomain: DomainHandler, @unchecked Sendable {
         } else {
             manager.requestImageDataAndOrientation(for: a, options: opts) { data, uti, _, _ in
                 guard let data = data else { completion(WireFormat.error("photos.export: no data")); return }
+                // Without --size this hands back the asset's original bytes, which for most
+                // iPhone captures is HEIC. --format lets a caller ask for something portable
+                // without also having to resize; previously it was accepted and discarded,
+                // so `--format jpeg --out shot.jpg` wrote a HEIC under a .jpg name and every
+                // downstream consumer that trusts the extension broke confusingly.
+                var outData = data
+                var outUTI: String? = uti
+                if let want = wantFormat, want == "jpeg" || want == "png" {
+                    let targetUTI = want == "jpeg" ? "public.jpeg" : "public.png"
+                    if uti != targetUTI {
+                        guard let rep = NSBitmapImageRep(data: data),
+                              let converted = rep.representation(
+                                using: want == "jpeg" ? .jpeg : .png,
+                                properties: want == "jpeg" ? [.compressionFactor: 0.9] : [:])
+                        else {
+                            completion(WireFormat.error("photos.export: transcode to \(want) failed")); return
+                        }
+                        outData = converted
+                        outUTI = targetUTI
+                    }
+                }
                 do {
-                    try data.write(to: outURL)
+                    try outData.write(to: outURL)
                     completion(WireFormat.success([
                         "ok": true, "assetId": id, "filePath": outURL.path,
-                        "uti": uti as Any? ?? NSNull(), "bytes": data.count,
+                        "uti": outUTI as Any? ?? NSNull(), "bytes": outData.count,
                         "originalWidth": a.pixelWidth, "originalHeight": a.pixelHeight,
                     ]))
                 } catch {
@@ -409,8 +436,13 @@ final class PhotosDomain: DomainHandler, @unchecked Sendable {
         opts.isSynchronous = false
         opts.deliveryMode = .highQualityFormat
         opts.isNetworkAccessAllowed = true
-        let save = (action["save"] as? Bool) ?? false
         let outRequested = action["out"] as? String
+        // Passing --out is itself a request to write a file. Requiring --save alongside it
+        // meant `thumbnail <id> --out shot.jpg` wrote nothing and instead returned the image
+        // inline as a base64 dataUrl, which for an agent caller is a large payload delivered
+        // at exactly the moment it asked for a path instead. Backward compatible: --out
+        // without --save previously had no effect, so nothing can depend on the old behavior.
+        let save = (action["save"] as? Bool) ?? (outRequested != nil)
         PHImageManager.default().requestImage(for: a, targetSize: target, contentMode: .aspectFit, options: opts) { image, _ in
             guard let image = image else { completion(WireFormat.error("photos.thumbnail: no image")); return }
             guard let tiff = image.tiffRepresentation,

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/PhotosDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/PhotosDomainTests.swift
@@ -65,6 +65,43 @@ final class PhotosDomainTests: XCTestCase {
         XCTAssertEqual(r["success"] as? Bool, false)
     }
 
+    func testExport_rejectsUnsupportedFormat() {
+        // --format used to be accepted and silently discarded, so a bad value looked
+        // identical to a good one. Validate before any asset lookup can mask it.
+        let r = runVerb("export", action: ["id": "bogus/L0/001", "out": "/tmp/x.jpg", "format": "webp"])
+        XCTAssertEqual(r["success"] as? Bool, false)
+    }
+
+    func testExport_live_formatJpegTranscodesHEIC() throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["LIVE_PHOTOS"] == "1")
+        let assets = runVerb("assets", action: ["limit": 1])
+        guard let list = assets["assets"] as? [[String: Any]], let id = list.first?["id"] as? String else {
+            throw XCTSkip("no assets in library")
+        }
+        let out = NSTemporaryDirectory() + "interceptor-photos-format-test.jpg"
+        let r = runVerb("export", action: ["id": id, "out": out, "format": "jpeg"])
+        XCTAssertEqual(r["success"] as? Bool, true)
+        XCTAssertEqual(r["uti"] as? String, "public.jpeg")
+        try? FileManager.default.removeItem(atPath: out)
+    }
+
+    func testThumbnail_live_outImpliesSave() throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["LIVE_PHOTOS"] == "1")
+        let assets = runVerb("assets", action: ["limit": 1])
+        guard let list = assets["assets"] as? [[String: Any]], let id = list.first?["id"] as? String else {
+            throw XCTSkip("no assets in library")
+        }
+        let out = NSTemporaryDirectory() + "interceptor-photos-thumb-test.jpg"
+        try? FileManager.default.removeItem(atPath: out)
+        // --out alone, no --save: must write the file rather than return a base64 dataUrl.
+        let r = runVerb("thumbnail", action: ["id": id, "out": out])
+        XCTAssertEqual(r["success"] as? Bool, true)
+        XCTAssertNil(r["dataUrl"])
+        XCTAssertEqual(r["filePath"] as? String, out)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: out))
+        try? FileManager.default.removeItem(atPath: out)
+    }
+
     func testAlbums_live() throws {
         try XCTSkipUnless(ProcessInfo.processInfo.environment["LIVE_PHOTOS"] == "1")
         let r = runVerb("albums")


### PR DESCRIPTION
## What

`interceptor macos photos export --size N` never resizes, and never produces a JPEG. The resize + transcode branch in `PhotosDomain.export` is unreachable from the CLI today.

The CLI forwards `--size` through the `flagVal` (string) loop, but the bridge reads it with `as? Int`:

```swift
if let sizePx = action["size"] as? Int, sizePx > 0 {   // never true from the CLI
```

The cast fails, so every call falls through to the raw-original branch and writes the asset's native bytes. On any iPhone-sourced library that means HEIC. `photos thumbnail --size` is hit by the same cast and stays pinned at its 256px default.

This is the trap the existing comment above that flag loop already calls out for `--limit`/`--offset`:

> `--limit/--offset must be int-typed because PhotosDomain casts them with `as? Int` (verified — string casts silently drop the value, causing accidental full-library fetches)`

`--size` was left in the string list.

Reproducer on 0.23.12 (4284x5712 HEIC original):

```
$ interceptor macos photos export "<id>/L0/001" --out small.jpg --size 400 --json
{ "ok": true, "uti": "public.heic", "bytes": 2179085,
  "originalWidth": 4284, "originalHeight": 5712 }
```

`--size 400` ignored, no `exportWidth`/`exportHeight`, 2.1 MB HEIC written to `small.jpg`.

## Two related flags that are accepted and discarded

**`--format`** is not mapped into the action at all, so `--format jpeg` is silently dropped by the CLI before the bridge ever sees it. Combined with the above, there is currently no way to get a JPEG out of `photos export`. Since `--out` names the file, the result is HEIC bytes under a `.jpg` name, which fails downstream in ways that look like a rendering bug rather than a format bug (my case: iMessage attachment previews).

**`photos thumbnail --out`** is read but only consulted inside the `save` branch, so `--out` alone writes nothing and returns the image inline as a base64 `dataUrl` instead. For an agent caller that is a sizable payload delivered at precisely the moment it asked for a path. Note `photos export` requires `--out` and always writes to it, so the two verbs currently disagree about what `--out` means.

## Changes

- **`cli/commands/macos.ts`** — parse `--size` with `flagInt`; add `--format` to the forwarded flags.
- **`PhotosDomain.export`** — honor `--format jpeg|png` in the no-`--size` branch by transcoding the original. Validated up front, before the asset fetch, so an unsupported value reports itself rather than hiding behind a `not found` from an unrelated bad id.
- **`PhotosDomain.thumbnail`** — `let save = (action["save"] as? Bool) ?? (outRequested != nil)`. Backward compatible: `--out` without `--save` previously had no effect, so nothing can depend on the old behavior.
- **`cli/help.ts`** — document `--size` and `--format` on `export` and the `--out` behavior on `thumbnail`. Neither flag appeared in help.
- **Tests** — one offline test that `--format webp` is rejected, plus two `LIVE_PHOTOS=1` tests covering the JPEG transcode and `--out`-implies-save.

## Verification

- `bunx tsc -p tsconfig.host.json` clean.
- `swift build` clean (only a pre-existing unrelated `SKView` warning).
- `swift test --filter PhotosDomainTests`: 14 passed, 0 failures.
- The bug itself is reproduced above against the released 0.23.12 binary.

One caveat, stated plainly: the two `LIVE_PHOTOS=1` tests **skip** in my run, because the `swift test` binary is not the signed `com.interceptor.bridge` bundle and therefore holds no Photos TCC grant, so `assets` returns nothing to exercise. They skip cleanly rather than fail. If you have a harness that runs them against a granted binary, they are the ones worth watching.

## Why I hit this

I was pulling iCloud-only originals out of Photos for an automation. `osxphotos --use-photokit` cannot ever work for this: it is a bundle-less CLI, so TCC has nothing to register and the grant is unobtainable. Interceptor's signed bridge carries `NSPhotoLibraryUsageDescription` plus the photos-library entitlement, so `photos export` retrieves them fine, which is genuinely the only working path I found on macOS 26. These three papercuts were the only friction, and I worked around all of them locally. Nothing here is blocking; it is correctness cleanup found while integrating.

Unrelated but worth a look while you are in here: `photos request` returns a hard `error: timeout: no response for 'macos_photos' after 15s` when the TCC consent prompt is merely still waiting for a human. The prompt does render and approving it works, but the CLI has already reported what reads like a failed capability. An agent will conclude Photos support is broken and stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS photo export options for selecting output format and thumbnail size.
  - Photo exports now support JPEG and PNG formats, including conversion when needed.
  - Thumbnails are automatically saved when an output path is provided; inline output remains available otherwise.

- **Bug Fixes**
  - Improved handling and validation of photo export options.
  - Export results now accurately report the output format and file size.

- **Documentation**
  - Updated command-line help with photo export and thumbnail usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->