### PR TITLE
fix(release): pin the Windows runner to the image GitHub actually serves

### DIFF
--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -3,9 +3,9 @@
   "runner": {
     "label": "windows-2025",
     "imageOS": "win25-vs2026",
-    "imageVersion": "20260818.207.1",
-    "releaseTag": "win25-vs2026/20260818.207",
-    "osBuild": "10.0.26100.33296"
+    "imageVersion": "20260810.198.2",
+    "releaseTag": "win25-vs2026/20260810.198",
+    "osBuild": "10.0.26100.33158"
   },
   "bun": {
     "versionFile": ".bun-version",


### PR DESCRIPTION
## Summary

- Restore the `windows-2025` runner pin to `win25-vs2026` / `20260810.198.2` (release `win25-vs2026/20260810.198`, OS build `10.0.26100.33158`), the image the hosted alias actually serves today.

## Evidence

The `v0.23.23` tag-gated run (32406551764) stopped at the intended pre-toolchain guard with `Unapproved runner image: win25-vs2026 20260810.198.2`. The `win25-vs2026/20260818.207` release is published in `actions/runner-images` but has not been rolled out to the `windows-2025` alias, so the refresh in #219 pinned an image no runner reports yet. The guard behaved exactly as designed: it refused to run release tools on an image that did not match the reviewed pin.

## Verification

- `bun test test/windows-release-contract.test.ts` passes
- Lock-only change; no build surface touched. The `v0.23.23` tag will be moved to the merge commit so the Windows lane re-runs against this pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows 2025 build environment to use an earlier validated image version, release tag, and operating system build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->