### PR TITLE
fix(build): refresh Windows runner-image pin to win25-vs2026/20260803.193

### DIFF
--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "runner": {
     "label": "windows-2025",
-    "imageOS": "win25",
-    "imageVersion": "20260719.202.1",
-    "releaseTag": "win25/20260719.202",
+    "imageOS": "win25-vs2026",
+    "imageVersion": "20260803.193.1",
+    "releaseTag": "win25-vs2026/20260803.193",
     "osBuild": "10.0.26100.33158"
   },
   "bun": {

--- a/test/windows-release-contract.test.ts
+++ b/test/windows-release-contract.test.ts
@@ -22,7 +22,7 @@ describe("Windows production release contract", () => {
     expect(read(".bun-version").trim()).toBe("1.3.14")
     expect(lock.bun.version).toBe("1.3.14")
     expect(lock.runner.label).toBe("windows-2025")
-    expect(lock.runner.imageOS).toBe("win25")
+    expect(lock.runner.imageOS).toBe("win25-vs2026")
     expect(lock.innoSetup.version).toBe("7.0.2")
     expect(lock.innoSetup.commercialLicenseEvidenceRequired).toBe(true)
     for (const sha of Object.values(lock.actions) as string[]) expect(sha).toMatch(/^[0-9a-f]{40}$/)


### PR DESCRIPTION
GitHub rotated the `windows-2025` runner image and renamed its `ImageOS` identifier from `win25` to `win25-vs2026` (release `win25-vs2026/20260803.193`, OS build 10.0.26100.33158). The stale pin fails the runner-image guard on every tag build until refreshed — verified against live run 31512135944, which reported `Unapproved runner image: win25-vs2026 20260803.193.1`.

Signing lane is otherwise fully provisioned: identity validation approved, certificate profile `hvm-public-trust` Active. Once this merges, the next `v*.*.*` tag produces signed Windows installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build environment to use the latest Visual Studio 2026-based toolchain image.
  * Updated the associated image version and release tag.
  * Updated release validation to require the pinned toolchain image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->