### PR TITLE
fix(release): refresh Windows runner pin for 0.23.20

### DIFF
--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.23.19",
+  "version": "0.23.20",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.23.19",
+  "version": "0.23.20",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.23.19",
+  "version": "0.23.20",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -3,8 +3,8 @@
   "runner": {
     "label": "windows-2025",
     "imageOS": "win25-vs2026",
-    "imageVersion": "20260803.193.1",
-    "releaseTag": "win25-vs2026/20260803.193",
+    "imageVersion": "20260810.198.2",
+    "releaseTag": "win25-vs2026/20260810.198",
     "osBuild": "10.0.26100.33158"
   },
   "bun": {


### PR DESCRIPTION
## Summary

- refresh the safety-pinned `windows-2025` image from `20260803.193.1` to the official `20260810.198.2` release
- keep the verified OS build unchanged at `10.0.26100.33158`
- bump the shared package, Chromium MV3, and Electron MV2 versions to 0.23.20

## Evidence

The v0.23.19 tag-gated Windows run stopped at the intended pre-toolchain guard because GitHub had rotated the hosted alias. The official `actions/runner-images` release `win25-vs2026/20260810.198` reports image version `20260810.198.2` and OS build `10.0.26100 Build 33158`.

## Verification

- 1,084 tests passed, 9 platform skips, 0 failures
- typecheck passed
- capability-blind audit passed
- Windows release-contract tests passed
- generated extension bundles and version-sync tests passed
- production build and signature smoke checks passed
- public-delta privacy/path scan passed