### PR TITLE
fix(release): exit 0 after the winget warning guard passes

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -325,6 +325,9 @@ jobs:
           $code = $LASTEXITCODE
           Write-Host "winget validate exit code: $code"
           if ($code -ne 0 -and $code -ne -1978335192 -and $code -ne 2316632104) { throw "WinGet validation failed (exit $code)" }
+          # The Actions pwsh epilogue re-exits with $LASTEXITCODE, which is
+          # still winget's warning code after the guard passes.
+          exit 0
       - name: Create or verify immutable draft and upload once
         shell: pwsh
         env:


### PR DESCRIPTION
Run 31528347715: the guard finally matched (logged code -1978335192) and did not throw — but the step still failed, because GitHub Actions appends `if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }` to pwsh steps, re-exiting with winget's non-zero warning code. Explicit `exit 0` after the guard; the `throw` path still fails the step on real validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)