### PR TITLE
fix(install): point the missing-daemon hint at the target that writes it

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -227,7 +227,7 @@ if ($DryRun) { Write-Host "==> DRY RUN — no files will be created or modified.
 
 # ── Preflight ────────────────────────────────────────────────────────────────────
 if (-not (Test-Path -LiteralPath $DaemonPath)) {
-  Write-Error "ERROR: daemon binary not found at $DaemonPath`n       Build it first: bash scripts/build.sh --target=windows-x64 (or --target=windows-arm64)"
+  Write-Error "ERROR: daemon binary not found at $DaemonPath`n       Build it first: bash scripts/build.sh`n       (The windows-x64 / windows-arm64 targets stage into dist\windows\<arch>\ for the Inno Setup payload, not the paths this script reads.)"
   exit 1
 }
 if (-not $SkipExtension -and -not (Test-Path -LiteralPath $ExtensionDir) -and -not $DryRun) {


### PR DESCRIPTION
`scripts/install.ps1`'s preflight checks for the daemon at `$Root\daemon\interceptor-daemon.exe` (line 229) and, when it's missing, tells you to run `bash scripts/build.sh --target=windows-x64` (line 230). Those two don't meet: `build_windows_arch` writes only into `dist/windows/$arch/` for the Inno Setup payload, so following the hint leaves line 229 failing exactly as before.

The only lane that writes the two paths this script reads — `dist\interceptor.exe` and `daemon\interceptor-daemon.exe` — is the default host target, which is what the extension hint three lines down (line 234) already recommends. This makes line 230 agree with it.

I've also named where the per-arch targets *do* stage, so the message stops reading as a contradiction of `ARCHITECTURE.md`'s Windows payload section.

```
ERROR: daemon binary not found at C:\src\Interceptor\daemon\interceptor-daemon.exe
       Build it first: bash scripts/build.sh
       (The windows-x64 / windows-arm64 targets stage into dist\windows\<arch>\ for the Inno Setup payload, not the paths this script reads.)
```

One line, string-only — no control flow touched. `[Parser]::ParseFile` reports 0 errors and the message renders as above.

Worth a sanity check from your side: I've assumed the host target is the intended source for a developer registration on Windows rather than that line 229 should learn to look under `dist\windows\<arch>\`. Line 234 and the "source-checkout developer registration" banner both point that way, but if you meant the preflight to accept a per-arch staging directory too, that's a different (and larger) patch than this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Windows installation error message with clearer build instructions.
  * Clarified where architecture-specific Windows artifacts are staged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->