### PR TITLE
fix(release): pin the Windows runner to the rolling-out 20260818.207 image

### DIFF
--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -3,9 +3,9 @@
   "runner": {
     "label": "windows-2025",
     "imageOS": "win25-vs2026",
-    "imageVersion": "20260810.198.2",
-    "releaseTag": "win25-vs2026/20260810.198",
-    "osBuild": "10.0.26100.33158"
+    "imageVersion": "20260818.207.1",
+    "releaseTag": "win25-vs2026/20260818.207",
+    "osBuild": "10.0.26100.33296"
   },
   "bun": {
     "versionFile": ".bun-version",


### PR DESCRIPTION
## Summary

- Pin the `windows-2025` runner to `win25-vs2026` / `20260818.207.1` (release `win25-vs2026/20260818.207`, OS build `10.0.26100.33296`), the image the hosted pool is converging on.

## Evidence

Two `v0.23.23` tag-gated runs twelve minutes apart stopped at the pre-toolchain guard with different live images: run 32406551764 reported `20260810.198.2`, run 32407631248 reported `20260818.207.1`. GitHub is mid-rollout of `win25-vs2026/20260818.207` across the `windows-2025` pool, so #220's revert matched the first runner and not the second. The forward pin is the one that stays correct once the rollout completes; a run that lands on a lagging runner during the window is re-run, not re-pinned.

## Verification

- `bun test test/windows-release-contract.test.ts` passes
- Lock-only change; no build surface touched. The `v0.23.23` tag moves to the merge commit so the Windows lane re-runs against this pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows 2025 build environment to use the latest runner image, release tag, and operating system build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->