### PR TITLE
fix(cli): act reads its value from the positional span, not a flag de…

### DIFF
--- a/cli/commands/compound.ts
+++ b/cli/commands/compound.ts
@@ -586,12 +586,46 @@ export async function runRead(
 
 // ── interceptor act <ref> [value] ───────────────────────────────────────────────────
 
+/**
+ * The text `act <ref> [value]` should type, or undefined when the command is a
+ * click. Normalized argv is [cmd, ...positionals, ...flags], so positionalCount
+ * marks where the positional span ends and the value is everything in it after
+ * the ref.
+ *
+ * This used to reject a hardcoded six-flag list instead, which meant every
+ * OTHER global boolean fell through and became the text to type: `act e1
+ * --json` sent input_text carrying the literal "--json" rather than clicking,
+ * and so did --no-skills-hint / --no-research-hint. Same bug class as issue
+ * #217, which fixed the low-level `type` verb this way.
+ *
+ * The filter fallback keeps direct callers that don't pass the boundary
+ * working; it cannot see global booleans, so prefer passing positionalCount.
+ */
+export function actValue(filtered: string[], positionalCount?: number): string | undefined {
+  let valueArgs: string[]
+  if (positionalCount !== undefined) {
+    valueArgs = filtered.slice(2, positionalCount + 1)
+  } else {
+    const flagSet = new Set(["--trusted", "--os", "--append", "--no-read", "--keys", "--timeout"])
+    valueArgs = []
+    let skip = false
+    for (let i = 2; i < filtered.length; i++) {
+      if (skip) { skip = false; continue }
+      if (filtered[i] === "--timeout" || filtered[i] === "--keys") { skip = true; continue }
+      if (flagSet.has(filtered[i])) continue
+      valueArgs.push(filtered[i])
+    }
+  }
+  return valueArgs.length > 0 ? valueArgs.join(" ") : undefined
+}
+
 export async function runAct(
   filtered: string[],
   globalTabId?: number,
   jsonMode = false,
   useWs = false,
-  contextId?: string
+  contextId?: string,
+  positionalCount?: number
 ): Promise<void> {
   const ref = filtered[1]
   if (!ref) {
@@ -606,17 +640,7 @@ export async function runAct(
   const timeoutIdx = filtered.indexOf("--timeout")
   const timeout = timeoutIdx !== -1 ? parseInt(filtered[timeoutIdx + 1]) : 2000
 
-  // Find value: everything after ref that isn't a flag
-  const flagSet = new Set(["--trusted", "--os", "--append", "--no-read", "--keys", "--timeout"])
-  const valueArgs: string[] = []
-  let skip = false
-  for (let i = 2; i < filtered.length; i++) {
-    if (skip) { skip = false; continue }
-    if (filtered[i] === "--timeout" || filtered[i] === "--keys") { skip = true; continue }
-    if (flagSet.has(filtered[i])) continue
-    valueArgs.push(filtered[i])
-  }
-  const value = valueArgs.length > 0 ? valueArgs.join(" ") : undefined
+  const value = actValue(filtered, positionalCount)
 
   const target = parseElementTarget(ref)
 
@@ -839,14 +863,14 @@ function output(jsonMode: boolean, result: { success: boolean; error?: string; d
 export async function runCompoundCommand(
   cmd: string,
   filtered: string[],
-  opts: { jsonMode?: boolean; useWs?: boolean; globalTabId?: number; anyTab?: boolean; contextId?: string }
+  opts: { jsonMode?: boolean; useWs?: boolean; globalTabId?: number; anyTab?: boolean; contextId?: string; positionalCount?: number }
 ): Promise<void> {
   switch (cmd) {
     case "open":    return runOpen(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId)
     case "websearch":
     case "search":  return runWebsearch(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId)
     case "read":    return runRead(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId)
-    case "act":     return runAct(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId)
+    case "act":     return runAct(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId, opts.positionalCount)
     case "inspect":  return runInspect(filtered, opts.globalTabId, opts.jsonMode, opts.useWs, opts.contextId)
     default:
       console.error(`error: unknown compound command '${cmd}'`)

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -385,7 +385,7 @@ async function main() {
   }
 
   if (COMPOUND_CMDS.has(cmd)) {
-    await runCompoundCommand(cmd, filtered, { jsonMode, useWs, globalTabId, anyTab, contextId: globalContextId })
+    await runCompoundCommand(cmd, filtered, { jsonMode, useWs, globalTabId, anyTab, contextId: globalContextId, positionalCount: normalized.positionalCount })
     return
   }
 

--- a/test/compound.test.ts
+++ b/test/compound.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { buildReadTreeAction, buildTabCreateAction } from "../cli/commands/compound"
+import { actValue, buildReadTreeAction, buildTabCreateAction } from "../cli/commands/compound"
+import { normalizeArgsSplit } from "../cli/normalize"
 import { parseElementTarget } from "../cli/parse"
 
 describe("buildReadTreeAction", () => {
@@ -60,5 +61,55 @@ describe("buildTabCreateAction", () => {
       "https://example.com"
     )
     expect(action.reuse).toBeUndefined()
+  })
+})
+
+describe("actValue", () => {
+  // `act` runs on the normalized argv [cmd, ...positionals, ...flags], so the
+  // value is the positional span after the ref. Global booleans live in the
+  // flag span and must never be mistaken for text to type.
+  const normalized = (cmd: string) => normalizeArgsSplit(cmd.split(" "))
+
+  test("no value is a click", () => {
+    const { argv, positionalCount } = normalized("act e1")
+    expect(actValue(argv, positionalCount)).toBeUndefined()
+  })
+
+  test("positional after the ref is the text to type", () => {
+    const { argv, positionalCount } = normalizeArgsSplit(["act", "e1", "hello world"])
+    expect(actValue(argv, positionalCount)).toBe("hello world")
+  })
+
+  test("unquoted multi-word text is rejoined", () => {
+    const { argv, positionalCount } = normalized("act e1 hello world")
+    expect(actValue(argv, positionalCount)).toBe("hello world")
+  })
+
+  // Regression: each of these used to fall through the hardcoded flag list and
+  // become the typed text, turning a click into input_text carrying the flag.
+  for (const flag of ["--json", "--no-skills-hint", "--no-research-hint", "--any-tab", "--changes"]) {
+    test(`${flag} stays a click, never typed text`, () => {
+      const { argv, positionalCount } = normalized(`act e1 ${flag}`)
+      expect(actValue(argv, positionalCount)).toBeUndefined()
+    })
+
+    test(`${flag} is not appended to a real value`, () => {
+      const { argv, positionalCount } = normalized(`act e1 hello ${flag}`)
+      expect(actValue(argv, positionalCount)).toBe("hello")
+    })
+  }
+
+  test("act-specific booleans are still excluded", () => {
+    const { argv, positionalCount } = normalized("act e1 hello --append --no-read")
+    expect(actValue(argv, positionalCount)).toBe("hello")
+  })
+
+  test("value flags keep their operands out of the text", () => {
+    const { argv, positionalCount } = normalized("act e1 hello --timeout 5000")
+    expect(actValue(argv, positionalCount)).toBe("hello")
+  })
+
+  test("fallback (no boundary) still excludes the act-specific flags", () => {
+    expect(actValue(["act", "e1", "hello", "--append"])).toBe("hello")
   })
 })


### PR DESCRIPTION
…nylist

`interceptor act <ref>` found the text to type by rejecting a hardcoded six-flag list (--trusted/--os/--append/--no-read/--keys/--timeout). Every OTHER global boolean fell through and became the value, so `act e1 --json` sent input_text carrying the literal "--json" instead of clicking:

    $ interceptor act e1 --json
    [b6632619] -> input_text
    { "success": false, "error": "element is <a> - unsupported input type" }

Same for --no-skills-hint and --no-research-hint. Any global boolean added later would have joined them silently.

normalizeArgsSplit already sorts argv into [cmd, ...positionals, ...flags] and reports positionalCount, which is exactly the boundary this needs -- parseActionsCommand has consumed it since #217 fixed the identical bug in the low-level `type` verb. The compound dispatcher just never passed it through to act. Plumb it in, and take the value from the positional span after the ref.

The detection moves into an exported pure actValue() so the contract is testable; the old denylist stays as its fallback for callers without the boundary. Verified against a live page: --json and --no-skills-hint now click, while `act e1 "hello world"`, `act e2 5551234 --json`, and `act e3 a@b.com --no-skills-hint` type exactly their intended values. --keys and --timeout paths are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compound command parsing so boolean flags are handled correctly instead of being interpreted as text.
  * Preserved the separation between positional arguments and command options.
  * Improved handling of clicks, multi-word text, and value-bearing flags.

* **Tests**
  * Added coverage for command value parsing and flag-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->