### PR TITLE
fix(release): refresh Windows runner image pin

### DIFF
--- a/scripts/installer/windows-toolchain.lock.json
+++ b/scripts/installer/windows-toolchain.lock.json
@@ -3,8 +3,8 @@
   "runner": {
     "label": "windows-2025",
     "imageOS": "win25-vs2026",
-    "imageVersion": "20260818.207.1",
-    "releaseTag": "win25-vs2026/20260818.207",
+    "imageVersion": "20260824.214.3",
+    "releaseTag": "win25-vs2026/20260824.214",
     "osBuild": "10.0.26100.33296"
   },
   "bun": {


### PR DESCRIPTION
## What changed

- pin the Windows production workflow to hosted image `20260824.214.3`
- record the corresponding immutable runner-images release tag
- retain the verified OS build `10.0.26100.33296`

## Evidence

The v0.23.33 tag run reported `win25-vs2026 20260824.214.3`. The official `actions/runner-images` release for `win25-vs2026/20260824.214` records the same image version and OS build.

## Verification

- `bun test test/windows-release-contract.test.ts` (7 pass)
- lock metadata assertion
- `git diff --check`
- public diff privacy scan