### PR TITLE
fix(release): accept both representations of winget's warning exit code and log it

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -319,9 +319,12 @@ jobs:
           winget validate --manifest "dist/release/winget/HackerValleyMedia.Interceptor/$version"
           # 0x8A150081 = APPINSTALLER_CLI_ERROR_MANIFEST_VALIDATION_WARNING:
           # the manifests are valid; the runner's winget build may still warn
-          # about the schema header line. Real validation failures (0x8A150082
-          # and anything else) still throw.
-          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335103) { throw 'WinGet validation failed' }
+          # about the schema header line. pwsh surfaces the DWORD as signed or
+          # unsigned depending on host, so accept both spellings. Real
+          # validation failures (0x8A150082 and anything else) still throw.
+          $code = $LASTEXITCODE
+          Write-Host "winget validate exit code: $code"
+          if ($code -ne 0 -and $code -ne -1978335103 -and $code -ne 2316632193) { throw "WinGet validation failed (exit $code)" }
       - name: Create or verify immutable draft and upload once
         shell: pwsh
         env:


### PR DESCRIPTION
Run 31525915050 still threw at the winget gate: the signed form (-1978335103) alone didn't match, so the runner's pwsh is surfacing the DWORD unsigned (2316632193) or the build returns a different code. Accept both spellings of 0x8A150081 and Write-Host the actual exit code so any remaining mismatch self-documents in the log instead of costing another blind iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)