### PR TITLE
fix(installer): preserve a trailing PATH separator across install/uninstall

### DIFF
--- a/scripts/installer/interceptor.iss
+++ b/scripts/installer/interceptor.iss
@@ -452,7 +452,9 @@ begin
   else if CountPathTokens(Current, Target) = 0 then
   begin
     if Current = '' then Intended := Target
-    else if Current[Length(Current)] = ';' then Intended := Current + Target
+    { A trailing separator belongs to the prior value: append "Target;" so the
+      uninstall splice removes "Target;" and restores the value byte-exactly. }
+    else if Current[Length(Current)] = ';' then Intended := Current + Target + ';'
     else Intended := Current + ';' + Target;
     Added := 1;
   end


### PR DESCRIPTION
Run 31521544137 got through signing, installer compilation, install, and signature verification, then failed the E2E gauntlet at 'PATH raw value was not restored.' Root cause: when the pre-install user `Path` ends with a trailing `;` (GitHub runners' default user Path does), `CapturePath` appended the install root directly after it and `RemoveOwnedPath`'s splice then consumed that separator along with the token — restoring `a;b` where the original was `a;b;`.

One-line fix: append `Target;` when the prior value ends with `;`, so the uninstall splice removes exactly the installer's own addition. All other shapes (empty, no trailing separator, mid-string token) already round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)