### PR TITLE
fix(macos/photos): --format composes with --size in export (follow-up to #187)

### DIFF
--- a/interceptor-bridge/Sources/Domains/PhotosDomain.swift
+++ b/interceptor-bridge/Sources/Domains/PhotosDomain.swift
@@ -325,17 +325,25 @@ final class PhotosDomain: DomainHandler, @unchecked Sendable {
         opts.isNetworkAccessAllowed = true
 
         if let sizePx = action["size"] as? Int, sizePx > 0 {
+            // --format composes with --size: encode the resized image as PNG when asked,
+            // else JPEG (the long-standing default). Otherwise --size + --format png
+            // writes JPEG bytes under a .png name — the same trusts-the-extension
+            // breakage the no-size branch below exists to prevent.
+            let usePNG = wantFormat == "png"
             let target = CGSize(width: sizePx, height: sizePx)
             manager.requestImage(for: a, targetSize: target, contentMode: .aspectFit, options: opts) { image, _ in
                 guard let image = image,
                       let tiff = image.tiffRepresentation,
                       let rep = NSBitmapImageRep(data: tiff),
-                      let data = rep.representation(using: .jpeg, properties: [.compressionFactor: 0.85])
+                      let data = rep.representation(
+                        using: usePNG ? .png : .jpeg,
+                        properties: usePNG ? [:] : [.compressionFactor: 0.85])
                 else { completion(WireFormat.error("photos.export: encode failed")); return }
                 do {
                     try data.write(to: outURL)
                     completion(WireFormat.success([
-                        "ok": true, "assetId": id, "filePath": outURL.path, "uti": "public.jpeg",
+                        "ok": true, "assetId": id, "filePath": outURL.path,
+                        "uti": usePNG ? "public.png" : "public.jpeg",
                         "bytes": data.count,
                         "originalWidth": a.pixelWidth, "originalHeight": a.pixelHeight,
                         "exportWidth": Int(image.size.width), "exportHeight": Int(image.size.height),
@@ -360,7 +368,7 @@ final class PhotosDomain: DomainHandler, @unchecked Sendable {
                         guard let rep = NSBitmapImageRep(data: data),
                               let converted = rep.representation(
                                 using: want == "jpeg" ? .jpeg : .png,
-                                properties: want == "jpeg" ? [.compressionFactor: 0.9] : [:])
+                                properties: want == "jpeg" ? [.compressionFactor: 0.85] : [:])
                         else {
                             completion(WireFormat.error("photos.export: transcode to \(want) failed")); return
                         }

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/PhotosDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/PhotosDomainTests.swift
@@ -85,6 +85,26 @@ final class PhotosDomainTests: XCTestCase {
         try? FileManager.default.removeItem(atPath: out)
     }
 
+    func testExport_live_sizeComposesWithFormatPng() throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["LIVE_PHOTOS"] == "1")
+        let assets = runVerb("assets", action: ["limit": 1])
+        guard let list = assets["assets"] as? [[String: Any]], let id = list.first?["id"] as? String else {
+            throw XCTSkip("no assets in library")
+        }
+        let out = NSTemporaryDirectory() + "interceptor-photos-size-png-test.png"
+        // The resize branch used to hardcode JPEG, so --size + --format png wrote
+        // JPEG bytes under a .png name. The two flags must compose.
+        let r = runVerb("export", action: ["id": id, "out": out, "size": 200, "format": "png"])
+        XCTAssertEqual(r["success"] as? Bool, true)
+        XCTAssertEqual(r["uti"] as? String, "public.png")
+        if let data = FileManager.default.contents(atPath: out) {
+            XCTAssertEqual([UInt8](data.prefix(4)), [0x89, 0x50, 0x4E, 0x47]) // PNG magic
+        } else {
+            XCTFail("no file written at \(out)")
+        }
+        try? FileManager.default.removeItem(atPath: out)
+    }
+
     func testThumbnail_live_outImpliesSave() throws {
         try XCTSkipUnless(ProcessInfo.processInfo.environment["LIVE_PHOTOS"] == "1")
         let assets = runVerb("assets", action: ["limit": 1])


### PR DESCRIPTION
## What

Follow-up to #187. The resize branch of `PhotosDomain.export` hardcoded JPEG encoding and reported `public.jpeg` unconditionally, so `export --size N --format png` wrote JPEG bytes under a `.png` name — the exact trusts-the-extension breakage #187's no-size branch exists to prevent. Proven live on a granted bridge build:

```
$ interceptor macos photos export "<id>" --out x.png --size 400 --format png --json
{ "uti": "public.jpeg", ... }   # file(1): JPEG image data
```

## Changes

- **`PhotosDomain.export`** resize branch: encode PNG when `--format png` (else JPEG at the file's standard 0.85) and report the true `uti`. `--format` validation is already handled up front by #187's guard.
- Align #187's no-size transcode `compressionFactor` 0.9 → 0.85 to match every other encode in the file.
- One `LIVE_PHOTOS=1` test: `size` + `format: png` must report `public.png` and write real PNG magic bytes. Skips cleanly without a Photos TCC grant, same as the existing live tests.

## Verification

- `bunx tsc -p tsconfig.host.json` clean.
- `swift test --filter PhotosDomainTests`: 15 tests, 0 failures (4 live skips without grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Photo exports now correctly honor PNG format requests when resizing, including accurate PNG file identification.
  * Resized JPEG exports continue to preserve compression settings.
  * Non-resized JPEG conversions now use improved compression for more consistent output quality.

* **Tests**
  * Added coverage for combined resize and PNG export options, including file validity and temporary-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->