### PR TITLE
fix(build): pre-seed pinned Bun cross-compile targets in the workspace root

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -60,6 +60,24 @@ jobs:
       - name: Validate store identity consistency
         run: bun scripts/installer/generate-native-host.ts --development --output native-host-development.json
 
+      # Bun's own cross-target fetch renames across drives (workspace on D:,
+      # cache on C:) and fails on these runners, so pre-seed the pinned target
+      # executables in the workspace root, where bun looks before downloading.
+      - name: Pre-seed pinned Bun cross-compile targets
+        shell: pwsh
+        run: |
+          $lock = Get-Content scripts/installer/windows-toolchain.lock.json -Raw | ConvertFrom-Json
+          foreach ($target in $lock.bunCompileTargets) {
+            $tarball = Join-Path $env:RUNNER_TEMP "$($target.seedFile).tgz"
+            Invoke-WebRequest -Uri $target.url -OutFile $tarball
+            if ((Get-FileHash $tarball -Algorithm SHA256).Hash.ToLowerInvariant() -ne $target.sha256) { throw "Hash mismatch: $($target.seedFile)" }
+            $extract = Join-Path $env:RUNNER_TEMP "$($target.seedFile)-extract"
+            New-Item -ItemType Directory -Force -Path $extract | Out-Null
+            tar -xzf $tarball -C $extract
+            if ($LASTEXITCODE -ne 0) { throw "Extraction failed: $($target.seedFile)" }
+            Move-Item (Join-Path $extract 'package/bin/bun.exe') $target.seedFile
+          }
+
       - name: Build native Windows payloads
         shell: bash
         env:

--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -11,6 +11,18 @@
     "versionFile": ".bun-version",
     "version": "1.3.14"
   },
+  "bunCompileTargets": [
+    {
+      "seedFile": "bun-windows-x64-baseline-v1.3.14",
+      "url": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.14.tgz",
+      "sha256": "0b080a2b30baefe85a529a12d795be47a9d42f57a9e3afbf7dda1b3d3387cbb7"
+    },
+    {
+      "seedFile": "bun-windows-aarch64-v1.3.14",
+      "url": "https://registry.npmjs.org/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.14.tgz",
+      "sha256": "e5eaf06e99b5fb4c11cff7c60fcc8c722e624348e3be3d1c51639af06ff73bc0"
+    }
+  ],
   "innoSetup": {
     "version": "7.0.2",
     "edition": "x64",

--- a/test/windows-release-contract.test.ts
+++ b/test/windows-release-contract.test.ts
@@ -23,6 +23,15 @@ describe("Windows production release contract", () => {
     expect(lock.bun.version).toBe("1.3.14")
     expect(lock.runner.label).toBe("windows-2025")
     expect(lock.runner.imageOS).toBe("win25-vs2026")
+    // Cross-compile target seeds must track the pinned Bun version exactly —
+    // bumping .bun-version forces a lock refresh here.
+    expect(lock.bunCompileTargets).toHaveLength(2)
+    for (const target of lock.bunCompileTargets) {
+      expect(target.seedFile.endsWith(`-v${lock.bun.version}`)).toBe(true)
+      expect(target.url).toStartWith("https://registry.npmjs.org/@oven/bun-windows-")
+      expect(target.url).toContain(`-${lock.bun.version}.tgz`)
+      expect(target.sha256).toMatch(/^[0-9a-f]{64}$/)
+    }
     expect(lock.innoSetup.version).toBe("7.0.2")
     expect(lock.innoSetup.commercialLicenseEvidenceRequired).toBe(true)
     for (const sha of Object.values(lock.actions) as string[]) expect(sha).toMatch(/^[0-9a-f]{40}$/)


### PR DESCRIPTION
Run 31519256083 (both attempts) died at `Failed to extract executable for 'bun-windows-x64-baseline-v1.3.14'`. The npm tarball itself is fine (verified: correct structure, extracts cleanly). Root cause: Bun extracts the downloaded target to a temp dir under the workspace and then renames `bun.exe` into its install cache — on GitHub Windows runners the workspace lives on `D:` and the cache on `C:`, and that cross-drive rename fails deterministically.

Bun checks the working directory for a file named `<target>-v<version>` before downloading anything (`CompileTarget::exe_path`), so this adds a `bunCompileTargets` section to the toolchain lock (npm tarball URLs + SHA256, tracked to the pinned Bun version by the release contract test) and a workflow step that fetches, hash-verifies, extracts, and seeds both target executables in the workspace root. No more mid-build downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer builds by ensuring required Bun components are available before packaging.
  * Added integrity verification for downloaded build components.

* **Tests**
  * Added release checks for supported Windows x64 and ARM64 targets, pinned versions, download sources, and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->