### PR TITLE
fix(build): bash-3.2-safe empty-array expansion in build.sh windows lane

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -272,7 +272,7 @@ build_windows_arch() {
   if [[ "${INTERCEPTOR_WINDOWS_IDENTITY_MODE:-production}" == "development" ]]; then
     identity_flag=(--development)
   fi
-  bun scripts/installer/generate-native-host.ts "${identity_flag[@]}" \
+  bun scripts/installer/generate-native-host.ts ${identity_flag[@]+"${identity_flag[@]}"} \
     --output "$stage/daemon/com.interceptor.host.json"
 
   # Bundle the unpacked browser extension so the installer drops it on disk at


### PR DESCRIPTION
One-line portability fix: `"${identity_flag[@]}"` under `set -u` aborts on macOS's default bash 3.2 when the array is empty (`identity_flag[@]: unbound variable`), killing every local `--target=windows-x64/arm64` build at the native-host generation step. Replaced with the standard `${arr[@]+"${arr[@]}"}` guard. CI's newer bash expands empty arrays fine either way — no behavior change there. Found while building the 0.23.17 Windows installers (attached to the release, ARM64 validated via the acceptance harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)