### PR TITLE
feat(windows): bundle the unpacked extension on disk at {app}\extension

### DIFF
--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -7,7 +7,7 @@ Interceptor for Windows is browser-only. It supports Windows 11 24H2 or newer on
 1. Download the architecture-matched `Interceptor-Browser-X.Y.Z-windows-x64.exe` or `Interceptor-Browser-X.Y.Z-windows-arm64.exe` from the matching GitHub release.
 2. Verify that Windows reports the publisher as **Hacker Valley Media**. Do not continue with an unsigned or differently signed production artifact.
 3. Run Setup. New installs use `%LOCALAPPDATA%\Programs\Interceptor`; upgrades and repairs preserve the existing same-product directory.
-4. Install the Interceptor extension from the Chrome Web Store for Chrome or Brave, or Microsoft Edge Add-ons for Edge. Setup never changes a browser profile or installs an extension without consent.
+4. Load the Interceptor extension. Setup drops an unpacked copy on disk at `%LOCALAPPDATA%\Programs\Interceptor\extension`; open your browser's extensions page (`chrome://extensions`, `brave://extensions`, or `edge://extensions`), enable **Developer mode**, click **Load unpacked**, and select that folder. Once the store listing is public you can install from the Chrome Web Store (Chrome/Brave) or Microsoft Edge Add-ons (Edge) instead. Setup never changes a browser profile or loads the extension without consent — it only stages the files.
 5. Open a new terminal and run:
 
    ```powershell
@@ -51,7 +51,7 @@ Uninstall removes only installer-owned PATH/native-host state and owned skill li
 
 - **Command not found:** open a new terminal, then run the executable directly from the install directory once to confirm the install.
 - **Unknown command or stale behavior:** run `where.exe interceptor`. If another copy resolves before `%LOCALAPPDATA%\Programs\Interceptor` (for example a leftover development install), remove that earlier PATH entry; the installer never edits PATH entries it does not own.
-- **Extension not connected:** confirm the store extension is enabled, then run `interceptor init --verbose`.
+- **Extension not connected:** confirm the extension is loaded (via **Load unpacked** from `%LOCALAPPDATA%\Programs\Interceptor\extension`, or the store listing once public) and enabled, then run `interceptor init --verbose`.
 - **Install/upgrade in progress:** wait for Setup to finish. If Setup was interrupted, rerun the same signed installer so its pending transaction can recover.
 - **Ports 19221/19222 already in use:** Interceptor v1 supports one active interactive Windows user. Stop the other Interceptor/development instance; Setup never terminates an unidentified process.
 - **Legacy administrator preview detected:** remove that copy from Installed apps with an administrator account, then rerun the per-user installer.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -274,6 +274,18 @@ build_windows_arch() {
   fi
   bun scripts/installer/generate-native-host.ts "${identity_flag[@]}" \
     --output "$stage/daemon/com.interceptor.host.json"
+
+  # Bundle the unpacked browser extension so the installer drops it on disk at
+  # {app}\extension — a single, stable place for the user to point "Load
+  # unpacked" (Developer mode). Mirrors the macOS package, which ships it under
+  # ~/Library/Application Support/Interceptor/extension. The extension is
+  # arch-independent (browser JS) and gitignored, so build it once if the
+  # windows-only target skipped build_extension, then stage a copy per arch.
+  if [[ ! -f extension/dist/manifest.json ]]; then
+    build_extension
+  fi
+  rm -rf "$stage/extension"
+  cp -R extension/dist "$stage/extension"
 }
 
 build_bridge() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -278,11 +278,12 @@ build_windows_arch() {
   # Bundle the unpacked browser extension so the installer drops it on disk at
   # {app}\extension — a single, stable place for the user to point "Load
   # unpacked" (Developer mode). Mirrors the macOS package, which ships it under
-  # ~/Library/Application Support/Interceptor/extension. The extension is
-  # arch-independent (browser JS) and gitignored, so build it once if the
-  # windows-only target skipped build_extension, then stage a copy per arch.
+  # ~/Library/Application Support/Interceptor/extension. Every target that calls
+  # build_windows_arch builds the extension first (see the dispatch below), so
+  # dist is always current here; fail loud rather than stage a stale copy.
   if [[ ! -f extension/dist/manifest.json ]]; then
-    build_extension
+    echo "extension/dist is missing — build_extension must run before build_windows_arch" >&2
+    exit 1
   fi
   rm -rf "$stage/extension"
   cp -R extension/dist "$stage/extension"
@@ -324,8 +325,10 @@ elif [[ "$TARGET" == "macos" ]]; then
   build_macos
   build_bridge
 elif [[ "$TARGET" == "windows-x64" ]]; then
+  build_extension
   build_windows_arch x64
 elif [[ "$TARGET" == "windows-arm64" ]]; then
+  build_extension
   build_windows_arch arm64
 elif [[ "$TARGET" == "windows" ]]; then
   echo "Unsupported target: windows. Use --target=windows-x64 or --target=windows-arm64." >&2

--- a/scripts/installer/interceptor.iss
+++ b/scripts/installer/interceptor.iss
@@ -83,9 +83,19 @@ Source: "{#StageDir}\interceptor.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\interceptor.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageDir}\daemon\interceptor-daemon.exe"; DestDir: "{app}\daemon"; Flags: ignoreversion
 Source: "{#StageDir}\daemon\com.interceptor.host.json"; DestDir: "{app}\daemon"; Flags: ignoreversion
+; Unpacked browser extension dropped on disk so the user has one stable place to
+; point "Load unpacked" (Developer mode). Setup still never touches a browser
+; profile or loads it automatically — it only stages the files.
+Source: "{#StageDir}\extension\*"; DestDir: "{app}\extension"; Excludes: "._*"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\..\.agents\skills\interceptor\*"; DestDir: "{app}\skills\interceptor"; Excludes: "._*"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\..\.agents\skills\interceptor-browser\*"; DestDir: "{app}\skills\interceptor-browser"; Excludes: "._*"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\..\.agents\skills\interceptor-research\*"; DestDir: "{app}\skills\interceptor-research"; Excludes: "._*"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[UninstallDelete]
+; recursesubdirs leaves the extension's (empty) subdir tree behind on uninstall;
+; remove the whole staged extension folder explicitly. filesandordirs also clears
+; anything a user dropped in — the browser only reads from here, never writes.
+Type: filesandordirs; Name: "{app}\extension"
 
 [Run]
 Filename: "https://github.com/Hacker-Valley-Media/Interceptor/blob/v{#AppVersion}/docs/windows-install.md"; Description: "Open the Windows setup guide"; Flags: shellexec postinstall skipifsilent unchecked nowait

--- a/scripts/installer/post-install.txt
+++ b/scripts/installer/post-install.txt
@@ -1,7 +1,14 @@
 Interceptor (Browser-Only) is installed.
 
-1. Install the Interceptor extension from your browser's approved store.
-   Chrome and Brave use the Chrome Web Store; Edge uses Microsoft Edge Add-ons.
+1. Load the bundled Interceptor extension. Setup dropped an unpacked copy on
+   disk at:
+
+       %LOCALAPPDATA%\Programs\Interceptor\extension
+
+   In Chrome, Brave, or Edge: open the extensions page (chrome://extensions,
+   brave://extensions, or edge://extensions), turn on Developer mode, click
+   "Load unpacked", and select that folder. (Once the store listing is public
+   you can install from the Chrome Web Store / Microsoft Edge Add-ons instead.)
 2. Open a new terminal so Windows loads the updated user PATH.
 3. Run:
 
@@ -11,9 +18,10 @@ Optional AI skill packs are bundled but are never linked without your consent:
 
     interceptor skills adopt
 
-The installer does not change browser profiles, enable developer mode, load an
-unpacked extension, start the daemon, or install extensions without consent.
-The daemon starts on demand after a CLI or browser-extension request.
+The installer stages the extension files on disk but does not change browser
+profiles, enable developer mode, load the extension, start the daemon, or
+install anything into a browser without consent. The daemon starts on demand
+after a CLI or browser-extension request.
 
 Windows support: Windows 11 24H2 or newer, x64 or ARM64, one active interactive
 user per machine. The native macOS commands (interceptor macos *) are not

--- a/scripts/installer/test-windows-installer.ps1
+++ b/scripts/installer/test-windows-installer.ps1
@@ -103,7 +103,9 @@ try {
   $icon = Join-Path $installRoot 'interceptor.ico'
   $uninstaller = Join-Path $installRoot 'unins000.exe'
   foreach ($path in @($cli, $daemon, $manifest, $icon, $uninstaller)) { Assert-True (Test-Path -LiteralPath $path) "Missing installed payload: $path" }
-  Assert-True (-not (Test-Path -LiteralPath (Join-Path $installRoot 'extension'))) 'Production installer included an unpacked extension.'
+  $extensionManifest = Join-Path $installRoot 'extension\manifest.json'
+  Assert-True (Test-Path -LiteralPath $extensionManifest) 'Unpacked extension was not dropped on disk for Load unpacked.'
+  Assert-True ((Get-Content -LiteralPath $extensionManifest -Raw | ConvertFrom-Json).manifest_version -eq 3) 'Bundled extension manifest is not a valid MV3 manifest.'
   Assert-True ((Get-Machine $cli) -eq $expectedMachine) 'Installed CLI architecture mismatch.'
   Assert-True ((Get-Machine $daemon) -eq $expectedMachine) 'Installed daemon architecture mismatch.'
   Assert-True ((& $cli --version) -match [regex]::Escape($Version)) 'Installed CLI version mismatch.'
@@ -143,6 +145,7 @@ try {
   $installed = $false
 
   Assert-True (-not (Test-Path -LiteralPath $cli)) 'CLI remained after uninstall.'
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $installRoot 'extension'))) 'Bundled extension remained after uninstall.'
   $pathAfterUninstall = Read-RegistryValue 'Environment' 'Path'
   Assert-True ($pathAfterUninstall.Exists -eq $pathSnapshot.Exists) 'PATH value presence was not restored.'
   if ($pathSnapshot.Exists) {

--- a/test/windows-release-contract.test.ts
+++ b/test/windows-release-contract.test.ts
@@ -126,14 +126,24 @@ describe("Windows production release contract", () => {
     expect(installer).toContain("Interceptor-Browser-1.2.3-windows-arm64.exe")
   })
 
-  test("removes PR 156's developer-mode and unpacked-extension behavior", () => {
+  test("ships the extension on disk for Load unpacked without auto-loading it", () => {
     const postInstall = read("scripts/installer/post-install.txt")
     const docs = read("docs/windows-install.md")
-    expect(postInstall).not.toMatch(/toggle developer|click ["']?load unpacked|enable developer mode\./i)
-    expect(postInstall).toContain("does not change browser profiles")
+    const iss = read("scripts/installer/interceptor.iss")
+    // The unpacked extension is staged on disk at {app}\extension, and both the
+    // installer copy and the uninstaller cleanup are declared.
+    expect(iss).toContain('Source: "{#StageDir}\\extension\\*"; DestDir: "{app}\\extension"')
+    expect(iss).toMatch(/\[UninstallDelete\][\s\S]*Type: filesandordirs; Name: "\{app\}\\extension"/)
+    expect(read("scripts/build.sh")).toContain('cp -R extension/dist "$stage/extension"')
+    // Docs/post-install point users at that on-disk folder for Load unpacked.
+    expect(postInstall).toContain("%LOCALAPPDATA%\\Programs\\Interceptor\\extension")
+    expect(docs).toContain("%LOCALAPPDATA%\\Programs\\Interceptor\\extension")
     expect(docs).toContain("Chrome Web Store")
     expect(docs).toContain("Microsoft Edge Add-ons")
     expect(docs).toContain("one active interactive user")
-    expect(docs).not.toMatch(/click ["']?load unpacked|enable developer mode\./i)
+    // Staging files is not loading them: Setup must never load the extension or
+    // change a browser profile on the user's behalf.
+    expect(postInstall).toMatch(/does not change browser[\s\S]*profiles/)
+    expect(postInstall).toMatch(/never (linked|loads?)|without your consent|without consent/i)
   })
 })


### PR DESCRIPTION
Closes #194.

## What

The Windows installer now drops an unpacked copy of the browser extension at `%LOCALAPPDATA%\Programs\Interceptor\extension` — one stable place to point **Load unpacked** (Developer mode) at, matching the macOS package (which ships it under `~/Library/Application Support/Interceptor/extension`). With the store listings still pending, this removes the need to clone and build from source just to load the extension.

Setup behavior is unchanged otherwise: it stages files only — it never touches a browser profile, enables developer mode, or loads the extension automatically.

## How

- **`scripts/build.sh`** — `build_windows_arch` stages `extension/dist` into `dist/windows/<arch>/extension`, building the extension first if the windows-only target skipped it. The extension is a gitignored build output, so it must ride the staged artifact into CI's installer compile job (it cannot be referenced repo-relative from the `.iss` like the committed skills).
- **`scripts/installer/interceptor.iss`** — new `[Files]` entry installing `{#StageDir}\extension\*` to `{app}\extension`, and a new `[UninstallDelete] filesandordirs` entry: `recursesubdirs` removes files on uninstall but leaves the empty `createallsubdirs` tree behind (a real defect the updated harness caught on the first run).
- **`scripts/installer/test-windows-installer.ps1`** — flips the deliberate extension-absent assertion to: extension present with a valid MV3 manifest after install, and fully gone after uninstall.
- **`scripts/installer/post-install.txt` / `docs/windows-install.md`** — instructions now lead with the on-disk Load-unpacked path; store install remains the path once listings are public.

## Verification

On a clean Windows 11 ARM64 VM (Chromium 151 browsers):

- `test-windows-installer.ps1` acceptance harness (install → verify → repair → uninstall): **passed**, including both new assertions.
- Real silent install: all 20 extension files on disk with a valid MV3 manifest (pinned key intact).
- The **installed** copy (not a checkout) loaded via Load-unpacked connects native messaging end-to-end — `native host connected (pong received)`, daemon spawned from the installed path — verified in Chrome, Edge, and Brave.
- Installer size cost: ~4.6 MB per arch (LZMA-compressed extension incl. Tesseract OCR assets).

No version bump — packaging + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows installations now include the browser extension for local, unpacked loading.
  * Added Chrome and Edge setup instructions, including Developer mode and “Load unpacked” steps.

* **Bug Fixes**
  * Uninstalling now removes the bundled extension and any added contents.
  * Installation no longer modifies browser profiles, automatically loads the extension, or starts the daemon.

* **Documentation**
  * Updated Windows installation and troubleshooting guidance for both local and store-based extension installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->