### PR TITLE
Ajustar Interceptor para funcionar em Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,64 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  linux:
+    name: linux — typecheck + tests + linux-x64 build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Shell syntax check (scripts/*.sh)
+        run: |
+          for f in scripts/*.sh; do
+            echo "bash -n $f"
+            bash -n "$f"
+          done
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      # Suites that shell out to base-macOS tools (plutil, security) skip
+      # themselves here; anything else failing is a real portability break.
+      - name: TypeScript tests
+        run: bun test
+
+      # Proves the Linux artifacts still compile and stage. The runner has
+      # Chrome and Firefox preinstalled, so install.sh's browser detection and
+      # native-messaging paths are exercised for real rather than skipped.
+      - name: Build linux-x64 package
+        run: bash scripts/build.sh --target=linux-x64
+
+      - name: Smoke — CLI and daemon run
+        run: |
+          ./dist/linux/x64/interceptor --version
+          ./dist/linux/x64/daemon/interceptor-daemon --standalone &
+          for i in $(seq 1 20); do [ -S /tmp/interceptor.sock ] && break; sleep 0.25; done
+          ./dist/linux/x64/interceptor status
+          ./dist/linux/x64/interceptor daemon stop
+
+      - name: Smoke — install.sh dry-run for every Linux browser target
+        run: |
+          for b in chrome chromium brave firefox; do
+            echo "--- --$b"
+            INSTALL_DRY_RUN=1 bash scripts/install.sh --browser-only "--$b" --skip-extension
+          done
+
+      - name: Package linux-x64 (tar.gz + deb)
+        run: |
+          bash scripts/package-linux.sh --arch x64 --format tar.gz,deb
+          ls -la dist/linux/packages
+
   test:
-    name: typecheck + tests + capability-blind audit
+    name: macos — typecheck + tests + capability-blind audit
     runs-on: macos-15
     steps:
       - name: Checkout

--- a/cli/commands/daemon.ts
+++ b/cli/commands/daemon.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { readLockFile, type LockFileData } from "../../daemon/lifecycle"
-import { IPC_PORT, LOCK_PATH, WS_PORT } from "../../shared/platform"
+import { IPC_PORT, LOCK_PATH, WS_PORT, isProcessAlive } from "../../shared/platform"
 import { sendCommand } from "../transport"
 
 export type DaemonStopOptions = {
@@ -49,13 +49,11 @@ export function parseDaemonStopArgs(args: string[]): DaemonStopOptions {
   return { reason, timeoutMs }
 }
 
+// Zombie-aware: a detached daemon reparented to a non-reaping PID 1 (any
+// container started without an init) keeps answering signal 0 after it exits,
+// which would make waitForStopped below time out on a daemon that did stop.
 function processAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch {
-    return false
-  }
+  return isProcessAlive(pid)
 }
 
 async function tcpPortOpen(port: number, timeoutMs = 150): Promise<boolean> {

--- a/cli/commands/diagnose.ts
+++ b/cli/commands/diagnose.ts
@@ -237,7 +237,9 @@ export async function runDiagnoseCommand(jsonMode: boolean, contextId?: string):
     lines.push(`⚠ binary mismatch (${m.browser}):`)
     lines.push(`    socket daemon: ${m.runningPath}`)
     lines.push(`    NMH manifest:  ${m.manifestPath}`)
-    lines.push(`    Chrome will spawn the manifest binary; CLI talks to the socket binary.`)
+    // Browser-neutral: the same mismatch applies to Chromium, Brave, and
+    // Firefox, all of which now have their own native-messaging host dir.
+    lines.push(`    ${m.browser} will spawn the manifest binary; CLI talks to the socket binary.`)
     lines.push(`    Fix: run 'interceptor init' or update the NMH manifest to match.`)
   }
 

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -19,7 +19,8 @@ import { ensureDaemon } from "../daemon-spawn"
 import {
   readStatusSnapshot,
   detectConfiguredBrowsers,
-  detectMacOSDefaultBrowser,
+  detectSystemDefaultBrowser,
+  defaultBrowserMatchesConfigured,
   formatStatus,
   snapshotToJson,
   type StatusSnapshot,
@@ -54,16 +55,16 @@ export async function runInitCommand(filtered: string[]): Promise<null> {
 
   const snap: StatusSnapshot = readStatusSnapshot()
 
-  if (verbose && process.platform === "darwin") {
+  // Same platform reasoning as `status --verbose` (cli/commands/meta.ts):
+  // on-disk native-messaging hosts + a discoverable system default browser.
+  if (verbose && (process.platform === "darwin" || process.platform === "linux")) {
     const configured = detectConfiguredBrowsers()
-    const sysDefault = detectMacOSDefaultBrowser()
-    let matches: boolean | null = null
-    if (sysDefault && configured.length > 0) {
-      matches = configured.some(b => b === sysDefault) || (sysDefault === "chrome" || sysDefault === "brave")
-        ? configured.includes(sysDefault as "chrome" | "brave")
-        : false
+    const sysDefault = detectSystemDefaultBrowser()
+    snap.browser = {
+      configured,
+      systemDefault: sysDefault,
+      matches: defaultBrowserMatchesConfigured(configured, sysDefault),
     }
-    snap.browser = { configured, systemDefault: sysDefault, matches }
   }
   if (verbose && snap.daemon) {
     const p = await probe()

--- a/cli/commands/meta.ts
+++ b/cli/commands/meta.ts
@@ -11,7 +11,8 @@ import { parseElementTarget } from "../parse"
 import {
   readStatusSnapshot,
   detectConfiguredBrowsers,
-  detectMacOSDefaultBrowser,
+  detectSystemDefaultBrowser,
+  defaultBrowserMatchesConfigured,
   formatStatus,
   snapshotToJson,
   type StatusSnapshot,
@@ -56,20 +57,18 @@ export async function parseMetaCommand(filtered: string[], jsonMode = false, con
       const verbose = filtered.includes("--verbose") || filtered.includes("--explain") || filtered.includes("-v")
       const snap: StatusSnapshot = readStatusSnapshot()
 
-      // Browser-config block (#52) — verbose-only, macOS-only.
-      if (verbose && process.platform === "darwin") {
+      // Browser-config block (#52) — verbose-only. Renders wherever native
+      // messaging hosts live on disk and a system default browser is
+      // discoverable: macOS (Application Support + LaunchServices) and Linux
+      // (XDG config home + xdg-settings). Windows keeps hosts in the registry,
+      // so there is nothing to scan there.
+      if (verbose && (process.platform === "darwin" || process.platform === "linux")) {
         const configured = detectConfiguredBrowsers()
-        const sysDefault = detectMacOSDefaultBrowser()
-        let matches: boolean | null = null
-        if (sysDefault && configured.length > 0) {
-          matches = configured.some(b => b === sysDefault) || (sysDefault === "chrome" || sysDefault === "brave")
-            ? configured.includes(sysDefault as "chrome" | "brave")
-            : false
-        }
+        const sysDefault = detectSystemDefaultBrowser()
         snap.browser = {
           configured,
           systemDefault: sysDefault,
-          matches,
+          matches: defaultBrowserMatchesConfigured(configured, sysDefault),
         }
       }
 

--- a/cli/daemon-spawn.ts
+++ b/cli/daemon-spawn.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, readFileSync, unlinkSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
-import { IS_WIN, SOCKET_PATH, PID_PATH, LOCK_PATH, LOG_PATH, WS_PORT } from "../shared/platform"
+import { IS_WIN, SOCKET_PATH, PID_PATH, LOCK_PATH, LOG_PATH, WS_PORT, isProcessAlive } from "../shared/platform"
 import { decideDaemonRecovery, probeDaemonHealth } from "../shared/daemon-health"
 import { readLockFile } from "../daemon/lifecycle"
 import { assertNoInstallMaintenance } from "../shared/install-maintenance"
@@ -92,15 +92,17 @@ function readRuntimeReadiness(): { ready: boolean } {
       const pidContent = readFileSync(PID_PATH, "utf-8").trim()
       const pid = parseInt(pidContent.split("\n")[0])
       if (!isNaN(pid)) {
-        try {
-          process.kill(pid, 0)
+        // isProcessAlive, não kill(pid, 0): um pid file velho + um daemon zumbi
+        // (container sem init reaper) leria como "já rodando" e todo comando
+        // travaria num socket morto (port Linux, docs/linux-port-report.md §3.5).
+        if (isProcessAlive(pid)) {
           if (IS_WIN) {
             const lock = readLockFile(LOCK_PATH)
             ready = !!lock && lock.pid === pid && lock.wsPort === WS_PORT && lock.shutdownProtocolVersion === 1
           } else {
             ready = existsSync(SOCKET_PATH)
           }
-        } catch { ready = false }
+        } else { ready = false }
       }
     } catch {}
   }

--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { spawnSync } from "node:child_process"
-import { IS_WIN, SOCKET_PATH, PID_PATH, transportLabel } from "../../shared/platform"
+import { IS_WIN, SOCKET_PATH, PID_PATH, transportLabel, isProcessAlive } from "../../shared/platform"
 import { skillsStatusSummary } from "../commands/skills"
 
 export type StatusSnapshot = {
@@ -30,8 +30,8 @@ export type StatusSnapshot = {
   launchAgentLoaded: boolean
   // #52 browser-config block — populated only on macOS in verbose mode
   browser?: {
-    configured: ("chrome" | "brave")[]   // browsers with NMH manifest installed
-    systemDefault: "chrome" | "brave" | "safari" | "firefox" | "other" | null
+    configured: string[]                 // browsers with an NMH manifest installed
+    systemDefault: DefaultBrowser
     matches: boolean | null              // null when systemDefault unknown
   }
   // #49 extension-reachability probe result — populated only when verbose+daemonAlive
@@ -91,7 +91,9 @@ export function readStatusSnapshot(): StatusSnapshot {
       daemonPid = parseInt(lines[0])
       transport = lines[1] || transportLabel()
       if (!isNaN(daemonPid)) {
-        try { process.kill(daemonPid, 0); daemonAlive = true } catch { daemonAlive = false }
+        // Zombie-aware: a stale pid file naming an unreaped daemon must read as
+        // "not running", not as a daemon nothing can reach.
+        daemonAlive = isProcessAlive(daemonPid)
       }
     } catch {}
   }
@@ -202,13 +204,51 @@ export function computeBridgeHint(input: {
   return []
 }
 
+export type DefaultBrowser = "chrome" | "chromium" | "brave" | "safari" | "firefox" | "other" | null
+
+/**
+ * Detect the system default browser. macOS reads LaunchServices preferences;
+ * Linux asks xdg-settings (the freedesktop equivalent — a `.desktop` file id
+ * such as `google-chrome.desktop`). Returns null on unsupported platforms or
+ * when detection fails. Best-effort — surfaces "unknown" rather than throwing.
+ */
+export function detectSystemDefaultBrowser(): DefaultBrowser {
+  if (process.platform === "linux") return detectLinuxDefaultBrowser()
+  return detectMacOSDefaultBrowser()
+}
+
+/**
+ * Linux default browser via `xdg-settings get default-web-browser`. Returns
+ * null when xdg-utils is absent (common in minimal containers) or the setting
+ * is unset — both mean "unknown", not "none".
+ */
+function detectLinuxDefaultBrowser(): DefaultBrowser {
+  try {
+    const result = spawnSync("xdg-settings", ["get", "default-web-browser"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    if (result.status !== 0 || !result.stdout) return null
+    const desktopId = result.stdout.trim().toLowerCase()
+    if (!desktopId) return null
+    // chromium before chrome: they are separate install targets with separate
+    // native-messaging dirs, so collapsing them would report a false match.
+    if (desktopId.includes("brave")) return "brave"
+    if (desktopId.includes("chromium")) return "chromium"
+    if (desktopId.includes("chrome")) return "chrome"
+    if (desktopId.includes("firefox")) return "firefox"
+    return "other"
+  } catch {
+    return null
+  }
+}
+
 /**
  * Detect the macOS system default browser via LaunchServices preferences.
  * Returns null on non-macOS or when detection fails. Best-effort — surfaces
  * "unknown" rather than throwing.
  */
-export function detectMacOSDefaultBrowser():
-  "chrome" | "brave" | "safari" | "firefox" | "other" | null {
+export function detectMacOSDefaultBrowser(): DefaultBrowser {
   if (process.platform !== "darwin") return null
   try {
     // LaunchServices preferences live in a binary plist; convert to JSON.
@@ -235,11 +275,16 @@ export function detectMacOSDefaultBrowser():
   }
 }
 
-// One source of truth for per-user NMH manifest locations on macOS — the same
-// browser set scripts/install.sh can configure. Used by `status` (presence)
-// and `diagnose` (manifest-path vs running-binary mismatch detection).
+// One source of truth for per-user NMH manifest locations — the same browser
+// set scripts/install.sh can configure, per platform. Used by `status`
+// (presence) and `diagnose` (manifest-path vs running-binary mismatch
+// detection). Chromium resolves these dirs itself, so the shapes differ:
+// macOS nests them under ~/Library/Application Support, Linux under the
+// XDG config home. Keep in lockstep with nm_dir_for() in scripts/install.sh —
+// a browser listed here but not there can never have a manifest to find.
 const NMH_MANIFEST_FILE = "com.interceptor.host.json"
-const NMH_BROWSER_DIRS: Record<string, string> = {
+
+const NMH_BROWSER_DIRS_DARWIN: Record<string, string> = {
   "chrome":             "Google/Chrome",
   "brave":              "BraveSoftware/Brave-Browser",
   "chrome-beta":        "Google/Chrome Beta",
@@ -250,13 +295,45 @@ const NMH_BROWSER_DIRS: Record<string, string> = {
   "vivaldi":            "Vivaldi",
 }
 
+// Linux: the four targets scripts/install.sh can configure. Chrome, Brave and
+// Chromium hang off the XDG config home; Firefox does not — Gecko keeps one
+// native-messaging dir per user under ~/.mozilla, outside both the XDG tree and
+// the profile tree, so it is resolved separately in nmhDirsFor().
+const NMH_BROWSER_DIRS_LINUX: Record<string, string> = {
+  "chrome":   "google-chrome",
+  "brave":    "BraveSoftware/Brave-Browser",
+  "chromium": "chromium",
+}
+
+/** Firefox's per-user native-messaging dir, relative to $HOME. Not XDG-based. */
+const NMH_FIREFOX_DIR_LINUX = ".mozilla/native-messaging-hosts"
+
+/** Root the per-browser NMH dirs hang off, per platform. Null when unsupported. */
+function nmhRoot(platform: string, home: string, env: Record<string, string | undefined>): string | null {
+  if (!home) return null
+  if (platform === "darwin") return `${home}/Library/Application Support`
+  if (platform === "linux") return env.XDG_CONFIG_HOME || `${home}/.config`
+  // Windows registers native hosts in the registry, not on disk — nothing to scan.
+  return null
+}
+
 /** Every installed Interceptor NMH manifest: browser slug + manifest file path. */
-export function installedNmhManifests(): Array<{ browser: string; manifestFile: string }> {
-  const home = process.env.HOME || ""
+export function installedNmhManifests(
+  platform: string = process.platform,
+  env: Record<string, string | undefined> = process.env,
+): Array<{ browser: string; manifestFile: string }> {
+  const home = env.HOME || ""
+  const root = nmhRoot(platform, home, env)
+  if (!root) return []
+  const dirs = platform === "linux" ? NMH_BROWSER_DIRS_LINUX : NMH_BROWSER_DIRS_DARWIN
   const out: Array<{ browser: string; manifestFile: string }> = []
-  for (const [browser, dir] of Object.entries(NMH_BROWSER_DIRS)) {
-    const manifestFile = `${home}/Library/Application Support/${dir}/NativeMessagingHosts/${NMH_MANIFEST_FILE}`
+  for (const [browser, dir] of Object.entries(dirs)) {
+    const manifestFile = `${root}/${dir}/NativeMessagingHosts/${NMH_MANIFEST_FILE}`
     if (existsSync(manifestFile)) out.push({ browser, manifestFile })
+  }
+  if (platform === "linux" && home) {
+    const firefoxManifest = `${home}/${NMH_FIREFOX_DIR_LINUX}/${NMH_MANIFEST_FILE}`
+    if (existsSync(firefoxManifest)) out.push({ browser: "firefox", manifestFile: firefoxManifest })
   }
   return out
 }
@@ -265,10 +342,24 @@ export function installedNmhManifests(): Array<{ browser: string; manifestFile: 
  * Detect which browsers have an Interceptor native messaging host manifest
  * installed in their per-user dir.
  */
-export function detectConfiguredBrowsers(): ("chrome" | "brave")[] {
-  return installedNmhManifests()
-    .map(m => m.browser)
-    .filter((b): b is "chrome" | "brave" => b === "chrome" || b === "brave")
+export function detectConfiguredBrowsers(): string[] {
+  return installedNmhManifests().map(m => m.browser)
+}
+
+/**
+ * Does the system default browser have an Interceptor native-messaging host?
+ *
+ * null when the default is unknown or nothing is configured — "unknown", not
+ * "mismatch". A mismatch is only worth reporting when both sides are known:
+ * URLs opened from other apps follow the OS default and bypass Interceptor,
+ * while `interceptor open` always lands in a configured browser.
+ */
+export function defaultBrowserMatchesConfigured(
+  configured: string[],
+  systemDefault: DefaultBrowser,
+): boolean | null {
+  if (!systemDefault || configured.length === 0) return null
+  return configured.includes(systemDefault)
 }
 
 /**
@@ -329,7 +420,10 @@ export function formatStatus(snap: StatusSnapshot, opts: { verbose?: boolean }):
     })) {
       lines.push(line)
     }
-  } else if (!IS_WIN) {
+  } else if (process.platform === "darwin") {
+    // Only advertised on macOS: `upgrade --full` installs the Swift bridge and
+    // hard-errors everywhere else, so printing it on Linux/Windows would send
+    // the user at a command that cannot succeed on their machine.
     lines.push("")
     lines.push("To enable native macOS control:    interceptor upgrade --full")
   }

--- a/daemon/com.interceptor.host.firefox.json
+++ b/daemon/com.interceptor.host.firefox.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.interceptor.host",
+  "description": "Interceptor daemon bridge",
+  "path": "__DAEMON_PATH__",
+  "type": "stdio",
+  "allowed_extensions": [
+    "interceptor@hackervalley.media"
+  ]
+}

--- a/daemon/context-registration.ts
+++ b/daemon/context-registration.ts
@@ -42,6 +42,15 @@ export type ContextConflictMessage = {
 export type ContextRegisteredMessage = {
   type: "context_registered"
   contextId: string
+  /**
+   * Whether THIS host can deliver OS-level trusted input (macOS only). The
+   * extension cannot see the host OS from a service worker, so without this it
+   * assumes the lane exists and escalates clicks into it — on Linux/Windows
+   * that escalation always fails, turning a synthetic click that DID land into
+   * "click failed at all layers". Optional so an older daemon simply leaves the
+   * extension on its default.
+   */
+  osInput?: boolean
 }
 
 export type ContextClaimResult =
@@ -65,17 +74,20 @@ export function contextConflictMessage(contextId: string): ContextConflictMessag
   }
 }
 
-export function contextRegisteredMessage(contextId: string): ContextRegisteredMessage {
-  return {
+export function contextRegisteredMessage(contextId: string, osInput?: boolean): ContextRegisteredMessage {
+  const message: ContextRegisteredMessage = {
     type: "context_registered",
     contextId,
   }
+  if (typeof osInput === "boolean") message.osInput = osInput
+  return message
 }
 
 export function claimContextId(
   contextMap: Map<string, ContextSocket>,
   ws: ContextSocket,
   contextId: string,
+  osInput?: boolean,
 ): ContextClaimResult {
   const existing = contextMap.get(contextId)
   if (existing && existing !== ws) {
@@ -98,6 +110,6 @@ export function claimContextId(
     status: "registered",
     contextId,
     previousContextId: previousContextId && previousContextId !== contextId ? previousContextId : undefined,
-    message: contextRegisteredMessage(contextId),
+    message: contextRegisteredMessage(contextId, osInput),
   }
 }

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -19,6 +19,7 @@ import {
 } from "../shared/monitor-artifacts"
 import { chooseOutboundTransport, isRelayPing, relaySlotAfterClose, validateContextRouting } from "./outbound-routing"
 import { claimContextId, describeContexts, type ContextSocket } from "./context-registration"
+import { osInputSupported } from "../shared/platform"
 import { failPendingBridgeRequests, formatBridgeUnavailableError, getBridgeRecoveryActions, getBridgeRecoveryLayout } from "./bridge-recovery"
 import { socketWriteAll, drainSocketQueue, releaseSocketQueue } from "./socket-write"
 import { captureSpinSample, spinWatchdogStep, SPIN_EXIT_TICKS, type SpinWatchdogState } from "./spin-watchdog"
@@ -2053,7 +2054,7 @@ function startWsServer(): ReturnType<typeof Bun.serve> {
 
         if (request.type === "extension") {
           const ctxId = request.contextId ?? "default"
-          const claim = claimContextId(extensionWsMap, ws as ContextSocket, ctxId)
+          const claim = claimContextId(extensionWsMap, ws as ContextSocket, ctxId, osInputSupported())
           ws.send(JSON.stringify(claim.message))
           if (claim.status === "conflict") {
             return
@@ -2072,7 +2073,7 @@ function startWsServer(): ReturnType<typeof Bun.serve> {
         if (request.type === NATIVE_REGISTER_TYPE) {
           const r = request as { contextId?: string; pid?: number; slice?: string; appName?: string; frameworks?: string[]; wayIn?: string }
           const ctxId = r.contextId && r.contextId.startsWith(NATIVE_CONTEXT_PREFIX) ? r.contextId : NATIVE_CONTEXT_PREFIX + (r.contextId ?? "app")
-          const claim = claimContextId(extensionWsMap, ws as ContextSocket, ctxId)
+          const claim = claimContextId(extensionWsMap, ws as ContextSocket, ctxId, osInputSupported())
           ws.send(JSON.stringify(claim.message))
           if (claim.status === "conflict") {
             return

--- a/docs/linux-install.md
+++ b/docs/linux-install.md
@@ -1,0 +1,154 @@
+# Install Interceptor on Linux
+
+Interceptor for Linux is browser-only: CLI + daemon + WebExtension. The `interceptor macos *` and `interceptor ios *` surfaces need a macOS host and are gated off automatically — `interceptor status` reports `mode: browser-only` and the macOS/iOS verbs return the surface hint instead of a bridge error.
+
+Supported: glibc x86-64 and arm64 (Ubuntu 22.04+, Debian 12+, Fedora 39+ and equivalents), plus musl builds for Alpine. The x64 build targets the baseline instruction set, so it also runs under x86-64 emulation (Rosetta/qemu) and on pre-AVX2 CPUs.
+
+Supported browsers: **Chrome**, **Chromium**, **Brave** (one MV3 build), and **Firefox** (a separate Gecko build).
+
+## Install from a package
+
+```bash
+sudo dpkg -i interceptor-<version>-linux-x64.deb      # Debian / Ubuntu
+sudo rpm -i  interceptor-<version>-linux-x64.rpm      # Fedora / RHEL / openSUSE
+```
+
+Both install to `/opt/interceptor` and put `interceptor` on `PATH`. They deliberately stop there: registering a native-messaging host writes into `~/.config` or `~/.mozilla`, which is per-user state a root install must not create for one arbitrary user. Finish per user:
+
+```bash
+interceptor-install --browser-only --chrome     # or --chromium, --brave, --firefox
+```
+
+## Install from a tarball
+
+```bash
+tar xzf interceptor-<version>-linux-x64.tar.gz
+sudo mv interceptor-<version>-linux-x64 /opt/interceptor
+bash /opt/interceptor/scripts/install.sh --browser-only --chrome
+```
+
+`install.sh` symlinks the CLI into `~/.local/bin` (override with `--link-cli-dir <dir>`, skip with `--no-link-cli`) and tells you if that directory is not on your `PATH`.
+
+**Alpine / musl:** the musl build links libstdc++ and libgcc dynamically, which bare Alpine does not ship. Install them first, or the binary exits with `Error loading shared library libstdc++.so.6`:
+
+```bash
+apk add libstdc++ libgcc
+```
+
+## Build from source
+
+```bash
+bun install                                        # see .bun-version for the pin
+bash scripts/build.sh --target=linux-x64           # linux-arm64, linux-x64-musl, linux-arm64-musl
+bash scripts/package-linux.sh --arch x64           # tar.gz + deb + rpm into dist/linux/packages
+```
+
+The staged tree in `dist/linux/<arch>/` is directly installable after extraction:
+
+```
+interceptor                              the CLI
+daemon/interceptor-daemon                the daemon the browser spawns as a native-messaging host
+daemon/com.interceptor.host.json         native-host manifest template (Chromium family)
+daemon/com.interceptor.host.firefox.json native-host manifest template (Gecko)
+extension/dist/                          unpacked MV3 extension — Chrome, Chromium, Brave
+extension/dist-firefox/                  unpacked MV3 extension — Firefox
+skills/                                  skill packs, found by `interceptor skills adopt`
+scripts/install.sh, uninstall.sh
+```
+
+Cross-compiling from macOS works too — the same `--target=linux-x64` flag produces the Linux artifacts and skips the macOS signing step.
+
+## Native-messaging host locations
+
+`install.sh` resolves `__DAEMON_PATH__` to the real daemon path and symlinks the manifest into the browser's per-user directory:
+
+| Browser | Native-messaging host directory |
+|---|---|
+| Google Chrome | `~/.config/google-chrome/NativeMessagingHosts/` |
+| Chromium | `~/.config/chromium/NativeMessagingHosts/` |
+| Brave | `~/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/` |
+| Firefox | `~/.mozilla/native-messaging-hosts/` |
+
+The Chromium-family dirs follow `$XDG_CONFIG_HOME`. Firefox's does not — Gecko keeps one host directory per user, outside both the XDG tree and the profile tree, shared by every Firefox profile. Chrome's other channels, Edge and Vivaldi are not auto-detected on Linux yet; their manifest can be dropped into the matching `~/.config/<product>/NativeMessagingHosts/` by hand.
+
+The two manifests differ in more than location: Chromium authorizes by extension origin (`allowed_origins: ["chrome-extension://…"]`) while Gecko authorizes by add-on id (`allowed_extensions: ["interceptor@hackervalley.media"]`).
+
+## Load the extension
+
+### Chromium and Brave
+
+They honor `--load-extension`, so `install.sh --chromium` / `--brave` loads and launches in one step. It first checks that the target profile has Developer mode on — without it Chromium silently drops the flag and every browser verb would time out.
+
+### Google Chrome
+
+Branded Chrome ignores `--load-extension` on every desktop platform, Linux included. Use the developer flow:
+
+1. Open `chrome://extensions`, enable **Developer mode**.
+2. **Load unpacked** → select `/opt/interceptor/extension/dist`.
+3. Confirm the ID is `hkjbaciefhhgekldhncknbjkofbpenng`.
+
+### Firefox
+
+Firefox has no command-line switch for unpacked add-ons.
+
+1. Open `about:debugging#/runtime/this-firefox`.
+2. **Load Temporary Add-on…** → select `/opt/interceptor/extension/dist-firefox/manifest.json`.
+3. If page verbs return nothing, grant host access: **about:addons → Interceptor → Permissions → "Access your data for all websites"** (Firefox MV3 treats host permissions as optional).
+
+A temporary add-on is dropped when Firefox quits; a signed XPI installs permanently. Firefox registers as the fixed context `firefox`, so with more than one browser connected address it as `--context firefox`.
+
+## Verify
+
+```bash
+interceptor init --verbose
+interceptor status --verbose
+```
+
+Expect `mode: browser-only`, `extension: reachable`, and a `browser:` block listing every configured native-messaging host plus the system default browser (read from `xdg-settings`).
+
+Optional, not linked automatically:
+
+```bash
+interceptor skills adopt
+```
+
+## Uninstall
+
+```bash
+bash /opt/interceptor/scripts/uninstall.sh    # per-user state
+sudo dpkg -r interceptor                      # or: sudo rpm -e interceptor
+```
+
+`uninstall.sh` removes the native-messaging manifests for all four browsers, the generated manifests, the CLI symlink it created, and daemon runtime files. It leaves recorded monitor sessions (`~/.local/state/interceptor/tasks`) and the browser extension itself in place.
+
+## What is not available on Linux
+
+| Capability | Status |
+|---|---|
+| `interceptor macos *`, `interceptor ios *` | macOS host only; the surface gate prints the upgrade hint |
+| `interceptor upgrade --full` | macOS only (the bridge is Swift/AppKit) |
+| `act --os`, `click --trusted`, OS-level input | No backend. The daemon returns an explicit "not supported on this platform" sentinel, tells the extension so at registration, and `interceptor capabilities` reports `os_input: false` |
+| Sparkle auto-update (`interceptor update`) | macOS only; reinstall the package |
+
+Firefox additionally lacks, by Gecko API surface:
+
+| Verb | Why |
+|---|---|
+| `ocr` | No offscreen-document API, so the bundled tesseract worker has nowhere to run |
+| `keepawake` | No `browser.power` |
+| `macos cdp *` | No `chrome.debugger` |
+| `eval` | Gecko applies the extension CSP and has no `userScripts` fallback in this build |
+| `bookmarks` (tree form) | `bookmarks.getTree()` rejects on Gecko; `bookmarks --query` works |
+| tab groups | No `browser.tabGroups`; grouping degrades to ungrouped, everything else is unaffected |
+
+Everything else — page reads, a11y trees, actions, navigation, tabs/frames, passive fetch/XHR/SSE/WebSocket/BroadcastChannel capture, HAR/pcapng export, DOM-render screenshots, `save`, monitor record, MCP, skills — runs on all four browsers.
+
+## Troubleshooting
+
+**`extension: not reachable`** — the extension is not loaded, or Developer mode is off in the profile the browser actually opened. Re-check the extensions page. On Firefox, a temporary add-on is gone after a restart.
+
+**`binary mismatch` from `interceptor diagnose`** — the daemon path inside the browser's `com.interceptor.host.json` no longer matches the running daemon (usually after moving the package). Re-run `install.sh`.
+
+**A code change does not take effect in Chromium** — a reused profile can keep the previous extension service worker. Launch once with a fresh `--user-data-dir`, or remove and re-add the unpacked extension.
+
+**Chrome/Chromium in a container** — Chromium needs user namespaces for its sandbox. Containers started without them need `--security-opt seccomp=unconfined` (preferred) or the browser launched with `--no-sandbox`.

--- a/docs/linux-port-report.md
+++ b/docs/linux-port-report.md
@@ -1,0 +1,504 @@
+# Relatório — Port do Interceptor para Linux x64
+
+**Versão base:** `0.23.20` (commit `679645d`) · **Data:** 2026-08-18/19
+**Alvos:** `linux-x64`, `linux-arm64`, `linux-x64-musl`, `linux-arm64-musl` · **Ambiente de teste:** `ubuntu:24.04` + `alpine:3.20` (linux/amd64)
+**Browsers:** Chrome · Chromium · Brave · Firefox
+
+> Seções 1–6: o port inicial. Seções 7–10: os passos de follow-up aplicados depois (CI, empacotamento, Chromium, Firefox, musl).
+
+---
+
+## 1. Resumo executivo
+
+O Interceptor já era estruturalmente portável — a camada `shared/platform.ts` separava Windows de "unix", `daemon/os-input.ts` já protegia o `dlopen` de CoreGraphics (PR #83) e `scripts/install.sh` já tinha ramos `Linux:` para Chrome e Brave. **O que faltava era o alvo de build e um conjunto de correções pontuais** onde o código assumia macOS silenciosamente.
+
+Resultado final, validado dentro de `ubuntu:24.04`:
+
+| | Antes | Depois |
+|---|---|---|
+| Alvo de build Linux | não existia | `--target=linux-x64` / `linux-arm64` (musl na fase 2) |
+| Suíte de testes no Linux | 1052 pass / **19 fail** | **1062 pass / 0 fail** (1074 após a fase 2) |
+| `typecheck` (3 projetos) | ok | ok |
+| Fluxo `install.sh` fim-a-fim | falhava | `Extension loaded into Brave and reachable` |
+| `interceptor daemon stop` | falso negativo (timeout) | `stopped: true` |
+| `diagnose` (mismatch de binário) | cego no Linux | detecta Chrome e Brave |
+| `capabilities.os_input` | `true` (mentira) | `false` (correto) |
+
+Nenhuma alteração muda o comportamento em macOS: todos os caminhos novos são condicionais em `process.platform` / `uname -s`, com o ramo Darwin idêntico ao anterior.
+
+---
+
+## 2. Arquitetura: o que precisava existir no Linux
+
+O produto tem três superfícies. Só a primeira é portável:
+
+| Superfície | Implementação | Linux |
+|---|---|---|
+| **Browser** (`interceptor open/read/act/net/...`) | CLI Bun + daemon Bun + WebExtension MV3 | ✅ portada |
+| **macOS** (`interceptor macos *`) | bridge Swift (AX, ScreenCaptureKit, Apple Events) | ❌ impossível — já bloqueada pelo *surface gate* |
+| **iOS** (`interceptor ios *`) | usbmux/lockdown + `codesign`/`plutil` do macOS | ❌ impossível — mesma porta |
+
+O `detectSurfaces()` (`cli/lib/surfaces.ts`) já exigia `process.platform === "darwin"` para habilitar macOS/iOS, então no Linux essas superfícies retornam a dica de upgrade em vez de erro de bridge. **Nada precisou mudar ali.**
+
+O transporte também já estava correto: `listenOptions()`/`connectOptions()` usam Unix socket em tudo que não é Windows, e `/tmp/interceptor.sock` funciona igual no Linux.
+
+---
+
+## 3. Alterações realizadas
+
+17 arquivos modificados, 2 criados (+369 / −68 linhas).
+
+### 3.1 Build — `scripts/build.sh`
+
+**Problema:** não havia alvo Linux. `--all` produzia macOS + Windows apenas.
+
+**Alterações:**
+
+1. **Nova função `build_linux_arch()`** espelhando `build_windows_arch()`, com os alvos `--target=linux-x64` e `--target=linux-arm64` (e o erro explícito para `--target=linux`, igual ao que já existia para `windows`).
+
+2. **`bun-linux-x64-baseline`, não `bun-linux-x64`.** O alvo não-baseline exige AVX2. Sob emulação x86-64 (Rosetta/qemu — ou seja, *qualquer* container amd64 num host Apple Silicon) e em CPUs pré-Haswell o binário morre com SIGILL na primeira instrução, sem diagnóstico. É a mesma escolha que o projeto já fazia em `bun-windows-x64-baseline`.
+
+3. **Guarda no bloco de `codesign`.** A condição era `uname -s == Darwin && TARGET != windows-*`. Com um alvo `linux-*`, o script tentaria assinar um ELF com `codesign` e depois executar `./dist/interceptor --version` (um binário Linux) no host macOS — falhando o build sobre um artefato correto. A condição passou a excluir `linux-*` também.
+
+4. **Layout do pacote** em `dist/linux/<arch>/`, escolhido para ser *diretamente instalável* após a extração:
+
+```
+interceptor                        CLI  (95 MB, self-contained)
+daemon/interceptor-daemon          daemon (94 MB)
+daemon/com.interceptor.host.json   template do native-messaging host
+extension/dist/                    extensão MV3 desempacotada
+skills/{interceptor,-browser,-research}
+scripts/{install.sh,uninstall.sh}
+```
+
+Duas restrições ditaram esse layout:
+- `scripts/install.sh` calcula `ROOT="$(dirname $0)/.."` e procura `$ROOT/daemon/interceptor-daemon` e `$ROOT/extension/dist` — por isso o `extension/dist` aninhado.
+- `resolvePackDir()` em `cli/commands/skills.ts` procura `<dir do binário>/skills` — por isso o CLI fica na raiz do pacote, com `skills/` ao lado. Confirmado em teste: `interceptor skills adopt` criou os 3 symlinks corretamente.
+
+### 3.2 Manifestos de native messaging — `cli/lib/status-renderer.ts`
+
+**Problema (bug real):** `installedNmhManifests()` montava caminhos macOS incondicionalmente:
+
+```ts
+`${home}/Library/Application Support/${dir}/NativeMessagingHosts/com.interceptor.host.json`
+```
+
+No Linux esses caminhos nunca existem, então a função **sempre retornava `[]`**. Consequência: `interceptor diagnose` ficava cego para a detecção de *binary mismatch* — exatamente o diagnóstico que explica "extensão não conecta" depois que o pacote é movido de lugar.
+
+**Correção:** tabela por plataforma + raiz por plataforma.
+
+| Plataforma | Raiz | Browsers |
+|---|---|---|
+| darwin | `~/Library/Application Support` | chrome, brave, chrome-beta/canary/dev/for-testing, edge, vivaldi |
+| linux | `$XDG_CONFIG_HOME` ou `~/.config` | `google-chrome`, `BraveSoftware/Brave-Browser` |
+| win32 | — (registro do Windows, nada em disco) | — |
+
+O conjunto Linux é deliberadamente igual ao que `nm_dir_for()` em `install.sh` sabe escrever — listar um browser que o instalador nunca configura seria código morto.
+
+**Validado:** com o manifesto adulterado, `interceptor diagnose` passou a reportar `⚠ binary mismatch (chrome)` e `(brave)` com os dois caminhos.
+
+### 3.3 Navegador padrão do sistema — `cli/lib/status-renderer.ts`, `cli/commands/meta.ts`, `cli/commands/init.ts`
+
+**Problema:** o bloco `browser:` de `status --verbose` / `init --verbose` era explicitamente `macOS-only` (`if (verbose && process.platform === "darwin")`), e a única detecção existente lia o plist do LaunchServices.
+
+**Correção:** novo `detectSystemDefaultBrowser()` que delega para `detectMacOSDefaultBrowser()` no macOS e para `xdg-settings get default-web-browser` no Linux (retorna um id `.desktop` como `brave-browser.desktop`). O gate passou a `darwin || linux`. Windows continua fora — lá os hosts vivem no registro, não em disco.
+
+**Validado:** no container o bloco passou a renderizar `configured: chrome, brave` / `system default: brave` / `✓ matches`.
+
+### 3.4 Dica enganosa de upgrade — `cli/lib/status-renderer.ts`
+
+`formatStatus()` imprimia `To enable native macOS control: interceptor upgrade --full` em **tudo que não fosse Windows** (`else if (!IS_WIN)`), inclusive Linux — onde `upgrade --full` aborta com `error: 'interceptor upgrade --full' is macOS only`. A condição passou a `process.platform === "darwin"`.
+
+### 3.5 Liveness de processo: zumbis — `shared/platform.ts` (+ 3 call sites)
+
+**Problema (bug real, específico de Linux):** todo o código usava `process.kill(pid, 0)` como prova de vida. Um **zumbi** — processo que já saiu mas cujo pai não fez `wait()` — continua respondendo ao sinal 0.
+
+Isso importa no Linux porque o daemon é lançado *detached* e é reparentado ao PID 1. Em container, PID 1 costuma **não** ser um init que faz reaping (`docker run` sem `--init`, a maioria das imagens de CI, muitos pods Kubernetes). Sintoma observado no teste:
+
+```
+$ interceptor daemon stop
+error: daemon did not exit and release ports 19221/19222 within 10000ms
+$ ps -eo pid,ppid,stat,comm
+ 7920     1 Zs   interceptor-dae      ← zumbi, mas kill(pid,0) diz "vivo"
+```
+
+As portas eram liberadas em menos de 1 s; o que travava era só o `processAlive()`. O daemon **tinha** parado — o comando mentia e saía com código ≠ 0.
+
+**Correção:** `isProcessAlive(pid)` em `shared/platform.ts` — faz o `kill(pid, 0)` e, **só no Linux**, confirma lendo o campo *state* de `/proc/<pid>/stat`, tratando `Z` como morto. O parsing corta após o **último** `)` porque o `comm` é parentetizado mas não escapado (um processo chamado `weird ) name (x)` deslocaria os campos). Se `/proc` não existir, cai de volta no sinal.
+
+Aplicado em três lugares: `cli/commands/daemon.ts` (a falha observada), `cli/daemon-spawn.ts` (auto-start — um pid file velho + zumbi faria o CLI achar que há daemon e travar num socket morto) e `cli/lib/status-renderer.ts` (`status` reportando um daemon inalcançável como "running").
+
+**Novo teste:** `test/process-liveness.test.ts`, 6 casos, com o leitor de `/proc` injetável.
+**Validado:** `daemon stop` passou a responder `{"success":true,"stopped":true,...}` no mesmo container.
+
+### 3.6 `capabilities.os_input` mentia no Linux — `shared/platform.ts`, `cli/index.ts`
+
+**Problema:** `extension/src/background/capabilities/meta.ts` responde `os_input: daemonConnected` — um service worker não consegue ver o SO do host. No Linux (e no Windows) isso anuncia uma camada cuja *toda* chamada retorna "not supported": `daemon/os-input.ts` só carrega CoreGraphics no Darwin e devolve o sentinel `act --os not supported on this platform (macOS only)`.
+
+Um agente lendo `capabilities` no Linux planejaria em cima de uma capacidade inexistente.
+
+**Correção:** `osInputSupported()` em `shared/platform.ts` (true só no darwin) e pós-processamento no CLI — que roda no mesmo host do daemon e portanto *sabe* a resposta — corrigindo `layers.os_input` antes de imprimir.
+
+**Validado:** `interceptor capabilities` no Linux passou a reportar `"os_input": false`.
+
+Confirmei também o contrato do lado do daemon rodando a fixture já existente `test/fixtures/linux-os-input-check.ts` dentro do container:
+```
+import-ok
+osClick:{"success":false,"error":"act --os not supported on this platform (macOS only)"}
+```
+
+### 3.7 `scripts/install.sh`
+
+1. **`--dry-run` não pode exigir o browser instalado.** No ramo Linux, `browser_bin_for()` falhava com `ERROR: Chrome binary not found in PATH` *antes* do early-return de dry-run. O ramo Darwin nunca toca no disco (só monta o caminho do `.app`), então o dry-run se comportava diferente entre plataformas sem motivo. Agora o dry-run usa um placeholder. — *Isso destravou 1 dos testes que falhavam.*
+
+2. **`probe_extension_reachable()` só conhecia o layout do repo.** Procurava `$ROOT/dist/interceptor`; no pacote Linux o CLI está em `$ROOT/interceptor`. O probe caía no `return 0` silencioso e o instalador imprimia o aviso "extension is NOT reachable" mesmo quando estava. Novo `resolve_interceptor_bin()` tenta, nessa ordem: `$ROOT/dist/interceptor` (repo) → `$ROOT/interceptor` (pacote) → `$PATH`.
+
+### 3.8 `scripts/uninstall.sh`
+
+Era 100% macOS. Três correções:
+
+1. **Caminhos de manifesto por plataforma.** Array `NM_MANIFESTS` selecionado por `uname -s`: no Linux, `$XDG_CONFIG_HOME/{google-chrome,BraveSoftware/Brave-Browser,chromium}/NativeMessagingHosts/`.
+
+2. **`$USER` não vinculada** (`set -u`). `id -u "${SUDO_USER:-$USER}"` abortava o uninstall no meio com `line 153: USER: unbound variable` — `$USER` não é exportada por shells não-login, que é o caso normal de um `docker exec`, uma unit systemd ou um runner de CI. Trocado por `${SUDO_USER:-$(id -un)}` com fallback `id -u`.
+
+3. **`pkgutil` inexistente no Linux + `pipefail`.** `pkgutil --pkgs | grep ... | while ...` retorna ≠ 0 quando `pkgutil` não existe, e com `set -euo pipefail` isso **abortava o resto do uninstall**. Bloco envolvido em `command -v pkgutil`.
+
+4. Home do usuário sob `sudo`: antes assumia `/Users/$SUDO_USER`. Agora consulta `getent passwd` (Linux) com fallback para a convenção macOS.
+
+**Validado:** `uninstall.sh` roda até o fim no Linux e os dois diretórios `NativeMessagingHosts/` ficam vazios.
+
+### 3.9 Testes
+
+Nenhum código de produto foi ajustado para "passar no teste"; os testes é que estavam presos ao macOS.
+
+| Arquivo | Mudança |
+|---|---|
+| `test/helpers/macos-tools.ts` *(novo)* | Sondas `HAS_PLUTIL` / `HAS_SECURITY` |
+| `ios-nskeyed`, `ios-instruments` | `describe.skipIf(!HAS_PLUTIL)` — toda a suíte depende de `nskeyedArchive`, que faz `plutil -convert binary1` |
+| `ios-lockdown`, `ios-installer`, `ios-webinspector-plist` | `test.skipIf(!HAS_PLUTIL)` só nos casos que tocam `plutil` |
+| `ios-keychain` | `describe.skipIf(!HAS_SECURITY)` — usa o keychain real via `/usr/bin/security` |
+| `test/diagnose-lockfile.test.ts` | Fixtures NMH por plataforma (`~/.config` vs `~/Library/Application Support`, conjuntos de browsers distintos) |
+| `test/process-liveness.test.ts` *(novo)* | Cobertura do parsing de zumbi |
+
+> **Detalhe que custou uma iteração:** a primeira versão de `macos-tools.ts` detectava a ferramenta via `spawnSync(...).error === undefined`. O `spawnSync` do Bun **não** preenche `.error` para um executável ausente — devolve `status: 127` com `error: undefined`. A sonda reportava *todas* as ferramentas como presentes. Trocado por `existsSync()` no caminho absoluto, com o motivo documentado no arquivo.
+
+Os 2 testes de `install-modes` que ainda falhavam no container de build (sem browser) passam no container que tem Chrome e Brave — a exigência é ambiental, não da plataforma:
+
+```
+12 pass · 5 skip · 0 fail   (test/install-modes.test.ts, Ubuntu 24.04 com Chrome 151 + Brave 151)
+```
+
+---
+
+## 4. Como foi testado
+
+**Cadeia de build:** container `oven/bun:1.3.14` em `linux/amd64` → `bun install` → `bash scripts/build.sh --target=linux-x64` → artefatos copiados para um container `ubuntu:24.04` limpo (`/opt/interceptor`), rodando como usuário não-root.
+
+O container de teste não tinha Bun nem Node — os binários são self-contained, então isso comprova que o pacote não depende de runtime instalado.
+
+**Ambiente:** Ubuntu 24.04.4 LTS · Xvfb `:99` + openbox · Google Chrome 151.0.7922.169 · Brave 151.1.93.136 · servidor de fixtures em Python (estático + `/sse` + `/ws` + `/api/*.json`) em `127.0.0.1:8899`.
+
+### 4.1 Instalação fim-a-fim
+
+```
+$ bash scripts/install.sh --browser-only --brave
+==> [browser] Installing native messaging symlink(s)...
+    Brave: /home/tester/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.interceptor.host.json
+==> [browser] Launching Brave with --load-extension...
+==> Verifying extension reachability (waits up to 8s)...
+==> Extension loaded into Brave and reachable.
+    Extension ID: hkjbaciefhhgekldhncknbjkofbpenng
+```
+
+```
+$ interceptor status --verbose
+mode: browser-only
+daemon: running   pid: 3240   transport: unix:/tmp/interceptor.sock
+browser:  configured: brave · system default: brave · ✓ matches
+extension: reachable (a content-script ping succeeded against an interceptor-group tab)
+skills: ✓ claude: 3/3 linked
+```
+
+O daemon foi lançado **pelo próprio Brave** via native messaging (`mode:native-messaging` → `spawning detached standalone daemon` → `ws extension registered`), que é o caminho real de produção, não um `--standalone` manual.
+
+### 4.2 Matriz de verbos exercitados
+
+| Grupo | Verbos | Resultado |
+|---|---|---|
+| Compostos | `open` `read` `act` `inspect` | ✅ |
+| Leitura | `text` `text --markdown` `html` `tree` `state` `find` `diff` | ✅ |
+| Extração | `table` `links` `images` `forms` `query` `exists` `count` `attr` `style` | ✅ |
+| Ações | `click` `click --selector` `click text:` `type` `select` `check` `focus` `hover` `dblclick` `rightclick` `keys` `drag` `scroll` `what-at` `regions` `upload` | ✅ |
+| Navegação | `navigate` `back` `forward` `wait` `wait-stable` | ✅ |
+| Abas/janelas | `tabs` `tab new/switch` `window` `frames` `contexts` `group` `brand` | ✅ |
+| Rede | `net log` `net log --format har/pcapng` `net monitor` `net page-comm log` `headers add/clear` `override` `sse log` `sse streams` | ✅ |
+| Captura | `screenshot` `screenshot --save` `canvas status/list` `ocr` `save` | ✅ |
+| Dados | `storage` `history` `bookmarks` `downloads` `cookies` `clear` | ✅ |
+| Batch/monitor | `batch` `monitor start/status/stop/list` | ✅ |
+| Locais | `status` `init` `diagnose` `capabilities` `manifest` `skills list/status/adopt` `mcp status/install/uninstall` `research` `extensions` `keepawake` `idle` `delegate` `events` `daemon stop` | ✅ |
+| Gates de superfície | `macos *` `ios *` `upgrade --full` | ✅ erram com a mensagem correta |
+
+Evidências pontuais:
+
+- **Captura passiva de rede** — `fetch` e `XHR` gravados com corpo, headers e content-type; export HAR válido (2 entries, JSON parseável) e pcapng com magic `0a 0d 0d 0a` correto.
+- **SSE** — `sse streams` mostrou o stream vivo (`chunkCount: 3`, texto acumulado) e `sse log` o stream concluído (`totalChunks: 5`, `duration: 4717`).
+- **WebSocket / BroadcastChannel** — `net monitor on --reload` + `net page-comm log` capturou `ws_opening`, `ws_open`, `broadcast_open` e `broadcast_send` com payload.
+- **OCR** — roda inteiramente na extensão (tesseract.js no offscreen document, WASM empacotado). `source: "tesseract"`, `confidence: 81`, leu o texto do canvas.
+- **Screenshot** — PNG de página inteira, 1019×3194, 237 KB, verificado byte a byte (magic PNG + dimensões no IHDR) e inspecionado visualmente: renderização completa e correta.
+- **`skills adopt`** — 3 symlinks criados em `~/.claude/skills/` apontando para `/opt/interceptor/skills/*`.
+- **`mcp install`** — escreveu `~/.claude.json` com `"command": "/opt/interceptor/interceptor"`.
+
+### 4.3 Suíte automatizada
+
+```
+$ bun test        # dentro do Ubuntu 24.04
+1062 pass · 37 skip · 0 fail · 3091 expect() · 138 arquivos · 25.35s
+
+$ bun run typecheck
+tsconfig.host.json ✓  tsconfig.extension.json ✓  tsconfig.json ✓
+```
+
+### 4.4 Limpeza
+
+Os containers `interceptor-build`, `interceptor-linux-test`, `interceptor-linux-test2`, a imagem-snapshot e as imagens base baixadas para o teste (`ubuntu:24.04`, `oven/bun:1.3.14`, `alpine:latest`) foram removidos ao final.
+
+---
+
+## 5. Limitações conhecidas no Linux
+
+### 5.1 Por design (paridade com Windows)
+
+| Item | Situação |
+|---|---|
+| `interceptor macos *` / `ios *` | Exigem host macOS. O surface gate já bloqueia. |
+| `upgrade --full` / `update` (Sparkle) | macOS apenas. No Linux, rebuild/reinstale o pacote. |
+| `act --os` / `click --trusted` (input de SO) | Sem backend. O daemon devolve o sentinel explícito; `capabilities` agora reporta `os_input: false`. Implementar via XTEST/uinput seria uma feature nova, não parte do port. |
+
+### 5.2 Do navegador, não da plataforma
+
+- **Google Chrome ignora `--load-extension`.** Confirmei no Chrome 151 Linux: a flag é descartada silenciosamente (o perfil não registra a extensão) e `--disable-features=DisableLoadExtensionCommandLineSwitch` já não funciona. É o mesmo comportamento que o `install.sh` documenta para macOS/Windows — em builds *branded* o caminho é "Load unpacked" manual. Brave, Vivaldi e Chrome for Testing continuam honrando a flag, e por isso o fluxo automático do `install.sh --brave` funciona ponta a ponta.
+- **`interceptor eval` exige o toggle "Allow User Scripts".** Sem a API `chrome.userScripts` habilitada por extensão, o eval cai num caminho limitado pela CSP da *extensão* e falha com "page CSP blocks eval" mesmo em páginas sem CSP. `interceptor capabilities` já expõe isso (`userScripts.api_present: false`). Não é específico do Linux — é um pré-requisito de instalação.
+
+### 5.3 Não verificável em container headless
+
+Duas funcionalidades dependem de o Chromium reportar a janela como **focada pelo SO** (`chrome.windows.get().focused`). Sob Xvfb + openbox isso nunca fica `true`, mesmo com `xdotool windowactivate`:
+
+- `clipboard read/write` → `Document is not focused` (restrição da Clipboard API).
+- Escalada automática de `click` para input de SO, que exige aba ativa em janela focada.
+
+Nenhuma das duas tem código específico de plataforma; ambas precisam de uma sessão de desktop real para validação.
+
+### 5.4 Observações registradas (sem alteração de código)
+
+Duas coisas que encontrei durante a investigação **não são regressões do port** e afetam macOS igualmente — deixo registradas em vez de mudá-las às cegas:
+
+1. **`waitForMutation()` instala o `MutationObserver` depois do dispatch do clique** (`extension/src/content/input-simulation.ts:108`), então uma mutação *síncrona* do handler nunca é vista e o clique é marcado como "no DOM change". Isso é conhecido e assumido pelo projeto — `extension/src/content/actions/click-selector.test.ts:28` comenta exatamente esse comportamento e as fixtures mutam de forma assíncrona por causa dele. Não mexi.
+
+2. **A escalada automática para `os_click` não chega a postar um evento de SO.** O router da extensão devolve `type: "click"` com um payload `method: "os_event"`, mas o daemon só posta o evento quando `actionType` começa com `os_` (`daemon/index.ts:768` e `:1467`). Ou seja, a escalada produz metadados (`escalated: {...}`) sem input de SO real, em qualquer plataforma. Quando ela "falha", o motivo observado foi sempre o guard de foreground (`tab is not the active tab` / `window is not the OS-focused window`), idêntico no macOS.
+
+O efeito prático no Linux: um clique que realmente aconteceu pode ser reportado como `click failed at all layers` quando o `waitForMutation` erra. O caminho correto de correção é o item (1), que é uma decisão do projeto — não uma questão de porta.
+
+---
+
+## 6. Arquivos alterados
+
+| Arquivo | Natureza |
+|---|---|
+| `scripts/build.sh` | alvo `linux-x64` / `linux-arm64`, staging do pacote, guarda do codesign |
+| `scripts/install.sh` | dry-run sem browser; resolução do CLI no layout de pacote |
+| `scripts/uninstall.sh` | manifestos por plataforma, `$USER` não vinculada, `pkgutil` guardado, home sob sudo |
+| `shared/platform.ts` | `isProcessAlive()` (zumbis), `osInputSupported()` |
+| `cli/lib/status-renderer.ts` | NMH por plataforma, `detectSystemDefaultBrowser()`, dica macOS-only, liveness |
+| `cli/commands/daemon.ts` | liveness zumbi-aware |
+| `cli/daemon-spawn.ts` | liveness zumbi-aware |
+| `cli/commands/meta.ts`, `cli/commands/init.ts` | bloco `browser:` habilitado no Linux |
+| `cli/index.ts` | correção de `capabilities.os_input` |
+| `test/helpers/macos-tools.ts` *(novo)* | sondas de `plutil` / `security` |
+| `test/process-liveness.test.ts` *(novo)* | cobertura de zumbis |
+| `test/ios-*.test.ts` (5), `test/diagnose-lockfile.test.ts` | gates por ferramenta / fixtures por plataforma |
+| `docs/linux-install.md` *(novo)* | guia de instalação Linux |
+
+---
+
+## 7. Fase 2 — passos de follow-up aplicados
+
+Os itens 1, 2, 3 e 5 da lista original de próximos passos foram implementados e validados; o item 4 (input de SO via XTEST/uinput) foi explicitamente descartado.
+
+**Resultado da fase 2, validado em `ubuntu:24.04`:**
+
+| | Antes da fase 2 | Depois |
+|---|---|---|
+| Suíte de testes no Linux | 1062 pass / 0 fail | **1074 pass / 0 fail** / 37 skip |
+| CI | só `macos-15` | job `ubuntu-24.04` (typecheck + testes + build + smoke + pacote) |
+| Distribuição | só a árvore `dist/linux/<arch>/` | `.tar.gz` + `.deb` + `.rpm`, CLI no `PATH` |
+| Browsers no Linux | Chrome, Brave | **+ Chromium, + Firefox (build Gecko)** |
+| libc | só glibc | **+ musl** (Alpine) |
+| Clique que "pousa" mas não muta o DOM | `click failed at all layers` | `success` + aviso honesto |
+
+### 7.1 CI Linux — `.github/workflows/ci.yml`
+
+Job `ubuntu-24.04` rodando em paralelo com o `macos-15` (renomeado para `macos — …`):
+
+`bash -n` em `scripts/*.sh` → `bun install --frozen-lockfile` → `typecheck` → `bun test` → `build.sh --target=linux-x64` → smoke do CLI/daemon (`--version`, `status`, `daemon stop`) → `install.sh --dry-run` para os **quatro** targets Linux → `package-linux.sh --arch x64 --format tar.gz,deb`.
+
+O runner `ubuntu-24.04` já traz Chrome e Firefox instalados, então a detecção de browser do `install.sh` e os testes `install-modes` rodam de verdade em vez de pular.
+
+### 7.2 Empacotamento — `scripts/package-linux.sh` *(novo)*
+
+```
+bash scripts/package-linux.sh --arch x64                  # tar.gz + deb + rpm
+bash scripts/package-linux.sh --arch x64 --format tar.gz  # só o tarball
+bash scripts/package-linux.sh --arch x64-musl             # tar.gz apenas
+```
+
+Prefixo `/opt/interceptor`, com `/usr/bin/interceptor` → binário e `/usr/bin/interceptor-install` → wrapper do `install.sh`.
+
+Decisões que valem registrar:
+
+- **O pacote de sistema NÃO registra o native-messaging host.** Isso escreve em `~/.config` / `~/.mozilla` — estado por usuário que uma instalação como root não pode criar para um usuário arbitrário. O `postinst` imprime o comando (`interceptor-install --browser-only --chrome`).
+- **`deb`/`rpm` são recusados para alvos musl.** Um binário musl instala limpo num Debian e não executa; produzir o pacote seria um erro silencioso.
+- **`AutoReqProv: no` no spec do RPM** — os binários são Bun self-contained; o autodetector geraria dependências que não existem.
+- **Alpine precisa de `apk add libstdc++ libgcc`.** Os builds musl do Bun linkam essas libs dinamicamente e o Alpine base não as traz — sem elas o binário morre com `Error loading shared library libstdc++.so.6` antes de imprimir nada. O `README-INSTALL.txt` do tarball musl traz esse passo como item 0.
+
+**CLI no `PATH`:** `install.sh` ganhou `link_cli_onto_path()` (Linux apenas — macOS usa o pkg, Windows o Setup). Symlink, nunca cópia; recusa-se a sobrescrever um arquivo real; avisa quando o diretório não está no `PATH`; flags `--no-link-cli` e `--link-cli-dir <dir>`. O caminho criado é **gravado** em `<generated>/cli-link` para que o `uninstall.sh` remova exatamente aquele link — sem o registro, um `--link-cli-dir` customizado ficaria órfão.
+
+> **Bug encontrado no caminho:** a leitura desse registro estava *depois* do bloco que apaga `daemon/.generated`, ou seja, o arquivo era removido antes de ser lido. Corrigido hoistando a leitura para antes da limpeza.
+
+**Bug real de empacotamento:** `install.sh` gravava o manifesto resolvido em `$ROOT/daemon/.generated`. Num prefixo root-owned (`/opt` vindo do deb) o usuário não pode criar esse diretório — `mkdir: cannot create directory '/opt/interceptor/daemon/.generated': Permission denied`. Agora, quando `$ROOT/daemon` não é gravável, o manifesto vai para `${XDG_STATE_HOME:-~/.local/state}/interceptor` — a mesma raiz que `shared/monitor-tasks.ts` já usa no Linux.
+
+### 7.3 Chromium — suporte completo
+
+Chromium usa a **mesma** extensão MV3 de Chrome/Brave, então foi só tabela de instalação:
+
+- `install.sh`: `--chromium` em `profile_root_for` / `nm_dir_for` / `browser_installed` / `browser_bin_for`, na auto-detecção e no dispatch de `load_extension`. Detecta `chromium` ou `chromium-browser` no `PATH`; NM dir em `~/.config/chromium/NativeMessagingHosts`.
+- `status-renderer.ts`: entrada `chromium` em `NMH_BROWSER_DIRS_LINUX`.
+- `uninstall.sh`: já cobria `~/.config/chromium`.
+- `detectLinuxDefaultBrowser()` passou a distinguir `chromium` de `chrome` — antes o `.desktop` do Chromium era mapeado para `"chrome"`, o que produziria um "✓ matches" falso agora que são alvos de instalação distintos.
+
+Chromium é *unbranded*, então honra `--load-extension`: `install.sh --chromium` carrega e lança em um passo.
+
+**Validado:** Chromium 154 (snapshot oficial), extensão carregada, daemon spawnado pelo próprio browser via native messaging, e a matriz de verbos verde (tree/text/table/click/type/select/check/hover/dblclick/rightclick/keys/scroll/navigate/exists/count/storage/net log/screenshot/**ocr**/capabilities).
+
+### 7.4 Firefox — build Gecko novo
+
+Firefox não é Chromium: exigiu um terceiro alvo de extensão, ao lado dos existentes MV2-Electron e Safari.
+
+**`extension/src/background-firefox.ts` *(novo)*** — mesmo padrão do `background-safari.ts`: compõe os mesmos módulos `background/*`, mas com o transporte normal (native messaging + WebSocket loopback; Gecko não tem o sandbox do Safari) e cada passo opcional embrulhado, para que uma API ausente perca **uma** capacidade e nunca o contexto inteiro. Não registra `background/cdp.ts` (`chrome.debugger`) nem `keepawake` (`chrome.power`) — omitidos em vez de embrulhados, para que a ausência fique visível no arquivo.
+
+**`build_extension_firefox()` em `scripts/build.sh`** — reusa `content.js` / `inject-net.js` / `inject-canvas.js` / `popup.js` verbatim do build Chromium e gera um manifesto Gecko. Quatro diferenças, todas obrigatórias:
+
+| | Chromium | Gecko |
+|---|---|---|
+| background | `service_worker` | `scripts` (event page) — um `service_worker` faz a extensão não carregar |
+| identidade | `key` (id determinístico) | `browser_specific_settings.gecko.id` |
+| autorização do host nativo | `allowed_origins: ["chrome-extension://…"]` | `allowed_extensions: ["interceptor@hackervalley.media"]` |
+| permissões | 27 | 19 (removidas: `tabGroups`, `debugger`, `power`, `offscreen`, `tabCapture`, `pageCapture`, `userScripts`, `search`) |
+
+`strict_min_version: "129.0"` — `world: "MAIN"` em content scripts chegou no 128 e `match_origin_as_fallback` no 129, e ambos são usados.
+
+**`daemon/com.interceptor.host.firefox.json` *(novo)*** — template Gecko do host nativo. `install.sh` seleciona template + diretório de extensão + NM dir via um único `IS_GECKO`.
+
+**Diferenças operacionais tratadas no `install.sh`:**
+- NM dir do Firefox é `~/.mozilla/native-messaging-hosts` — **um por usuário**, fora da árvore XDG e fora da árvore de perfis. Por isso ele é resolvido separadamente também no `installedNmhManifests()`.
+- `--profiles` não se aplica (perfis Gecko são indexados por `profiles.ini`, não são diretórios "Default"/"Profile 2"); o comando explica isso e sai.
+- Firefox não tem `--load-extension`. O `load_extension` imprime o caminho do `about:debugging` e para, em vez de lançar um browser que ignoraria a flag.
+
+**Contexto fixo `firefox`** (Chromium usa UUID aleatório), então os dois coexistem no mesmo daemon e o Firefox é endereçável com `--context firefox`.
+
+**Validado:** Firefox 154, add-on instalado via RDP (`installTemporaryAddon` — a mesma chamada do `about:debugging` e do `web-ext`), registrado como contexto `firefox` simultaneamente com o Chromium. Verde: árvore a11y, text/html/find, table/links/images/forms/query/exists/count/attr, click (selector, ref, `text:`), type/select/check/focus/hover/dblclick/rightclick/keys/scroll, navigate/back, tabs/frames/window/group, **captura passiva de fetch+XHR**, **SSE**, **WebSocket + BroadcastChannel**, screenshot de página inteira, canvas list, storage/history/downloads/cookies, batch, monitor.
+
+### 7.5 O bug do clique — resolvido
+
+O primeiro relatório registrou, sem corrigir: um clique sintético que **pousa** mas cuja mutação de DOM não é observada em 200 ms escala para `os_click`, e essa escalada falha, produzindo `click failed at all layers` para uma ação que funcionou.
+
+Com o Firefox entrando em cena isso deixou de ser aceitável: no Gecko a escalada é *estruturalmente* impossível. A correção tem três partes:
+
+1. **`ExtensionTransportConfig.osInputAvailable`** — um entrypoint pode declarar que aquele build não tem lane de input de SO. O `background-firefox.ts` declara `false`.
+2. **O daemon informa o host.** O ack de registro (`context_registered`) passou a carregar `osInput: boolean`, vindo de `osInputSupported()` — que só é `true` no macOS. Campo opcional: um daemon antigo simplesmente não o envia e a extensão mantém o default. Isso conserta o build **Chromium rodando em Linux/Windows**, que não tem como enxergar o SO do host de dentro de um service worker.
+3. **O router só escala se houver para onde.** `isOsInputAvailable()` virou assíncrona e é aguardada antes de decidir. Quando não há lane, o resultado sintético é devolvido como **sucesso** com o aviso `no DOM change after click — …`, que é a informação que o usuário realmente precisa.
+
+Como MV3 destrói o service worker por ociosidade e leva o estado de módulo junto, a resposta do daemon é **persistida** em `chrome.storage.local` e reidratada sob demanda — sem isso, o primeiro clique após cada acordar voltaria a escalar.
+
+`interceptor capabilities` passou a reportar exatamente o valor que o router consulta, em vez de "há um daemon conectado".
+
+**Antes → depois**, mesmo botão sem handler, Chromium/Linux:
+
+```
+{"success": false, "error": "click failed at all layers", ...}
+{"success": true,  "data": "clicked [e1]",
+ "warning": "no DOM change after click — if the site requires trusted events, try: interceptor click --trusted e1"}
+```
+
+> **Nota de diagnóstico:** a primeira verificação desta correção falhou por um motivo que não era o código — um perfil Chromium reaproveitado mantinha o **service worker antigo** da extensão. Com `--user-data-dir` novo, o comportamento correto apareceu imediatamente. Isso está registrado no troubleshooting do `docs/linux-install.md`.
+
+### 7.6 Degradação honesta de APIs ausentes no Gecko
+
+Três erros crus viraram mensagens acionáveis:
+
+| Verbo | Antes (Firefox) | Depois |
+|---|---|---|
+| `ocr` | `Type error for parameter filter (Error processing contextTypes.0: Invalid enumeration value "OFFSCREEN_DOCUMENT")` | `this browser has no offscreen-document API (Chromium-only) … use a Chromium-based browser for ocr` |
+| `keepawake` | `can't access property "requestKeepAwake", chrome.power is undefined` | `keepawake is unavailable — this browser has no power API (Chromium-only)` |
+| `bookmarks` | `An unexpected error occurred` | `bookmarks call failed: An unexpected error occurred` (com checagem de presença da API) |
+
+Sobre `bookmarks`: só a forma-árvore falha no Gecko; `bookmarks --query` funciona. A API existe e o erro vem do próprio Firefox, então o handler agora distingue "API ausente" de "chamada falhou" e repassa o texto original em vez de engolir.
+
+### 7.7 musl / Alpine
+
+`--target=linux-x64-musl` e `--target=linux-arm64-musl` (`bun-linux-x64-musl-baseline` / `bun-linux-arm64-musl`), staging idêntico ao glibc em `dist/linux/<arch>-musl/`.
+
+**Validado em `alpine:3.20`:** após `apk add libstdc++ libgcc`, `interceptor --version`, `status`, `daemon stop`, `manifest --json` e `skills list` rodam. O `ldd` confirma o linker musl (`/lib/ld-musl-x86_64.so.1`).
+
+### 7.8 Cobertura de teste adicionada
+
+| Arquivo | O que trava |
+|---|---|
+| `test/nmh-locations.test.ts` *(novo)* | As três formas de diretório NMH (macOS / XDG / `~/.mozilla`), o conjunto de browsers por plataforma, `XDG_CONFIG_HOME` respeitado só pela família Chromium, e Windows/sem-HOME retornando vazio |
+| `test/context-uniqueness.test.ts` | O ack de registro carregando (ou omitindo) `osInput`, e `claimContextId` repassando o flag |
+
+---
+
+## 8. Arquivos alterados na fase 2
+
+| Arquivo | Natureza |
+|---|---|
+| `.github/workflows/ci.yml` | job `ubuntu-24.04` |
+| `scripts/package-linux.sh` *(novo)* | tar.gz / deb / rpm |
+| `scripts/build.sh` | `build_extension_firefox`, alvos musl, staging da extensão Gecko + template |
+| `scripts/install.sh` | `--chromium`, `--firefox`, `--no-link-cli`, `--link-cli-dir`, seleção Gecko, `GENERATED_DIR` gravável, link do CLI no PATH |
+| `scripts/uninstall.sh` | NM do Firefox, registro do link do CLI (lido antes da limpeza) |
+| `extension/src/background-firefox.ts` *(novo)* | entrypoint Gecko |
+| `daemon/com.interceptor.host.firefox.json` *(novo)* | template do host nativo Gecko |
+| `daemon/context-registration.ts`, `daemon/index.ts` | `osInput` no ack de registro |
+| `extension/src/background/transport.ts` | `osInputAvailable` + persistência + consumo do ack |
+| `extension/src/background/router.ts` | escalada condicionada à existência da lane |
+| `extension/src/background/capabilities/meta.ts` | `os_input` reporta a visão do router |
+| `extension/src/background/offscreen.ts` | guarda de API ausente |
+| `extension/src/background/keepawake.ts` | guarda de `chrome.power` |
+| `extension/src/background/capabilities/bookmarks.ts` | erro atribuído |
+| `cli/lib/status-renderer.ts` | `chromium` + `firefox` na tabela NMH, `defaultBrowserMatchesConfigured()` |
+| `cli/commands/meta.ts`, `cli/commands/init.ts` | uso do matcher compartilhado |
+| `cli/commands/diagnose.ts` | dica de mismatch neutra quanto ao browser |
+| `test/nmh-locations.test.ts` *(novo)*, `test/context-uniqueness.test.ts` | cobertura |
+| `docs/linux-install.md` | Chromium, Firefox, pacotes, musl, troubleshooting |
+
+---
+
+## 9. Ambiente de validação da fase 2
+
+Container `ubuntu:24.04` (linux/amd64, `--security-opt seccomp=unconfined`), Xvfb `:99` + openbox, servidor de fixtures Python (estático + `/sse` + `/ws` + `/api/*.json`), instalado a partir do **`.deb`** como usuário não-root.
+
+Browsers: Google Chrome 151.0.7922.169 · Brave 151.1.93.136 · Chromium 154.0.8011.0 (snapshot oficial) · Firefox 154.0 (tarball Mozilla). Alpine 3.20 para o binário musl.
+
+Testes finais: `1074 pass / 37 skip / 0 fail` em 139 arquivos; `typecheck` limpo nos 3 projetos; `.deb`, `.rpm` e `.tar.gz` construídos e o `.deb` instalado/desinstalado de verdade.
+
+Containers e imagens removidos ao final.
+
+---
+
+## 10. O que continua fora de escopo
+
+- **Input de SO no Linux (XTEST/uinput)** — descartado explicitamente. Continua sendo uma feature nova, com implicações de permissão, e não parte do port. `act --os` / `--trusted` seguem devolvendo o sentinel honesto, agora também refletido em `capabilities` e na decisão de escalada.
+- **Edge e Vivaldi no Linux** — fora do pedido; os diretórios seriam `~/.config/microsoft-edge` e `~/.config/vivaldi`, e adicioná-los exige tocar `nm_dir_for()`/`browser_installed()` no `install.sh` **e** `NMH_BROWSER_DIRS_LINUX` no `status-renderer.ts`, mantidos em espelho de propósito.
+- **XPI assinado do Firefox** — o add-on hoje carrega como temporário (`about:debugging`), que some ao fechar o browser. Assinar exige conta e submissão na AMO.
+- **`waitForMutation` instalando o observer depois do dispatch** — o projeto documenta esse comportamento num teste próprio (`click-selector.test.ts:28`); permanece intocado. A correção da fase 2 remove a *consequência* no Linux (o falso "failed"), não a causa.

--- a/extension/src/background-firefox.ts
+++ b/extension/src/background-firefox.ts
@@ -1,0 +1,86 @@
+// Firefox (Gecko) WebExtension background — MV3 event page.
+//
+// Firefox implements MV3 with an event page (`background.scripts`), not a
+// service worker, and exposes the `chrome.*` namespace as a promise-and-callback
+// alias over `browser.*`, so every module under background/ runs unmodified. The
+// transport is the same one Chromium builds use: native messaging first
+// (com.interceptor.host, registered under ~/.mozilla/native-messaging-hosts),
+// with the loopback WebSocket as the fallback — Gecko puts no Safari-style
+// sandbox between an extension and ws://localhost.
+//
+// What Gecko does NOT have decides the rest of this file:
+//   chrome.debugger   -> the CDP lane (background/cdp.ts) cannot register
+//   chrome.tabGroups  -> tab-group + brand-tab-group degrade to ungrouped
+//   chrome.power      -> keepawake has no backend
+//   chrome.offscreen  -> tesseract OCR has nowhere to run
+//   chrome.tabCapture / pageCapture -> compositor capture lanes are absent
+//
+// Every optional step is therefore wrapped: a Gecko version that lacks one API
+// must lose that one capability, never the whole browser context. Losing the
+// context would make the browser invisible to `interceptor contexts` and take
+// the working verbs down with the missing one.
+//
+// The context id is fixed at "firefox" (Chromium builds use a random UUID) so a
+// Firefox instance coexists with Chrome/Brave in the daemon's context map and is
+// addressable as `--context firefox`.
+
+import {
+  configureTransport,
+  connectToHost,
+  connectWsChannel,
+  registerAlarmListener,
+  registerSwKeepaliveListener,
+  registerStorageContextListener,
+} from "./background/transport"
+import { registerTabGroupListeners, ensureInterceptorGroup } from "./background/tab-group"
+import { registerBrandTabGroup } from "./background/brand-tab-group"
+import { registerTabLifecycle } from "./background/tab-lifecycle"
+import { registerDelegationListeners } from "./background/delegation"
+import { initializeActionRouter } from "./background/router"
+
+function runOptionalStartupStep(name: string, step: () => void): void {
+  try {
+    step()
+  } catch (err) {
+    console.warn(`[interceptor] Firefox startup step '${name}' unavailable:`, err)
+  }
+}
+
+function addOptionalRuntimeListener(
+  name: string,
+  event: { addListener?: (listener: () => void) => void } | undefined,
+): void {
+  if (typeof event?.addListener !== "function") return
+  runOptionalStartupStep(name, () => event.addListener?.(connect))
+}
+
+function connect(): void {
+  connectToHost()
+  connectWsChannel()
+  runOptionalStartupStep("interceptor tab group", ensureInterceptorGroup)
+}
+
+// Module state, not a global: static imports run before this module's body, so a
+// global assigned here could not govern an imported module's startup.
+configureTransport({ contextId: "firefox", osInputAvailable: false })
+
+// Control plane first — a capability that fails to register must not be able to
+// prevent the daemon from ever seeing this browser.
+runOptionalStartupStep("action router", initializeActionRouter)
+runOptionalStartupStep("alarm keepalive", registerAlarmListener)
+runOptionalStartupStep("event-page keepalive", registerSwKeepaliveListener)
+runOptionalStartupStep("context storage", registerStorageContextListener)
+runOptionalStartupStep("tab groups", registerTabGroupListeners)
+runOptionalStartupStep("brand tab group", registerBrandTabGroup)
+runOptionalStartupStep("tab lifecycle", registerTabLifecycle)
+runOptionalStartupStep("delegation", registerDelegationListeners)
+
+// chrome.debugger (background/cdp.ts) and chrome.power (background/keepawake.ts)
+// have no Gecko implementation at all; they are omitted rather than guarded so
+// the absence is visible here instead of surfacing as a swallowed warning.
+
+const runtime = (chrome as unknown as { runtime?: typeof chrome.runtime }).runtime
+addOptionalRuntimeListener("runtime.onInstalled", runtime?.onInstalled)
+addOptionalRuntimeListener("runtime.onStartup", runtime?.onStartup)
+
+connect()

--- a/extension/src/background/capabilities/bookmarks.ts
+++ b/extension/src/background/capabilities/bookmarks.ts
@@ -1,8 +1,33 @@
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
 
+/**
+ * Gecko surfaces most bookmarks failures as the bare string "An unexpected
+ * error occurred", which tells the caller nothing about whether the API is
+ * missing, unpermitted, or genuinely failing. Name the browser-side condition
+ * we can actually check — API presence — and pass the original text through.
+ */
+function bookmarksError(err: unknown): ActionResult {
+  const api = (chrome as unknown as { bookmarks?: unknown }).bookmarks
+  const detail = err instanceof Error ? err.message : String(err)
+  if (!api) {
+    return { success: false, error: "this browser does not expose a bookmarks API" }
+  }
+  return { success: false, error: `bookmarks call failed: ${detail}` }
+}
+
 export async function handleBookmarkActions(
   action: { type: string; [key: string]: unknown },
   _tabId: number
+): Promise<ActionResult> {
+  try {
+    return await dispatchBookmarkAction(action)
+  } catch (err) {
+    return bookmarksError(err)
+  }
+}
+
+async function dispatchBookmarkAction(
+  action: { type: string; [key: string]: unknown }
 ): Promise<ActionResult> {
   switch (action.type) {
     case "bookmark_tree": {

--- a/extension/src/background/capabilities/meta.ts
+++ b/extension/src/background/capabilities/meta.ts
@@ -1,4 +1,4 @@
-import { activeTransport } from "../transport"
+import { activeTransport, isOsInputAvailable } from "../transport"
 import { debuggerAttached, cdpAttachActDetach } from "../cdp"
 import { resolveTabLifecycle } from "../tab-lifecycle"
 
@@ -52,7 +52,10 @@ export async function handleMetaActions(
         success: true,
         data: {
           layers: {
-            os_input: daemonConnected,
+            // Report the value the router will actually consult, not just
+            // "a daemon is connected": on a host with no OS-input backend the
+            // daemon says so at registration and every escalation is skipped.
+            os_input: daemonConnected && await isOsInputAvailable(),
             tabCapture: true,
             cdp_debugger: hasDebugger,
             debugger_active: debuggerActive

--- a/extension/src/background/context-registration.ts
+++ b/extension/src/background/context-registration.ts
@@ -11,7 +11,9 @@ type ChromeLike = {
 }
 
 export type ContextRegistrationControl =
-  | { type: "context_registered"; contextId?: unknown }
+  // osInput: the daemon telling us whether ITS host can deliver OS-level
+  // trusted input. Only macOS can; a service worker cannot see the host OS.
+  | { type: "context_registered"; contextId?: unknown; osInput?: unknown }
   | { type: "context_conflict"; contextId?: unknown; error?: unknown }
 
 export function registrationControlType(msg: unknown): ContextRegistrationControl["type"] | null {

--- a/extension/src/background/keepawake.ts
+++ b/extension/src/background/keepawake.ts
@@ -15,14 +15,21 @@ export async function setKeepAwake(
   on: boolean,
   level: KeepAwakeLevel = "system"
 ): Promise<{ on: boolean; level?: KeepAwakeLevel }> {
+  // chrome.power is Chromium-only. Without this check the Gecko build reports
+  // "can't access property requestKeepAwake, chrome.power is undefined" — a raw
+  // TypeError that reads like a bug rather than an absent capability.
+  const power = (chrome as unknown as { power?: typeof chrome.power }).power
+  if (typeof power?.requestKeepAwake !== "function") {
+    throw new Error("keepawake is unavailable — this browser has no power API (Chromium-only)")
+  }
   if (on) {
     // "system" keeps the CPU awake but lets the display sleep overnight;
     // "display" keeps the screen on too.
-    chrome.power.requestKeepAwake(level)
+    power.requestKeepAwake(level)
     await chrome.storage.local.set({ [KEEPAWAKE_STORAGE_KEY]: { on: true, level } })
     return { on: true, level }
   }
-  chrome.power.releaseKeepAwake()
+  power.releaseKeepAwake()
   await chrome.storage.local.set({ [KEEPAWAKE_STORAGE_KEY]: { on: false } })
   return { on: false }
 }

--- a/extension/src/background/offscreen.ts
+++ b/extension/src/background/offscreen.ts
@@ -1,7 +1,23 @@
 export const OFFSCREEN_IDLE_MS = 30_000
 let offscreenIdleTimer: ReturnType<typeof setTimeout> | null = null
 
+/**
+ * Offscreen documents are a Chromium API. The Gecko build has no equivalent, so
+ * every caller here (image crop/stitch/diff and the tesseract OCR worker) has no
+ * backend on Firefox. Detect that up front: without this, `runtime.getContexts`
+ * below rejects with a raw Gecko enum error ("Invalid enumeration value
+ * OFFSCREEN_DOCUMENT") that says nothing about what the user should do.
+ */
+export function offscreenAvailable(): boolean {
+  const api = (chrome as unknown as { offscreen?: { createDocument?: unknown } }).offscreen
+  return typeof api?.createDocument === "function"
+}
+
+export const OFFSCREEN_UNSUPPORTED_ERROR =
+  "this browser has no offscreen-document API (Chromium-only), so image compositing and tesseract OCR are unavailable here — use a Chromium-based browser for `ocr`"
+
 export async function ensureOffscreen(): Promise<void> {
+  if (!offscreenAvailable()) throw new Error(OFFSCREEN_UNSUPPORTED_ERROR)
   const contexts = await chrome.runtime.getContexts({
     contextTypes: ["OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType]
   })
@@ -26,6 +42,12 @@ export function resetOffscreenTimer(): void {
 }
 
 export async function sendToOffscreen(msg: Record<string, unknown>): Promise<unknown> {
+  // Return the shared {success,error} shape rather than throwing: every caller
+  // already forwards that straight to the CLI, so an unsupported browser reads
+  // as a clear capability gap instead of an unhandled rejection.
+  if (!offscreenAvailable()) {
+    return { success: false, error: OFFSCREEN_UNSUPPORTED_ERROR }
+  }
   await ensureOffscreen()
   return new Promise((resolve) => {
     chrome.runtime.sendMessage({ ...msg, target: "offscreen" }, resolve)

--- a/extension/src/background/transport.ts
+++ b/extension/src/background/transport.ts
@@ -33,6 +33,12 @@ let configuredContextId: string | null = null
 let forceWebSocketTransport = false
 let WebSocketImpl = globalThis.WebSocket
 let safariNativeRelayEnabled = false
+// null = not yet known on this service-worker generation. MV3 tears the worker
+// down on idle and module state dies with it, so the daemon's answer is also
+// persisted (see OS_INPUT_STORAGE_KEY) and rehydrated on demand — otherwise the
+// first click after every wake would escalate again on a host that cannot.
+let osInputAvailable: boolean | null = null
+export const OS_INPUT_STORAGE_KEY = "interceptor_os_input"
 let safariNativeRelayClient: SafariNativeRelayClient | null = null
 export const NATIVE_KEEPALIVE_PONG_TIMEOUT_MS = 15_000
 export const RECENT_NATIVE_ACTIVITY_GRACE_MS = 10_000
@@ -46,6 +52,14 @@ export type ExtensionTransportConfig = {
   contextId?: string
   forceWebSocket?: boolean
   safariNativeRelay?: boolean
+  /**
+   * Can this build reach an OS-level input lane at all? Chromium builds can
+   * (the daemon posts CGEvents on macOS) and Safari can (the containing appex
+   * routes to `interceptor macos`). The Gecko build cannot on any host, so it
+   * sets this false and the router stops escalating clicks it can never land.
+   * Defaults true — a build must opt out explicitly.
+   */
+  osInputAvailable?: boolean
   /** Test/host injection; production entrypoints use the runtime WebSocket. */
   webSocketImpl?: typeof WebSocket
 }
@@ -57,7 +71,43 @@ export function configureTransport(config: ExtensionTransportConfig): void {
   }
   forceWebSocketTransport = config.forceWebSocket === true
   safariNativeRelayEnabled = config.safariNativeRelay === true
+  // An entrypoint that hard-disables the lane (the Gecko build) is authoritative
+  // and re-applies on every worker start; anything else waits for the daemon.
+  osInputAvailable = config.osInputAvailable === false ? false : null
   if (config.webSocketImpl) WebSocketImpl = config.webSocketImpl
+}
+
+/**
+ * Whether this build + host pair has any OS-level input lane to escalate into.
+ *
+ * Unknown resolves to true — the historical behavior — so a daemon too old to
+ * report the flag keeps working exactly as before.
+ */
+export async function isOsInputAvailable(): Promise<boolean> {
+  if (osInputAvailable !== null) return osInputAvailable
+  try {
+    const stored = (await chrome.storage.local.get(OS_INPUT_STORAGE_KEY))[OS_INPUT_STORAGE_KEY]
+    if (typeof stored === "boolean") {
+      osInputAvailable = stored
+      return stored
+    }
+  } catch {}
+  return true
+}
+
+/** Record the daemon's answer for this worker generation and the next. */
+function rememberOsInputAvailability(reported: boolean): void {
+  // A build that disabled the lane outright stays disabled: a browser with no
+  // OS-input API cannot use one just because the host happens to have it.
+  const next = osInputAvailable === false ? false : reported
+  osInputAvailable = next
+  try {
+    const storage = (chrome as unknown as { storage?: { local?: { set?: (items: Record<string, unknown>) => unknown } } }).storage
+    const result = storage?.local?.set?.({ [OS_INPUT_STORAGE_KEY]: next })
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      ;(result as Promise<void>).catch(() => {})
+    }
+  } catch {}
 }
 
 /** Restore injected entrypoint configuration between tests. */
@@ -82,6 +132,7 @@ export function resetTransportForTesting(): void {
   safariNativeRelayClient = null
   if (activeTransport === "websocket" || activeTransport === "safari-native") activeTransport = "none"
   configuredContextId = null
+  osInputAvailable = null
   forceWebSocketTransport = false
   safariNativeRelayEnabled = false
   WebSocketImpl = globalThis.WebSocket
@@ -377,6 +428,12 @@ function handleControlPlaneMessage(
     return
   }
   if (controlType === "context_registered") {
+    // Adopt the daemon's answer about ITS host. Absent (older daemon) leaves the
+    // entrypoint default in place; an entrypoint that hard-disabled the lane
+    // (the Gecko build) stays disabled — a browser with no OS-input API cannot
+    // use one just because the host has it.
+    const reported = (msg as { osInput?: unknown }).osInput
+    if (typeof reported === "boolean") rememberOsInputAvailability(reported)
     if (transport === "websocket") {
       markWsRegistered()
     } else {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -238,6 +238,86 @@ fs.writeFileSync("extension/dist-safari/manifest.json", JSON.stringify(manifest,
   chmod -R u+rwX,go+rX extension/dist-safari/icons 2>/dev/null || true
 }
 
+build_extension_firefox() {
+  # Firefox / Gecko WebExtension (MV3). Third retarget of the same src tree:
+  # event-page background (background-firefox), content/inject scripts reused
+  # verbatim from dist, and a Gecko-shaped manifest.
+  #
+  # Four things differ from the Chromium manifest and each one is load-bearing:
+  #   * background.scripts, not background.service_worker — Gecko implements MV3
+  #     with event pages; a service_worker key makes the extension fail to load.
+  #   * browser_specific_settings.gecko.id — required, and it is the value the
+  #     native-messaging manifest lists under allowed_extensions (Chromium keys
+  #     that on chrome-extension:// origins instead), so the two must agree.
+  #   * no "key" — that is Chromium's deterministic-id mechanism; Gecko derives
+  #     identity from the gecko.id above and warns on the unknown key.
+  #   * a reduced permission set — see FIREFOX_DROPPED below.
+  echo "Building Firefox WebExtension (MV3)..."
+  rm -rf extension/dist-firefox
+  mkdir -p extension/dist-firefox
+  bun build extension/src/background-firefox.ts --outfile=extension/dist-firefox/background-firefox.js --target=browser
+  cp extension/dist/content.js extension/dist-firefox/content.js
+  cp extension/dist/net-buffer-content.js extension/dist-firefox/net-buffer-content.js
+  cp extension/dist/inject-net.js extension/dist-firefox/inject-net.js
+  cp extension/dist/inject-canvas.js extension/dist-firefox/inject-canvas.js
+  cp extension/dist/popup.js extension/dist-firefox/popup.js
+  cp extension/popup.html extension/dist-firefox/popup.html
+  rm -rf extension/dist-firefox/icons
+  cp -R extension/icons extension/dist-firefox/icons
+  bun -e '
+const fs = require("fs");
+const base = JSON.parse(fs.readFileSync("extension/manifest.json", "utf8"));
+// Permissions Gecko has no implementation for. Listing one is not fatal (Firefox
+// warns and ignores it) but it would misrepresent the surface to anyone reading
+// the manifest, and the matching verbs fail at the API call either way.
+const FIREFOX_DROPPED = new Set([
+  "tabGroups",     // no browser.tabGroups; tab-group listeners degrade to ungrouped
+  "debugger",      // no CDP lane in Gecko
+  "power",         // no browser.power; keepawake has no backend
+  "offscreen",     // no offscreen documents -> tesseract OCR cannot run
+  "tabCapture",    // no browser.tabCapture
+  "pageCapture",   // no browser.pageCapture
+  "userScripts",   // Gecko userScripts is a different, MV2-shaped API
+  "search",        // browser.search exists but with an incompatible shape
+]);
+const manifest = {
+  manifest_version: 3,
+  name: "Interceptor",
+  version: base.version,
+  description: base.description,
+  icons: base.icons,
+  // Gecko requires an explicit add-on id for native messaging. Keep it in
+  // lockstep with allowed_extensions in daemon/com.interceptor.host.firefox.json.
+  // strict_min_version 129: content_scripts world:"MAIN" landed in 128 and
+  // match_origin_as_fallback in 129, and both are used below.
+  browser_specific_settings: {
+    gecko: { id: "interceptor@hackervalley.media", strict_min_version: "129.0" }
+  },
+  permissions: base.permissions.filter((p) => !FIREFOX_DROPPED.has(p)),
+  host_permissions: base.host_permissions,
+  commands: base.commands,
+  // Event page. The bundle is self-contained (bun inlines every import), so no
+  // type:module — Gecko accepts it but it buys nothing here.
+  background: { scripts: ["background-firefox.js"] },
+  content_security_policy: base.content_security_policy,
+  action: {
+    default_title: "Interceptor",
+    default_popup: "popup.html",
+    default_icon: base.action && base.action.default_icon ? base.action.default_icon : base.icons
+  },
+  content_scripts: [
+    { matches: ["<all_urls>"], js: ["net-buffer-content.js"], run_at: "document_start", all_frames: true, match_origin_as_fallback: true },
+    { matches: ["<all_urls>"], js: ["inject-net.js"], run_at: "document_start", world: "MAIN", all_frames: true, match_origin_as_fallback: true },
+    { matches: ["<all_urls>"], js: ["inject-canvas.js"], run_at: "document_start", world: "MAIN", all_frames: true, match_origin_as_fallback: true },
+    { matches: ["<all_urls>"], js: ["content.js"], run_at: "document_idle", all_frames: true, match_origin_as_fallback: true }
+  ]
+};
+fs.writeFileSync("extension/dist-firefox/manifest.json", JSON.stringify(manifest, null, 2) + "\n");
+'
+  chmod 644 extension/dist-firefox/* 2>/dev/null || true
+  chmod -R u+rwX,go+rX extension/dist-firefox/icons 2>/dev/null || true
+}
+
 build_host() {
   echo "Building CLI (host)..."
   bun build cli/index.ts --compile --outfile=dist/interceptor
@@ -341,6 +421,77 @@ build_windows_arch() {
   cp -R extension/dist "$stage/extension"
 }
 
+build_linux_arch() {
+  local arch="$1"
+  local bun_target stage
+
+  # x64 uses the -baseline target on purpose. The non-baseline bun-linux-x64
+  # build requires AVX2, which is absent under x86-64 emulation (Rosetta /
+  # qemu-user, i.e. every amd64 container on an Apple-Silicon host) and on
+  # pre-Haswell hardware; the binary SIGILLs on first instruction with no
+  # diagnostic. Same rationale as bun-windows-x64-baseline above.
+  #
+  # The -musl variants target Alpine and other musl distros. A glibc-linked
+  # binary does not run there at all (the loader path itself differs), so this
+  # is a separate artifact, not a compatibility flag.
+  case "$arch" in
+    x64)         bun_target="bun-linux-x64-baseline" ;;
+    arm64)       bun_target="bun-linux-arm64" ;;
+    x64-musl)    bun_target="bun-linux-x64-musl-baseline" ;;
+    arm64-musl)  bun_target="bun-linux-arm64-musl" ;;
+    *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
+  esac
+
+  stage="dist/linux/$arch"
+  rm -rf "$stage"
+  mkdir -p "$stage/daemon" "$stage/scripts"
+
+  echo "Building CLI (Linux $arch, $bun_target)..."
+  bun build cli/index.ts --compile --target="$bun_target" --outfile="$stage/interceptor"
+  echo "Building daemon (Linux $arch, $bun_target)..."
+  bun build daemon/index.ts --compile --target="$bun_target" --outfile="$stage/daemon/interceptor-daemon"
+
+  # Native-messaging manifest template. Unlike Windows (registry + a fixed
+  # relative path) Linux hosts read an absolute `path` out of the JSON, so the
+  # template ships with the __DAEMON_PATH__ placeholder and scripts/install.sh
+  # resolves it against wherever the package was extracted.
+  cp daemon/com.interceptor.host.json "$stage/daemon/com.interceptor.host.json"
+  cp daemon/com.interceptor.host.firefox.json "$stage/daemon/com.interceptor.host.firefox.json"
+
+  # Layout below is exactly what scripts/install.sh expects to find relative to
+  # its own parent dir, so the staged tree is directly installable after
+  # extraction: `bash scripts/install.sh --browser-only --chrome`.
+  if [[ ! -f extension/dist/manifest.json ]]; then
+    echo "extension/dist is missing — build_extension must run before build_linux_arch" >&2
+    exit 1
+  fi
+  rm -rf "$stage/extension"
+  mkdir -p "$stage/extension"
+  cp -R extension/dist "$stage/extension/dist"
+  # Gecko retarget ships alongside the Chromium one; scripts/install.sh picks
+  # the directory that matches the chosen browser.
+  if [[ ! -f extension/dist-firefox/manifest.json ]]; then
+    echo "extension/dist-firefox is missing — build_extension_firefox must run before build_linux_arch" >&2
+    exit 1
+  fi
+  cp -R extension/dist-firefox "$stage/extension/dist-firefox"
+
+  cp scripts/install.sh scripts/uninstall.sh "$stage/scripts/"
+
+  # Skill packs next to the CLI binary — resolvePackDir() in cli/commands/skills.ts
+  # looks for <dir of argv0>/skills, so `interceptor skills adopt` works from the
+  # extracted package without a repo checkout. Mirrors the Windows {app}\skills
+  # staging in scripts/installer/interceptor.iss.
+  rm -rf "$stage/skills"
+  mkdir -p "$stage/skills"
+  for pack in interceptor interceptor-browser interceptor-research; do
+    cp -R ".agents/skills/$pack" "$stage/skills/$pack"
+  done
+  find "$stage/skills" -name '._*' -delete 2>/dev/null || true
+
+  chmod 755 "$stage/interceptor" "$stage/daemon/interceptor-daemon"
+}
+
 build_bridge() {
   # Swift-only, macOS-only. Warn-and-continue on CI/linux hosts.
   if ! command -v swift >/dev/null 2>&1; then
@@ -369,21 +520,28 @@ if [[ "$BUILD_ALL" == "1" ]]; then
   build_extension
   build_extension_mv2
   build_extension_safari
+  build_extension_firefox
   build_host
   build_macos
   build_windows_arch x64
   build_windows_arch arm64
+  build_linux_arch x64
+  build_linux_arch arm64
+  build_linux_arch x64-musl
+  build_linux_arch arm64-musl
   build_bridge
 elif [[ "$TARGET" == "host" ]]; then
   build_extension
   build_extension_mv2
   build_extension_safari
+  build_extension_firefox
   build_host
   build_bridge
 elif [[ "$TARGET" == "macos" ]]; then
   build_extension
   build_extension_mv2
   build_extension_safari
+  build_extension_firefox
   build_macos
   build_bridge
 elif [[ "$TARGET" == "windows-x64" ]]; then
@@ -394,6 +552,25 @@ elif [[ "$TARGET" == "windows-arm64" ]]; then
   build_windows_arch arm64
 elif [[ "$TARGET" == "windows" ]]; then
   echo "Unsupported target: windows. Use --target=windows-x64 or --target=windows-arm64." >&2
+  exit 1
+elif [[ "$TARGET" == "linux-x64" ]]; then
+  build_extension
+  build_extension_firefox
+  build_linux_arch x64
+elif [[ "$TARGET" == "linux-arm64" ]]; then
+  build_extension
+  build_extension_firefox
+  build_linux_arch arm64
+elif [[ "$TARGET" == "linux-x64-musl" ]]; then
+  build_extension
+  build_extension_firefox
+  build_linux_arch x64-musl
+elif [[ "$TARGET" == "linux-arm64-musl" ]]; then
+  build_extension
+  build_extension_firefox
+  build_linux_arch arm64-musl
+elif [[ "$TARGET" == "linux" ]]; then
+  echo "Unsupported target: linux. Use --target=linux-x64, linux-arm64, linux-x64-musl, or linux-arm64-musl." >&2
   exit 1
 else
   echo "Unsupported target: $TARGET" >&2
@@ -407,7 +584,10 @@ fi
 # No --entitlements here: entitlement enforcement only applies under the
 # hardened runtime, which ad-hoc signing doesn't enable. Release builds are
 # re-signed (--force) with the real identity + entitlements by release.sh.
-if [[ "$(uname -s)" == "Darwin" && "$TARGET" != windows-* ]] && command -v codesign >/dev/null 2>&1; then
+# Cross-target stages (windows-*, linux-*) produce PE/ELF images that codesign
+# cannot sign and that this host cannot execute — signing or smoke-running them
+# here would fail the build on a correct artifact.
+if [[ "$(uname -s)" == "Darwin" && "$TARGET" != windows-* && "$TARGET" != linux-* ]] && command -v codesign >/dev/null 2>&1; then
   for b in dist/interceptor daemon/interceptor-daemon dist/interceptor-bridge; do
     if [[ -f "$b" ]]; then
       codesign --remove-signature "$b" 2>/dev/null || true
@@ -428,6 +608,7 @@ if [[ "$BUILD_ALL" == "1" ]]; then
   echo "  Extension: extension/dist/"
   echo "  Electron extension: extension/dist-mv2/"
   echo "  Safari extension: extension/dist-safari/"
+  echo "  Firefox extension: extension/dist-firefox/"
   echo "  Host CLI:   dist/interceptor"
   echo "  Host Daemon: daemon/interceptor-daemon"
   echo "  macOS CLI:  dist/interceptor"
@@ -435,14 +616,27 @@ if [[ "$BUILD_ALL" == "1" ]]; then
   echo "  macOS Bridge: dist/interceptor-bridge"
   echo "  Windows x64: dist/windows/x64/"
   echo "  Windows ARM64: dist/windows/arm64/"
+  echo "  Linux x64: dist/linux/x64/"
+  echo "  Linux ARM64: dist/linux/arm64/"
+  echo "  Linux x64 (musl): dist/linux/x64-musl/"
+  echo "  Linux ARM64 (musl): dist/linux/arm64-musl/"
 elif [[ "$TARGET" == "windows-x64" ]]; then
   echo "  Windows x64: dist/windows/x64/"
 elif [[ "$TARGET" == "windows-arm64" ]]; then
   echo "  Windows ARM64: dist/windows/arm64/"
+elif [[ "$TARGET" == "linux-x64" ]]; then
+  echo "  Linux x64: dist/linux/x64/"
+elif [[ "$TARGET" == "linux-arm64" ]]; then
+  echo "  Linux ARM64: dist/linux/arm64/"
+elif [[ "$TARGET" == "linux-x64-musl" ]]; then
+  echo "  Linux x64 (musl): dist/linux/x64-musl/"
+elif [[ "$TARGET" == "linux-arm64-musl" ]]; then
+  echo "  Linux ARM64 (musl): dist/linux/arm64-musl/"
 else
   echo "  Extension: extension/dist/"
   echo "  Electron extension: extension/dist-mv2/"
   echo "  Safari extension: extension/dist-safari/"
+  echo "  Firefox extension: extension/dist-firefox/"
   echo "  CLI:       dist/interceptor"
   echo "  Daemon:    daemon/interceptor-daemon"
   if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,9 +4,25 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DAEMON_PATH="$ROOT/daemon/interceptor-daemon"
 TEMPLATE_PATH="$ROOT/daemon/com.interceptor.host.json"
-GENERATED_DIR="$ROOT/daemon/.generated"
+# Where the resolved native-messaging manifest is written. A dev checkout keeps
+# it next to the daemon; a system-wide install (deb/rpm under /opt) cannot —
+# the prefix is root-owned and the manifest is per-user state anyway, since it
+# is what the per-user NativeMessagingHosts symlink points at. Fall back to the
+# XDG state home, the same root shared/monitor-tasks.ts already uses on Linux.
+if [[ -w "$ROOT/daemon" ]] || [[ ! -e "$ROOT/daemon" && -w "$ROOT" ]]; then
+  GENERATED_DIR="$ROOT/daemon/.generated"
+else
+  GENERATED_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/interceptor"
+fi
 GENERATED_MANIFEST="$GENERATED_DIR/com.interceptor.host.json"
 EXTENSION_DIR="$ROOT/extension/dist"
+# Gecko variants. Firefox keys native-messaging access on the add-on id
+# (allowed_extensions) rather than a chrome-extension:// origin, so it needs its
+# own manifest template — and its own extension build, since Gecko MV3 uses an
+# event page instead of a service worker. Both are selected in one place below.
+GECKO_TEMPLATE_PATH="$ROOT/daemon/com.interceptor.host.firefox.json"
+GECKO_GENERATED_MANIFEST="$GENERATED_DIR/com.interceptor.host.firefox.json"
+GECKO_EXTENSION_DIR="$ROOT/extension/dist-firefox"
 INSTALL_BRIDGE_SCRIPT="$ROOT/scripts/install-bridge.sh"
 
 # ── Platform detection ────────────────────────────────────────────────────────
@@ -36,6 +52,12 @@ profile_root_for() {
     Darwin:vivaldi)            echo "$HOME/Library/Application Support/Vivaldi" ;;
     Linux:brave)               echo "$HOME/.config/BraveSoftware/Brave-Browser" ;;
     Linux:chrome)              echo "$HOME/.config/google-chrome" ;;
+    Linux:chromium)            echo "$HOME/.config/chromium" ;;
+    # Firefox has no Chromium "User Data" dir. Profiles live under
+    # ~/.mozilla/firefox/<salt>.<name> and are indexed by profiles.ini, so the
+    # Chromium-shaped --profile / --profiles handling does not apply; the
+    # callers below special-case it.
+    Linux:firefox)             echo "$HOME/.mozilla/firefox" ;;
     *) return 1 ;;
   esac
 }
@@ -58,6 +80,10 @@ nm_dir_for() {
     Darwin:vivaldi)            echo "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts" ;;
     Linux:brave)               echo "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
     Linux:chrome)              echo "$HOME/.config/google-chrome/NativeMessagingHosts" ;;
+    Linux:chromium)            echo "$HOME/.config/chromium/NativeMessagingHosts" ;;
+    # Gecko keeps native-messaging hosts in one per-user dir for every Firefox
+    # profile, outside the profile tree entirely.
+    Linux:firefox)             echo "$HOME/.mozilla/native-messaging-hosts" ;;
     *) return 1 ;;
   esac
 }
@@ -77,6 +103,10 @@ browser_installed() {
                   || command -v brave >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
     Linux:chrome)   ( command -v google-chrome >/dev/null 2>&1 \
                   || command -v google-chrome-stable >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
+    Linux:chromium) ( command -v chromium >/dev/null 2>&1 \
+                  || command -v chromium-browser >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
+    Linux:firefox)  ( command -v firefox >/dev/null 2>&1 \
+                  || command -v firefox-esr >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
     *) echo 0 ;;
   esac
 }
@@ -103,6 +133,16 @@ browser_bin_for() {
     Linux:chrome)
       if command -v google-chrome >/dev/null 2>&1; then echo google-chrome
       elif command -v google-chrome-stable >/dev/null 2>&1; then echo google-chrome-stable
+      else return 1; fi
+      ;;
+    Linux:chromium)
+      if command -v chromium >/dev/null 2>&1; then echo chromium
+      elif command -v chromium-browser >/dev/null 2>&1; then echo chromium-browser
+      else return 1; fi
+      ;;
+    Linux:firefox)
+      if command -v firefox >/dev/null 2>&1; then echo firefox
+      elif command -v firefox-esr >/dev/null 2>&1; then echo firefox-esr
       else return 1; fi
       ;;
     *) return 1 ;;
@@ -134,6 +174,10 @@ kill_browser() {
 
 # ── Parse flags ────────────────────────────────────────────────────────────────
 SKIP_EXTENSION=0
+# Linux tarball installs have no packaging step to put the CLI on PATH, so the
+# installer links it itself (off on macOS/Windows, where the pkg/Setup owns it).
+LINK_CLI=1
+LINK_CLI_DIR=""
 BROWSER=""
 PROFILE=""
 LIST_PROFILES=0
@@ -152,6 +196,14 @@ while [[ $i -le $# ]]; do
     --chrome-for-testing) BROWSER="chrome-for-testing" ;;
     --edge)               BROWSER="edge" ;;
     --vivaldi)            BROWSER="vivaldi" ;;
+    --chromium)           BROWSER="chromium" ;;
+    --firefox)            BROWSER="firefox" ;;
+    --no-link-cli)        LINK_CLI=0 ;;
+    --link-cli-dir)
+      i=$((i + 1))
+      LINK_CLI_DIR="${!i}"
+      ;;
+    --link-cli-dir=*)     LINK_CLI_DIR="${arg#--link-cli-dir=}" ;;
     --profile)
       i=$((i + 1))
       PROFILE="${!i}"
@@ -190,11 +242,15 @@ while [[ $i -le $# ]]; do
        echo "  --chrome-for-testing   Target Google Chrome for Testing (macOS only in this revision)"
        echo "  --edge                 Target Microsoft Edge (macOS only in this revision)"
        echo "  --vivaldi              Target Vivaldi (macOS only in this revision)"
+       echo "  --chromium             Target Chromium (Linux only in this revision)"
+       echo "  --firefox              Target Firefox (Linux only in this revision; Gecko build)"
        echo "  --profile <name>       Profile directory name (e.g. \"Default\", \"Profile 2\")"
        echo "  --profiles             List available profiles and exit"
        echo ""
        echo "Options:"
        echo "  --skip-extension  Only install native messaging (skip extension load)"
+       echo "  --no-link-cli     Do not symlink the interceptor CLI onto PATH (Linux)"
+       echo "  --link-cli-dir D  Symlink the CLI into D instead of ~/.local/bin (Linux)"
        echo "  --dry-run         Print steps without executing them"
        exit 1 ;;
   esac
@@ -212,7 +268,16 @@ if [[ "$LIST_PROFILES" == "1" ]]; then
     elif [[ "$(browser_installed chrome-for-testing)" == "1" ]]; then BROWSER="chrome-for-testing"
     elif [[ "$(browser_installed edge)"               == "1" ]]; then BROWSER="edge"
     elif [[ "$(browser_installed vivaldi)"            == "1" ]]; then BROWSER="vivaldi"
+    elif [[ "$(browser_installed chromium)"           == "1" ]]; then BROWSER="chromium"
     fi
+  fi
+  if [[ "$BROWSER" == "firefox" ]]; then
+    echo "Firefox does not use Chromium's profile-directory layout."
+    echo "Its profiles are indexed by $HOME/.mozilla/firefox/profiles.ini and are"
+    echo "selected with 'firefox -P'. Interceptor's native-messaging host is"
+    echo "registered once per user ($HOME/.mozilla/native-messaging-hosts) and"
+    echo "applies to every profile, so --profile is not needed."
+    exit 0
   fi
   PROFILE_ROOT="$(profile_root_for "$BROWSER" || true)"
   if [[ -z "$PROFILE_ROOT" ]]; then echo "No supported browser found."; exit 1; fi
@@ -300,13 +365,17 @@ if [[ -z "$BROWSER" ]]; then
   BRAVE_INSTALLED=$(browser_installed brave)
   EDGE_INSTALLED=$(browser_installed edge)
   VIVALDI_INSTALLED=$(browser_installed vivaldi)
+  CHROMIUM_INSTALLED=$(browser_installed chromium)
+  FIREFOX_INSTALLED=$(browser_installed firefox)
   TOTAL_INSTALLED=$(( CHROME_INSTALLED + CHROME_BETA_INSTALLED + CHROME_CANARY_INSTALLED \
                     + CHROME_DEV_INSTALLED + CHROME_FOR_TESTING_INSTALLED \
-                    + BRAVE_INSTALLED + EDGE_INSTALLED + VIVALDI_INSTALLED ))
+                    + BRAVE_INSTALLED + EDGE_INSTALLED + VIVALDI_INSTALLED \
+                    + CHROMIUM_INSTALLED + FIREFOX_INSTALLED ))
 
   if (( TOTAL_INSTALLED == 0 )); then
     echo "ERROR: No supported browser found." >&2
-    echo "       Install Chrome (stable/Beta/Canary/Dev/for-Testing), Brave, Edge, or Vivaldi, then re-run." >&2
+    echo "       Install Chrome (stable/Beta/Canary/Dev/for-Testing), Brave, Edge, Vivaldi," >&2
+    echo "       Chromium, or Firefox, then re-run." >&2
     exit 1
   fi
 
@@ -320,7 +389,9 @@ if [[ -z "$BROWSER" ]]; then
   elif [[ "$CHROME_FOR_TESTING_INSTALLED" == "1" ]]; then DEFAULT_BROWSER="chrome-for-testing"
   elif [[ "$BRAVE_INSTALLED"              == "1" ]]; then DEFAULT_BROWSER="brave"
   elif [[ "$EDGE_INSTALLED"               == "1" ]]; then DEFAULT_BROWSER="edge"
-  else                                                    DEFAULT_BROWSER="vivaldi"
+  elif [[ "$VIVALDI_INSTALLED"            == "1" ]]; then DEFAULT_BROWSER="vivaldi"
+  elif [[ "$CHROMIUM_INSTALLED"           == "1" ]]; then DEFAULT_BROWSER="chromium"
+  else                                                    DEFAULT_BROWSER="firefox"
   fi
 
   if (( TOTAL_INSTALLED == 1 )); then
@@ -340,12 +411,14 @@ if [[ -z "$BROWSER" ]]; then
     [[ "$BRAVE_INSTALLED"              == "1" ]] && echo "  brave               Brave Browser"
     [[ "$EDGE_INSTALLED"               == "1" ]] && echo "  edge                Microsoft Edge"
     [[ "$VIVALDI_INSTALLED"            == "1" ]] && echo "  vivaldi             Vivaldi"
+    [[ "$CHROMIUM_INSTALLED"           == "1" ]] && echo "  chromium            Chromium"
+    [[ "$FIREFOX_INSTALLED"            == "1" ]] && echo "  firefox             Firefox (Gecko build)"
     [[ "$CHROME_INSTALLED" == "1" && "$BRAVE_INSTALLED" == "1" ]] && echo "  both                Chrome (stable) and Brave"
     echo ""
     read -r -p "Browser (default: $DEFAULT_BROWSER): " ANSWER
     ANSWER="${ANSWER:-$DEFAULT_BROWSER}"
     case "$ANSWER" in
-      chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi|both) BROWSER="$ANSWER" ;;
+      chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi|chromium|firefox|both) BROWSER="$ANSWER" ;;
       *)
         echo "Unrecognized browser '$ANSWER'." >&2
         exit 1 ;;
@@ -354,6 +427,17 @@ if [[ -z "$BROWSER" ]]; then
 fi
 
 echo "==> Browser: $BROWSER"
+
+# Firefox is the one non-Chromium target: different native-host manifest shape,
+# different extension build, no --load-extension, no Chromium profile layout.
+# Resolve all of that here so the steps below stay single-branch.
+IS_GECKO=0
+if [[ "$BROWSER" == "firefox" ]]; then
+  IS_GECKO=1
+  TEMPLATE_PATH="$GECKO_TEMPLATE_PATH"
+  GENERATED_MANIFEST="$GECKO_GENERATED_MANIFEST"
+  EXTENSION_DIR="$GECKO_EXTENSION_DIR"
+fi
 
 # Helper that runs a step or prints it under --dry-run.
 run_step() {
@@ -395,6 +479,8 @@ case "$BROWSER" in
   brave)              NM_DIRS+=("$(nm_dir_for brave)") ;;
   edge)               NM_DIRS+=("$(nm_dir_for edge)") ;;
   vivaldi)            NM_DIRS+=("$(nm_dir_for vivaldi)") ;;
+  chromium)           NM_DIRS+=("$(nm_dir_for chromium)") ;;
+  firefox)            NM_DIRS+=("$(nm_dir_for firefox)") ;;
   both)
     NM_DIRS+=("$(nm_dir_for chrome)")
     NM_DIRS+=("$(nm_dir_for brave)")
@@ -420,6 +506,8 @@ for dir in "${NM_DIRS[@]}"; do
       *Brave-Browser*|*BraveSoftware*)   echo "    Brave:              $dir/com.interceptor.host.json" ;;
       *Microsoft\ Edge*)                 echo "    Edge:               $dir/com.interceptor.host.json" ;;
       *Vivaldi*)                         echo "    Vivaldi:            $dir/com.interceptor.host.json" ;;
+      *native-messaging-hosts*)          echo "    Firefox:            $dir/com.interceptor.host.json" ;;
+      *chromium*|*Chromium*)             echo "    Chromium:           $dir/com.interceptor.host.json" ;;
     esac
   fi
 done
@@ -467,10 +555,24 @@ os.replace(tmp, path)
 PY
 }
 
+# Locate the interceptor CLI for the post-launch probe. Two layouts ship this
+# script: a repo checkout (binary under $ROOT/dist/) and an extracted release
+# package (binary at $ROOT, with daemon/, extension/, skills/ beside it — the
+# layout `interceptor skills adopt` resolves packs from). Fall back to $PATH for
+# an already-installed CLI. Echoes nothing when none is found.
+resolve_interceptor_bin() {
+  local candidate
+  for candidate in "$ROOT/dist/interceptor" "$ROOT/interceptor"; do
+    if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+  done
+  if command -v interceptor >/dev/null 2>&1; then command -v interceptor; return 0; fi
+  return 1
+}
+
 # Probe whether the just-launched extension is reachable. Returns 0 if yes.
 probe_extension_reachable() {
-  local interceptor_bin="$ROOT/dist/interceptor"
-  [[ -x "$interceptor_bin" ]] || return 0  # nothing to probe with; skip silently
+  local interceptor_bin
+  interceptor_bin="$(resolve_interceptor_bin)" || return 0  # nothing to probe with; skip silently
   # status --verbose ends with a per-component breakdown including "extension:"
   "$interceptor_bin" status --verbose 2>/dev/null | grep -qE "^extension:[[:space:]]+reachable"
 }
@@ -501,10 +603,40 @@ load_extension() {
     chrome-for-testing) BROWSER_NAME="Chrome for Testing" ;;
     edge)               BROWSER_NAME="Edge" ;;
     vivaldi)            BROWSER_NAME="Vivaldi" ;;
+    chromium)           BROWSER_NAME="Chromium" ;;
+    firefox)            BROWSER_NAME="Firefox" ;;
     *)
       echo "ERROR: load_extension called with unknown browser '$target'." >&2
       return 1 ;;
   esac
+
+  # ── Gecko ───────────────────────────────────────────────────────────────────
+  # Firefox has no --load-extension switch and no Chromium developer-mode flag,
+  # so none of the Chromium preflight below applies. An unsigned MV3 add-on can
+  # be loaded two ways: temporarily via about:debugging (survives until the
+  # browser quits, works on release Firefox), or permanently from a signed XPI.
+  # Print the path and stop — silently launching Firefox would do nothing.
+  if [[ "$target" == "firefox" ]]; then
+    echo ""
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "==> [browser] DRY: would print Firefox load instructions for $EXTENSION_DIR"
+      return 0
+    fi
+    echo "==> Firefox loads unpacked add-ons through about:debugging, not a command-line switch."
+    echo "    Native messaging metadata has already been installed."
+    echo ""
+    echo "    Load it (per browser session):"
+    echo "      1. Open about:debugging#/runtime/this-firefox"
+    echo "      2. Click 'Load Temporary Add-on…'"
+    echo "      3. Select $EXTENSION_DIR/manifest.json"
+    echo ""
+    echo "    Grant host access (Firefox MV3 treats host permissions as optional):"
+    echo "      about:addons -> Interceptor -> Permissions -> 'Access your data for all websites'"
+    echo ""
+    echo "    Verify with: interceptor status --verbose   (expect 'extension: reachable')"
+    echo "    A signed XPI installs permanently; temporary add-ons are dropped on quit."
+    return 0
+  fi
   if [[ "$PLATFORM" == "Darwin" ]]; then
     case "$target" in
       brave)
@@ -544,8 +676,16 @@ load_extension() {
     BROWSER_APP=""
     BROWSER_BIN="$(browser_bin_for "$target" || true)"
     if [[ -z "$BROWSER_BIN" ]]; then
-      echo "ERROR: $BROWSER_NAME binary not found in PATH on this platform." >&2
-      return 1
+      # A dry run reports the steps it *would* take; it must not depend on the
+      # browser actually being installed. The Darwin branch above never probes
+      # the filesystem either (it just names the .app), so failing here would
+      # make --dry-run behave differently on Linux than on macOS for no reason.
+      if [[ "$DRY_RUN" == "1" ]]; then
+        BROWSER_BIN="$target"
+      else
+        echo "ERROR: $BROWSER_NAME binary not found in PATH on this platform." >&2
+        return 1
+      fi
     fi
   fi
 
@@ -739,8 +879,68 @@ load_extension() {
   fi
 }
 
+# ── Step 3b: put the CLI on PATH (Linux) ──────────────────────────────────────
+# macOS installs come from a pkg that writes /usr/local/bin, and Windows Setup
+# edits PATH; a Linux tarball has neither, so without this the CLI only works by
+# absolute path. Symlink, never copy: an upgrade replaces the target in place.
+link_cli_onto_path() {
+  [[ "$PLATFORM" == "Linux" ]] || return 0
+  [[ "$LINK_CLI" == "1" ]] || return 0
+
+  local cli_bin link_dir link_path
+  cli_bin="$(resolve_interceptor_bin || true)"
+  if [[ -z "$cli_bin" ]]; then
+    echo "==> [cli] Skipping PATH link — no interceptor binary found next to this script."
+    return 0
+  fi
+  # An `interceptor` already on PATH that resolves to this same binary is the
+  # steady state after the first install; re-linking it would be noise.
+  if command -v interceptor >/dev/null 2>&1; then
+    local existing
+    existing="$(command -v interceptor)"
+    if [[ "$(readlink -f "$existing" 2>/dev/null || echo "$existing")" == "$(readlink -f "$cli_bin" 2>/dev/null || echo "$cli_bin")" ]]; then
+      echo "==> [cli] Already on PATH: $existing"
+      return 0
+    fi
+  fi
+
+  link_dir="${LINK_CLI_DIR:-$HOME/.local/bin}"
+  link_path="$link_dir/interceptor"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "==> [cli] DRY: mkdir -p $link_dir"
+    echo "==> [cli] DRY: ln -sfn $cli_bin $link_path"
+    return 0
+  fi
+
+  # Refuse to clobber a real file: a symlink is ours to replace, anything else
+  # belongs to the user or another package manager.
+  if [[ -e "$link_path" && ! -L "$link_path" ]]; then
+    echo "==> [cli] NOT linking — $link_path exists and is not a symlink."
+    echo "    Remove it or pass --link-cli-dir <dir> to place the link elsewhere."
+    return 0
+  fi
+
+  mkdir -p "$link_dir"
+  ln -sfn "$cli_bin" "$link_path"
+  # Record where the link went so uninstall removes exactly this one. Without
+  # the record, uninstall can only guess at the conventional dirs and would
+  # leave a --link-cli-dir link behind.
+  mkdir -p "$GENERATED_DIR"
+  printf '%s\n' "$link_path" > "$GENERATED_DIR/cli-link"
+  echo "==> [cli] Linked: $link_path -> $cli_bin"
+  case ":$PATH:" in
+    *":$link_dir:"*) ;;
+    *)
+      echo "    NOTE: $link_dir is not on your PATH. Add it, e.g.:"
+      echo "      echo 'export PATH=\"$link_dir:\$PATH\"' >> ~/.bashrc && exec \$SHELL" ;;
+  esac
+}
+
+link_cli_onto_path
+
 case "$BROWSER" in
-  chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi)
+  chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi|chromium|firefox)
     load_extension "$BROWSER" ;;
   both)
     load_extension chrome
@@ -755,8 +955,12 @@ if [[ "$MODE" == "browser-only" ]]; then
   echo "==> Done. Installed in browser-only mode."
   echo "    No macOS bridge installed; no LaunchAgent written."
   echo "    Test:    interceptor status   (expect 'mode: browser-only')"
-  echo ""
-  echo "    To upgrade later:    interceptor upgrade --full"
+  # `upgrade --full` installs the Swift bridge and hard-errors off macOS, so
+  # only advertise it where it can actually run.
+  if [[ "$PLATFORM" == "Darwin" ]]; then
+    echo ""
+    echo "    To upgrade later:    interceptor upgrade --full"
+  fi
   exit 0
 fi
 

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Package a staged Linux build (dist/linux/<arch>/) for distribution.
+#
+#   bash scripts/package-linux.sh --arch x64                  # tar.gz + deb + rpm
+#   bash scripts/package-linux.sh --arch x64 --format tar.gz  # just the tarball
+#   bash scripts/package-linux.sh --arch x64-musl             # tar.gz only (musl)
+#
+# Run scripts/build.sh --target=linux-<arch> first; this script never builds.
+#
+# Install prefix is /opt/interceptor with /usr/bin/interceptor pointing at it.
+# The system package deliberately stops there: registering a native-messaging
+# host writes into ~/.config or ~/.mozilla, which is per-user state a root
+# package install must not create for one arbitrary user. Each user finishes
+# with `interceptor-install` (or scripts/install.sh directly).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ARCH=""
+FORMATS=""
+OUT_DIR="dist/linux/packages"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)     ARCH="$2"; shift 2 ;;
+    --arch=*)   ARCH="${1#--arch=}"; shift ;;
+    --format)   FORMATS="$2"; shift 2 ;;
+    --format=*) FORMATS="${1#--format=}"; shift ;;
+    --out)      OUT_DIR="$2"; shift 2 ;;
+    --out=*)    OUT_DIR="${1#--out=}"; shift ;;
+    -h|--help)
+      echo "Usage: bash scripts/package-linux.sh --arch <x64|arm64|x64-musl|arm64-musl> [--format tar.gz,deb,rpm] [--out DIR]"
+      exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ARCH" ]]; then
+  echo "ERROR: --arch is required (x64 | arm64 | x64-musl | arm64-musl)." >&2
+  exit 1
+fi
+
+STAGE="dist/linux/$ARCH"
+if [[ ! -x "$STAGE/interceptor" ]]; then
+  echo "ERROR: $STAGE/interceptor not found." >&2
+  echo "       Run: bash scripts/build.sh --target=linux-$ARCH" >&2
+  exit 1
+fi
+
+VERSION="$(grep '"version"' package.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+
+# Architecture naming differs per packaging system; keep the three vocabularies
+# explicit rather than string-munging them at each use.
+case "$ARCH" in
+  x64)        DEB_ARCH="amd64"; RPM_ARCH="x86_64";  LIBC="glibc" ;;
+  arm64)      DEB_ARCH="arm64"; RPM_ARCH="aarch64"; LIBC="glibc" ;;
+  x64-musl)   DEB_ARCH="";      RPM_ARCH="";        LIBC="musl"  ;;
+  arm64-musl) DEB_ARCH="";      RPM_ARCH="";        LIBC="musl"  ;;
+  *) echo "ERROR: unsupported --arch '$ARCH'." >&2; exit 1 ;;
+esac
+
+# musl targets exist for Alpine, which uses apk, not dpkg or rpm. Producing a
+# .deb of a musl-linked binary would install cleanly on Debian and then fail to
+# execute, so those formats are refused rather than silently built.
+if [[ -z "$FORMATS" ]]; then
+  if [[ "$LIBC" == "musl" ]]; then FORMATS="tar.gz"; else FORMATS="tar.gz,deb,rpm"; fi
+fi
+
+mkdir -p "$OUT_DIR"
+BASENAME="interceptor-$VERSION-linux-$ARCH"
+
+# Common tree assembled once and reused by every format: prefix-relative paths
+# exactly as they land on the target system.
+PKGROOT="$(mktemp -d)"
+trap 'rm -rf "$PKGROOT"' EXIT
+mkdir -p "$PKGROOT/opt/interceptor" "$PKGROOT/usr/bin"
+cp -R "$STAGE"/. "$PKGROOT/opt/interceptor/"
+chmod 755 "$PKGROOT/opt/interceptor/interceptor" "$PKGROOT/opt/interceptor/daemon/interceptor-daemon"
+
+# One wrapper instead of a second copy of the installer: it forwards to the
+# packaged scripts/install.sh, which resolves everything relative to its own
+# parent dir.
+cat > "$PKGROOT/usr/bin/interceptor-install" <<'WRAPPER'
+#!/bin/sh
+# Register Interceptor's native-messaging host for the CURRENT user.
+exec bash /opt/interceptor/scripts/install.sh "$@"
+WRAPPER
+chmod 755 "$PKGROOT/usr/bin/interceptor-install"
+ln -sfn /opt/interceptor/interceptor "$PKGROOT/usr/bin/interceptor"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+build_tar() {
+  local out="$OUT_DIR/$BASENAME.tar.gz"
+  echo "==> tar.gz: $out"
+  # Ship the same prefix layout the packages use, under one top-level directory
+  # so `tar xzf` never scatters files into $PWD.
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/$BASENAME"
+  cp -R "$STAGE"/. "$tmp/$BASENAME/"
+  local musl_note=""
+  if [[ "$LIBC" == "musl" ]]; then
+    # Bun's musl builds link libstdc++/libgcc dynamically and bare Alpine ships
+    # neither, so the binary dies with "Error loading shared library
+    # libstdc++.so.6" before printing anything of its own.
+    musl_note="  0. Alpine only — install the C++ runtime Bun links against:
+       apk add libstdc++ libgcc
+"
+  fi
+  cat > "$tmp/$BASENAME/README-INSTALL.txt" <<EOF
+Interceptor $VERSION — Linux $ARCH ($LIBC)
+
+$musl_note  1. Move this directory somewhere stable, e.g.:
+       sudo mv $BASENAME /opt/interceptor
+  2. Put the CLI on PATH:
+       ln -sfn /opt/interceptor/interceptor ~/.local/bin/interceptor
+  3. Register the native-messaging host for your browser:
+       bash /opt/interceptor/scripts/install.sh --browser-only --chrome
+     (also: --brave, --chromium, --firefox)
+  4. Load the extension — see docs/linux-install.md.
+
+Uninstall: bash /opt/interceptor/scripts/uninstall.sh
+EOF
+  tar -czf "$out" -C "$tmp" "$BASENAME"
+  rm -rf "$tmp"
+}
+
+build_deb() {
+  if ! have dpkg-deb; then
+    echo "==> deb: SKIPPED (dpkg-deb not found)"
+    return 0
+  fi
+  local out="$OUT_DIR/${BASENAME}.deb" tmp
+  echo "==> deb: $out"
+  tmp="$(mktemp -d)"
+  cp -R "$PKGROOT"/. "$tmp/"
+  mkdir -p "$tmp/DEBIAN"
+  cat > "$tmp/DEBIAN/control" <<EOF
+Package: interceptor
+Version: $VERSION
+Section: web
+Priority: optional
+Architecture: $DEB_ARCH
+Maintainer: Hacker Valley Media <support@hackervalley.media>
+Recommends: google-chrome-stable | chromium | brave-browser | firefox
+Description: Drive a real signed-in browser from one CLI, built for AI agents
+ Interceptor runs as a WebExtension inside your existing Chrome, Chromium,
+ Brave, or Firefox session and exposes it through a single CLI: accessibility
+ trees, page text, clicks and typing, passive network capture, screenshots,
+ and record/replay. Browser-only on Linux; the macOS and iOS surfaces need a
+ macOS host.
+EOF
+  cat > "$tmp/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+echo "Interceptor installed to /opt/interceptor."
+echo "Finish setup for your user:  interceptor-install --browser-only --chrome"
+echo "  (also: --brave, --chromium, --firefox)"
+EOF
+  chmod 755 "$tmp/DEBIAN/postinst"
+  # dpkg-deb refuses a tree it cannot attribute; normalize before building.
+  find "$tmp" -type d -exec chmod 755 {} +
+  dpkg-deb --root-owner-group --build "$tmp" "$out" >/dev/null
+  rm -rf "$tmp"
+}
+
+build_rpm() {
+  if ! have rpmbuild; then
+    echo "==> rpm: SKIPPED (rpmbuild not found)"
+    return 0
+  fi
+  local out="$OUT_DIR/${BASENAME}.rpm" top
+  echo "==> rpm: $out"
+  top="$(mktemp -d)"
+  mkdir -p "$top/BUILD" "$top/RPMS" "$top/SPECS" "$top/BUILDROOT"
+  local buildroot="$top/BUILDROOT/interceptor-$VERSION"
+  mkdir -p "$buildroot"
+  cp -R "$PKGROOT"/. "$buildroot/"
+  cat > "$top/SPECS/interceptor.spec" <<EOF
+Name:           interceptor
+Version:        $VERSION
+Release:        1
+Summary:        Drive a real signed-in browser from one CLI, built for AI agents
+License:        Elastic-2.0
+URL:            https://github.com/Hacker-Valley-Media/Interceptor
+BuildArch:      $RPM_ARCH
+# The binaries are self-contained Bun builds; nothing is linked at package level.
+AutoReqProv:    no
+
+%description
+Interceptor runs as a WebExtension inside your existing Chrome, Chromium,
+Brave, or Firefox session and exposes it through a single CLI: accessibility
+trees, page text, clicks and typing, passive network capture, screenshots,
+and record/replay. Browser-only on Linux; the macOS and iOS surfaces need a
+macOS host.
+
+%files
+/opt/interceptor
+/usr/bin/interceptor
+/usr/bin/interceptor-install
+
+%post
+echo "Interceptor installed to /opt/interceptor."
+echo "Finish setup for your user:  interceptor-install --browser-only --chrome"
+
+%changelog
+EOF
+  # rpmbuild traces its %install/%clean shell with set -x on stderr even when it
+  # succeeds; keep the log and only surface it if the build actually fails.
+  if ! rpmbuild --define "_topdir $top" \
+                --define "_rpmdir $top/RPMS" \
+                --buildroot "$buildroot" \
+                -bb "$top/SPECS/interceptor.spec" >"$top/rpmbuild.log" 2>&1; then
+    echo "ERROR: rpmbuild failed:" >&2
+    cat "$top/rpmbuild.log" >&2
+    rm -rf "$top"
+    return 1
+  fi
+  local built
+  built="$(find "$top/RPMS" -name '*.rpm' -type f | head -1)"
+  if [[ -z "$built" ]]; then
+    echo "ERROR: rpmbuild produced no package." >&2
+    rm -rf "$top"
+    return 1
+  fi
+  cp "$built" "$out"
+  rm -rf "$top"
+}
+
+IFS=',' read -r -a FORMAT_LIST <<< "$FORMATS"
+for fmt in "${FORMAT_LIST[@]}"; do
+  case "$fmt" in
+    tar.gz) build_tar ;;
+    deb)
+      if [[ "$LIBC" == "musl" ]]; then
+        echo "==> deb: SKIPPED (musl build; Alpine uses apk, and a musl binary will not run on a dpkg distro)"
+      else
+        build_deb
+      fi
+      ;;
+    rpm)
+      if [[ "$LIBC" == "musl" ]]; then
+        echo "==> rpm: SKIPPED (musl build; a musl binary will not run on an rpm distro)"
+      else
+        build_rpm
+      fi
+      ;;
+    *) echo "ERROR: unknown format '$fmt' (tar.gz | deb | rpm)." >&2; exit 1 ;;
+  esac
+done
+
+echo ""
+echo "Packages in $OUT_DIR:"
+ls -la "$OUT_DIR" | grep -E "$BASENAME" || true

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,6 +6,10 @@
 #     /Library/Application Support/Interceptor (system locations — needs sudo)
 #   • Developer install (install.sh): repo-relative, no sudo
 #
+# Runs on macOS and Linux. The macOS-only steps (LaunchAgent, .app bundle,
+# pkgutil receipts) are individually guarded and no-op elsewhere; the
+# native-messaging manifest paths switch on `uname -s`.
+#
 # --bridge-only flag downgrades a full install back to browser-only by
 # removing ONLY the Swift-bridge artifacts (LaunchAgent + .app + symlink),
 # leaving the daemon / CLI / extension / native-messaging manifest in place.
@@ -38,11 +42,45 @@ for arg in "$@"; do
   esac
 done
 
+PLATFORM="$(uname -s)"   # Darwin | Linux
+
 USER_HOME="${USER_HOME_OVERRIDE:-$HOME}"
-# Honor sudo: prefer the GUI user's home so we clean per-user files even when
-# uninstall is run as root.
-if [[ -n "${SUDO_USER:-}" && -d "/Users/$SUDO_USER" ]]; then
-  USER_HOME="/Users/$SUDO_USER"
+# Honor sudo: prefer the invoking user's home so we clean per-user files even
+# when uninstall is run as root. Home layout is /Users/<name> on macOS and
+# /home/<name> on Linux, so ask the password database rather than guessing;
+# fall back to the macOS convention when getent is unavailable.
+if [[ -n "${SUDO_USER:-}" ]]; then
+  SUDO_USER_HOME=""
+  if command -v getent >/dev/null 2>&1; then
+    SUDO_USER_HOME="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+  fi
+  if [[ -z "$SUDO_USER_HOME" && -d "/Users/$SUDO_USER" ]]; then
+    SUDO_USER_HOME="/Users/$SUDO_USER"
+  fi
+  if [[ -n "$SUDO_USER_HOME" && -d "$SUDO_USER_HOME" ]]; then
+    USER_HOME="$SUDO_USER_HOME"
+  fi
+fi
+
+# Per-user native-messaging manifest locations, per platform. Mirrors
+# nm_dir_for() in scripts/install.sh — anything install.sh can write here,
+# uninstall must be able to remove.
+XDG_CFG="${XDG_CONFIG_HOME:-$USER_HOME/.config}"
+if [[ "$PLATFORM" == "Linux" ]]; then
+  NM_MANIFESTS=(
+    "$XDG_CFG/google-chrome/NativeMessagingHosts/com.interceptor.host.json"
+    "$XDG_CFG/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.interceptor.host.json"
+    "$XDG_CFG/chromium/NativeMessagingHosts/com.interceptor.host.json"
+    # Gecko: one dir per user, outside both the XDG tree and the profile tree.
+    "$USER_HOME/.mozilla/native-messaging-hosts/com.interceptor.host.json"
+  )
+else
+  NM_MANIFESTS=(
+    "$USER_HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.interceptor.host.json"
+    "$USER_HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.interceptor.host.json"
+    "$USER_HOME/Library/Application Support/Google/ChromeForTesting/NativeMessagingHosts/com.interceptor.host.json"
+    "$USER_HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.interceptor.host.json"
+  )
 fi
 
 PATH_MARKER_START="# >>> interceptor path >>>"
@@ -57,7 +95,7 @@ if [[ "$BRIDGE_ONLY" == "1" ]]; then
   rm -f /tmp/interceptor-bridge.sock /tmp/interceptor-bridge.pid
 
   echo "==> Removing bridge LaunchAgent..."
-  TARGET_UID="$(id -u "${SUDO_USER:-$USER}" 2>/dev/null || echo "")"
+  TARGET_UID="$(id -u "${SUDO_USER:-$(id -un)}" 2>/dev/null || id -u)"
   if [[ -n "$TARGET_UID" ]]; then
     launchctl bootout "gui/$TARGET_UID/com.interceptor.bridge" 2>/dev/null || true
   fi
@@ -100,22 +138,42 @@ rm -f /tmp/interceptor.sock /tmp/interceptor.pid
 rm -f /tmp/interceptor-bridge.sock /tmp/interceptor-bridge.pid
 
 echo "==> Removing native messaging manifests..."
-rm -f "$USER_HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.interceptor.host.json"
-rm -f "$USER_HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.interceptor.host.json"
-rm -f "$USER_HOME/Library/Application Support/Google/ChromeForTesting/NativeMessagingHosts/com.interceptor.host.json"
-rm -f "$USER_HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.interceptor.host.json"
+for manifest in "${NM_MANIFESTS[@]}"; do
+  rm -f "$manifest"
+done
+
+# Read the CLI-link record BEFORE the generated dirs below are deleted — the
+# record lives inside one of them. install.sh writes the exact path it linked
+# (it honors --link-cli-dir, so the conventional locations are not enough).
+CLI_LINK_RECORDS=(
+  "${XDG_STATE_HOME:-$USER_HOME/.local/state}/interceptor/cli-link"
+  "$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)/daemon/.generated/cli-link"
+)
+RECORDED_LINKS=()
+for record in "${CLI_LINK_RECORDS[@]}"; do
+  [[ -f "$record" ]] || continue
+  while IFS= read -r recorded; do
+    [[ -n "$recorded" ]] && RECORDED_LINKS+=("$recorded")
+  done < "$record"
+  rm -f "$record"
+done
 
 # Dev install — clean repo-relative generated dir if present
 if [[ -d "$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)/daemon/.generated" ]]; then
   rm -rf "$(cd "$(dirname "$0")/.." && pwd)/daemon/.generated"
 fi
+# System install (deb/rpm under a root-owned /opt) — install.sh writes the
+# resolved manifests to the XDG state home instead.
+rm -f "${XDG_STATE_HOME:-$USER_HOME/.local/state}/interceptor/com.interceptor.host.json" \
+      "${XDG_STATE_HOME:-$USER_HOME/.local/state}/interceptor/com.interceptor.host.firefox.json"
+rmdir "${XDG_STATE_HOME:-$USER_HOME/.local/state}/interceptor" 2>/dev/null || true
 
 echo "==> Removing extension metadata from old installs if present..."
 rm -f "$USER_HOME/Library/Application Support/Google/Chrome/External Extensions/hkjbaciefhhgekldhncknbjkofbpenng.json"
 rm -f "$USER_HOME/Library/Application Support/BraveSoftware/Brave-Browser/External Extensions/hkjbaciefhhgekldhncknbjkofbpenng.json"
 
 echo "==> Removing bridge LaunchAgent (both system and per-user paths)..."
-TARGET_UID="$(id -u "${SUDO_USER:-$USER}" 2>/dev/null || echo "")"
+TARGET_UID="$(id -u "${SUDO_USER:-$(id -un)}" 2>/dev/null || id -u)"
 if [[ -n "$TARGET_UID" ]]; then
   launchctl bootout "gui/$TARGET_UID/com.interceptor.bridge" 2>/dev/null || true
 fi
@@ -154,9 +212,28 @@ if [[ -e "/Library/Application Support/Interceptor" ]]; then
     echo "    /Library/Application Support/Interceptor — re-run with sudo"
 fi
 
-# Forget the package receipts so a future reinstall starts clean.
-pkgutil --pkgs 2>/dev/null | grep -E '^com\.interceptor\.' | while read -r p; do
-  pkgutil --forget "$p" >/dev/null 2>&1 || true
+# Forget the package receipts so a future reinstall starts clean. macOS-only:
+# pkgutil does not exist on Linux, and under `set -euo pipefail` the resulting
+# empty pipeline exits non-zero and would abort the rest of the uninstall.
+if command -v pkgutil >/dev/null 2>&1; then
+  pkgutil --pkgs 2>/dev/null | grep -E '^com\.interceptor\.' | while read -r p; do
+    pkgutil --forget "$p" >/dev/null 2>&1 || true
+  done
+fi
+
+echo "==> Removing CLI PATH symlinks created by install.sh..."
+# Only ever remove a symlink that points into an Interceptor install — a real
+# file, or a link to something else, belongs to the user or another package.
+for link in "${RECORDED_LINKS[@]+"${RECORDED_LINKS[@]}"}" \
+            "$USER_HOME/.local/bin/interceptor" "/usr/local/bin/interceptor" \
+            "${XDG_BIN_HOME:-$USER_HOME/.local/bin}/interceptor"; do
+  [[ -L "$link" ]] || continue
+  target="$(readlink -f "$link" 2>/dev/null || true)"
+  case "$target" in
+    */interceptor)
+      rm -f "$link" 2>/dev/null && echo "    removed $link -> $target" || \
+        echo "    $link — re-run with sudo" ;;
+  esac
 done
 
 echo "==> Removing legacy CLI install directory if present..."
@@ -172,5 +249,7 @@ echo ""
 echo "Interceptor uninstalled."
 echo ""
 echo "Remove the browser extension manually if it is still present:"
-echo "  Brave:  brave://extensions/"
-echo "  Chrome: chrome://extensions/"
+echo "  Brave:    brave://extensions/"
+echo "  Chrome:   chrome://extensions/"
+echo "  Chromium: chrome://extensions/"
+echo "  Firefox:  about:addons  (temporary add-ons are dropped when Firefox quits)"

--- a/shared/platform.ts
+++ b/shared/platform.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+
 export type PlatformName = "win32" | "darwin" | string
 
 export type PlatformConfig = {
@@ -49,6 +51,57 @@ export const EVENTS_PATH = current.eventsPath
 export const MONITOR_SESSIONS_DIR = current.monitorSessionsDir
 export const MAINTENANCE_GUARD_PATH = current.maintenanceGuardPath
 export const EVENTS_MAX_SIZE = 10 * 1024 * 1024
+
+/**
+ * Is `pid` a live process — counting a zombie as dead?
+ *
+ * `process.kill(pid, 0)` is the usual liveness probe, but it succeeds for a
+ * zombie: an exited child whose parent has not reaped it still owns its PID and
+ * still accepts signal 0. That matters on Linux specifically, because the daemon
+ * is spawned detached and gets reparented to PID 1 — and in a container PID 1 is
+ * frequently the app's own entrypoint rather than an init that reaps (plain
+ * `docker run` without `--init`, most CI containers, many Kubernetes pods). There
+ * the exited daemon stays a zombie forever, so a bare kill(pid, 0) reports a
+ * daemon that is long gone as running: `interceptor daemon stop` then waits out
+ * its whole timeout and exits non-zero on a daemon it successfully stopped.
+ *
+ * Linux exposes the real answer in /proc/<pid>/stat field 3 (state); "Z" is a
+ * zombie. Read that when /proc is available and fall back to the signal probe
+ * everywhere else (macOS has no /proc, and its launchd always reaps).
+ */
+export function isProcessAlive(pid: number, readStat: (path: string) => string = (p) => readFileSync(p, "utf-8")): boolean {
+  try {
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+  if (process.platform !== "linux") return true
+  try {
+    const stat = readStat(`/proc/${pid}/stat`)
+    // comm (field 2) is parenthesized and may itself contain spaces/parens, so
+    // split after the LAST ')' — state is the first token after it.
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 1).trim()
+    const state = afterComm.split(/\s+/)[0]
+    return state !== "Z"
+  } catch {
+    // No /proc entry (already reaped, or /proc not mounted): trust the signal probe.
+    return true
+  }
+}
+
+/**
+ * Does this host have an OS-level trusted-input backend?
+ *
+ * Only macOS does: daemon/os-input.ts drives CoreGraphics CGEvents, and both
+ * the Windows stub (daemon/os-input-win.ts) and the non-Darwin branch of
+ * os-input.ts return an explicit "not supported" sentinel. The extension
+ * reports this layer as available whenever a daemon is connected — it has no
+ * way to see the host OS — so the CLI corrects the answer for `capabilities`
+ * rather than letting an agent plan around a layer that cannot fire here.
+ */
+export function osInputSupported(platform: PlatformName = process.platform): boolean {
+  return platform === "darwin"
+}
 
 // File-upload transport sizing. The `upload` verb ships file bytes
 // base64-encoded inside the command JSON. Three limits gate the path:

--- a/test/context-uniqueness.test.ts
+++ b/test/context-uniqueness.test.ts
@@ -12,6 +12,44 @@ function socket(sent: string[] = []): ContextSocket {
   }
 }
 
+describe("registration ack — host OS-input capability", () => {
+  // The extension cannot see the host OS from a service worker, so the daemon
+  // reports it here. Without the flag the extension assumes an OS-input lane
+  // exists and escalates clicks into it; on Linux/Windows that escalation
+  // always fails and reports a click that DID land as a total failure.
+  test("omits osInput entirely when the daemon does not report it", () => {
+    const message = contextRegisteredMessage("work")
+    expect(message).toEqual({ type: "context_registered", contextId: "work" })
+    expect("osInput" in message).toBe(false)
+  })
+
+  test("carries osInput:false for a host with no OS-input backend", () => {
+    expect(contextRegisteredMessage("work", false)).toEqual({
+      type: "context_registered",
+      contextId: "work",
+      osInput: false,
+    })
+  })
+
+  test("carries osInput:true on a host that has one", () => {
+    expect(contextRegisteredMessage("work", true)).toEqual({
+      type: "context_registered",
+      contextId: "work",
+      osInput: true,
+    })
+  })
+
+  test("claimContextId forwards the flag into the ack it hands the socket", () => {
+    const map = new Map<string, ContextSocket>()
+    const result = claimContextId(map, socket(), "work", false)
+    expect(result.message).toEqual({
+      type: "context_registered",
+      contextId: "work",
+      osInput: false,
+    })
+  })
+})
+
 describe("context name uniqueness guard", () => {
   test("allows first registration", () => {
     const map = new Map<string, ContextSocket>()

--- a/test/diagnose-lockfile.test.ts
+++ b/test/diagnose-lockfile.test.ts
@@ -18,6 +18,19 @@ const LOCK: LockFileData = {
   mode: "standalone",
 }
 
+// installedNmhManifests() scans the platform's real native-messaging layout:
+// ~/Library/Application Support/<vendor dir> on macOS, $XDG_CONFIG_HOME (or
+// ~/.config) on Linux, and a different browser set on each. Build fixtures in
+// whichever shape the host uses so the same assertions hold on both.
+const IS_LINUX = process.platform === "linux"
+const NMH_ROOT_REL = IS_LINUX ? ".config" : "Library/Application Support"
+const NMH_DIRS: Record<string, string> = IS_LINUX
+  ? { chrome: "google-chrome", brave: "BraveSoftware/Brave-Browser" }
+  : { chrome: "Google/Chrome", brave: "BraveSoftware/Brave-Browser", "chrome-canary": "Google/Chrome Canary" }
+// A configurable browser other than the one the primary cases use, so
+// "non-default browser" coverage stays meaningful on both platforms.
+const SECOND_BROWSER = IS_LINUX ? "chrome" : "chrome-canary"
+
 let dir: string
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "interceptor-lock-test-")) })
 afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
@@ -72,13 +85,10 @@ describe("binary mismatch detection", () => {
 
   function fixtureHome(manifests: Record<string, { path?: string } | "corrupt">): string {
     const home = join(dir, "home")
-    const dirs: Record<string, string> = {
-      chrome: "Google/Chrome",
-      brave: "BraveSoftware/Brave-Browser",
-      "chrome-canary": "Google/Chrome Canary",
-    }
+    const dirs = NMH_DIRS
     for (const [browser, content] of Object.entries(manifests)) {
-      const nmhDir = join(home, "Library/Application Support", dirs[browser], "NativeMessagingHosts")
+      if (!dirs[browser]) continue
+      const nmhDir = join(home, NMH_ROOT_REL, dirs[browser], "NativeMessagingHosts")
       mkdirSync(nmhDir, { recursive: true })
       writeFileSync(
         join(nmhDir, "com.interceptor.host.json"),
@@ -114,11 +124,11 @@ describe("binary mismatch detection", () => {
   test("covers non-default browsers from the install.sh set", async () => {
     fixtureHome({
       brave: { path: LOCK.execPath },
-      "chrome-canary": { path: "/stale/dev/build" },
+      [SECOND_BROWSER]: { path: "/stale/dev/build" },
     })
     const mismatches = await detect(LOCK)
     expect(mismatches).toEqual([
-      { browser: "chrome-canary", manifestPath: "/stale/dev/build", runningPath: LOCK.execPath },
+      { browser: SECOND_BROWSER, manifestPath: "/stale/dev/build", runningPath: LOCK.execPath },
     ])
   })
 
@@ -157,7 +167,7 @@ describe("context-kind-aware probes", () => {
 describe("interceptor diagnose (spawned, no daemon)", () => {
   test("--json reports daemon down + mismatch from fixtures, never spawns a daemon", () => {
     const home = join(dir, "home")
-    const nmhDir = join(home, "Library/Application Support/Google/Chrome/NativeMessagingHosts")
+    const nmhDir = join(home, NMH_ROOT_REL, NMH_DIRS.chrome, "NativeMessagingHosts")
     mkdirSync(nmhDir, { recursive: true })
     writeFileSync(join(nmhDir, "com.interceptor.host.json"), JSON.stringify({ path: "/somewhere/else" }), "utf-8")
 

--- a/test/helpers/macos-tools.ts
+++ b/test/helpers/macos-tools.ts
@@ -1,0 +1,35 @@
+/**
+ * test/helpers/macos-tools.ts — availability probes for the base-macOS command
+ * line tools some daemon/ios code shells out to.
+ *
+ * The iOS surface only ever runs on a macOS host (usbmux, codesign, Xcode), so
+ * `daemon/ios/*` is free to call /usr/bin/plutil and /usr/bin/security directly.
+ * Their tests inherit that dependency. On a Linux host — a Linux port build, or
+ * CI running the suite in a container — those binaries do not exist and the
+ * affected tests fail with "Executable not found in $PATH" rather than telling
+ * anyone anything about the code.
+ *
+ * Gate on the tool, not on `process.platform`: that keeps the tests running
+ * anywhere the dependency is actually satisfied, and keeps the skip reason
+ * honest.
+ */
+
+import { existsSync } from "node:fs"
+
+// Probe the absolute paths the daemon/ios code actually invokes. Do NOT probe by
+// spawning: Bun's spawnSync reports a missing executable as exit status 127 with
+// `error` left undefined, so the obvious `result.error === undefined` check
+// reports every tool as present on a host that has none of them.
+function toolExists(path: string): boolean {
+  try {
+    return existsSync(path)
+  } catch {
+    return false
+  }
+}
+
+/** Apple's property-list converter — used to build/validate real bplist00 bytes. */
+export const HAS_PLUTIL = toolExists("/usr/bin/plutil")
+
+/** Apple's keychain CLI — used by daemon/ios/keychain.ts to store the Apple-ID token. */
+export const HAS_SECURITY = toolExists("/usr/bin/security")

--- a/test/install-modes.test.ts
+++ b/test/install-modes.test.ts
@@ -35,6 +35,10 @@ const BRAVE_NM_SUBSTR = IS_DARWIN
   ? "BraveSoftware/Brave-Browser/NativeMessagingHosts"
   : ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
 
+// Chromium é alvo só-Linux nesta revisão (o install.sh o adiciona na fase-2 do port). NM dir:
+// `~/.config/chromium/NativeMessagingHosts`.
+const CHROMIUM_NM_SUBSTR = "chromium/NativeMessagingHosts"
+
 /**
  * Whether a browser binary/app is detectable on this platform.
  *
@@ -43,9 +47,10 @@ const BRAVE_NM_SUBSTR = IS_DARWIN
  * that need a specific browser to be auto-detected skip themselves when it's
  * absent so CI without browsers installed stays green.
  */
-function browserInstalled(target: "chrome" | "brave" | "edge" | "vivaldi"): boolean {
+function browserInstalled(target: "chrome" | "brave" | "edge" | "vivaldi" | "chromium"): boolean {
   if (IS_DARWIN) {
-    const apps: Record<typeof target, string> = {
+    if (target === "chromium") return false // chromium é alvo só-Linux neste teste (port fase-2)
+    const apps: Record<"chrome" | "brave" | "edge" | "vivaldi", string> = {
       chrome: "/Applications/Google Chrome.app",
       brave: "/Applications/Brave Browser.app",
       edge: "/Applications/Microsoft Edge.app",
@@ -54,11 +59,14 @@ function browserInstalled(target: "chrome" | "brave" | "edge" | "vivaldi"): bool
     return spawnSync("test", ["-d", apps[target]]).status === 0
   }
   // Edge / Vivaldi on Linux are out of scope in this revision (a follow-up).
-  // Only chrome and brave have Linux install-detection.
+  // chrome, brave e chromium têm detecção de instalação no Linux (chromium veio na fase-2 do port).
   if (target === "edge" || target === "vivaldi") return false
-  const candidates = target === "chrome"
-    ? ["google-chrome", "google-chrome-stable"]
-    : ["brave-browser", "brave"]
+  const candidates =
+    target === "chrome"
+      ? ["google-chrome", "google-chrome-stable"]
+      : target === "chromium"
+        ? ["chromium", "chromium-browser"]
+        : ["brave-browser", "brave"]
   return candidates.some(b => spawnSync("command", ["-v", b], { shell: true }).status === 0)
 }
 
@@ -213,6 +221,12 @@ describe("install browser selection — dry-run", () => {
       expect(stdout).toMatch(/only supported browser found|defaulting to 'brave' \(non-interactive/)
       expect(stdout).toContain("Browser: brave")
       expect(stdout).toContain(BRAVE_NM_SUBSTR)
+    } else if (browserInstalled("chromium")) {
+      // Chromium-only host (Linux; chromium virou alvo de primeira classe na fase-2 do port), então
+      // o install.sh auto-seleciona chromium em vez de abortar.
+      expect(stdout).toMatch(/only supported browser found|defaulting to 'chromium' \(non-interactive/)
+      expect(stdout).toContain("Browser: chromium")
+      expect(stdout).toContain(CHROMIUM_NM_SUBSTR)
     } else {
       // No browser installed — script aborts before NM resolution. Documented exit path.
       expect(status).not.toBe(0)

--- a/test/ios-installer.test.ts
+++ b/test/ios-installer.test.ts
@@ -4,6 +4,7 @@ import {
   installProxyInstallRequest, encodeInstallProxyFrame, tryReadInstallProxyFrame,
 } from "../daemon/ios/installer"
 import { plistToObject } from "../daemon/ios/lockdown"
+import { HAS_PLUTIL } from "./helpers/macos-tools"
 
 // Locks the AFC header (magic + 4×u64 LE) and the installation_proxy request
 // framing (shared 4-byte-BE + plist with lockdown).
@@ -24,7 +25,9 @@ describe("AFC header codec", () => {
   })
 })
 
-describe("installation_proxy request", () => {
+// Asserting the request body means parsing it back with plistToObject,
+// which shells out to /usr/bin/plutil.
+describe.skipIf(!HAS_PLUTIL)("installation_proxy request", () => {
   test("Install carries PackageType Developer + the bundle id", () => {
     const req = installProxyInstallRequest("PublicStaging/Runner.app", "com.interceptor.InterceptorRunner.xctrunner")
     const frame = encodeInstallProxyFrame(req)

--- a/test/ios-instruments.test.ts
+++ b/test/ios-instruments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { nskeyedArchive } from "../daemon/ios/usertunnel"
 import { _decodeReturn } from "../daemon/ios/instruments"
 import { INSTRUMENTS_CHANNEL } from "../shared/ios-dev"
+import { HAS_PLUTIL } from "./helpers/macos-tools"
 
 // Instruments reply decoding: a DTX reply carries the return value nskeyed-encoded
 // in payloadRaw (else the first archived aux entry).
@@ -13,7 +14,8 @@ function auxBytes(archived: Buffer): Buffer {
   return Buffer.concat([nul, h, archived])
 }
 
-describe("instruments reply decode", () => {
+// Fixtures are produced by nskeyedArchive, which shells out to plutil.
+describe.skipIf(!HAS_PLUTIL)("instruments reply decode", () => {
   test("runningProcesses-shaped array from payloadRaw", () => {
     const payloadRaw = nskeyedArchive({ arr: [
       { dict: { pid: { int: 501 }, name: { str: "SpringBoard" } } },

--- a/test/ios-keychain.test.ts
+++ b/test/ios-keychain.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { storeToken, loadToken, deleteToken, hasToken } from "../daemon/ios/keychain"
+import { HAS_SECURITY } from "./helpers/macos-tools"
 
 // Roundtrips the Apple-ID token through the REAL login keychain under a throwaway
 // service name, then deletes it. Verifies the trust boundary: the token
 // lives in the Keychain (via Bun.secrets since issue #244, never on argv), never in
 // state.json.
 
-describe("keychain token store", () => {
+// Every case here drives the REAL login keychain through /usr/bin/security.
+describe.skipIf(!HAS_SECURITY)("keychain token store", () => {
   // Unique per-run-ish service so a crashed prior run can't collide. No Date.now
   // in the value — just a fixed test service we always clean up.
   const ref = { service: "com.interceptor.ios.appleid.test", account: "roundtrip" }

--- a/test/ios-lockdown.test.ts
+++ b/test/ios-lockdown.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   plistNode, buildPlist, encodeLockdownFrame, tryReadLockdownFrame, plistToObject,
 } from "../daemon/ios/lockdown"
+import { HAS_PLUTIL } from "./helpers/macos-tools"
 
 // Locks the lockdown wire format: 4-byte BIG-endian length + XML plist body
 // (distinct from usbmux's little-endian typed header), and the richer plist
@@ -48,7 +49,8 @@ describe("lockdown plist + frame codec", () => {
     expect(second.body.toString()).toContain("<string>B</string>")
   })
 
-  test("plistToObject roundtrips a built plist through plutil", () => {
+  // plistToObject shells out to /usr/bin/plutil; the rest of the codec is pure JS.
+  test.skipIf(!HAS_PLUTIL)("plistToObject roundtrips a built plist through plutil", () => {
     const xml = Buffer.from(buildPlist({ Request: "StartService", Service: "com.apple.afc", Flag: true, N: 5 }))
     const obj = plistToObject(xml)
     expect(obj.Request).toBe("StartService")

--- a/test/ios-nskeyed.test.ts
+++ b/test/ios-nskeyed.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, test } from "bun:test"
 import { nskeyedArchive } from "../daemon/ios/usertunnel"
 import { nskeyedUnarchive } from "../daemon/ios/nskeyed"
 import { decodePlist, PlistUID } from "../daemon/ios/webinspector-plist"
+import { HAS_PLUTIL } from "./helpers/macos-tools"
 
 // Round-trips NSKeyedArchiver: archive a PlistNode → binary plist → unarchive to
 // plain JS. Proves the $objects/CF$UID graph resolves and bounds hold.
 
-describe("nskeyed round-trip", () => {
+// nskeyedArchive builds the object graph as XML and hands it to `plutil
+// -convert binary1`, so the whole suite needs the macOS tool present.
+describe.skipIf(!HAS_PLUTIL)("nskeyed round-trip", () => {
   test("string", () => {
     expect(nskeyedUnarchive(nskeyedArchive({ str: "hello" }))).toBe("hello")
   })

--- a/test/ios-webinspector-plist.test.ts
+++ b/test/ios-webinspector-plist.test.ts
@@ -4,6 +4,7 @@ import {
   decodePlist, decodeBinaryPlist, decodeXmlPlist, encodeXmlPlist, isBinaryPlist,
   PlistError, DEFAULT_PLIST_LIMITS, type PlistValue,
 } from "../daemon/ios/webinspector-plist"
+import { HAS_PLUTIL } from "./helpers/macos-tools"
 
 // Locks the bounded WIR plist codec: binary + XML decode incl. <data>, hard
 // caps that fail before allocation, and well-formed XML encode. Validated
@@ -41,7 +42,8 @@ describe("webinspector plist codec", () => {
     expect((v.__argument.WIRSocketDataKey as Buffer).toString()).toBe("hello-socket-bytes")
   })
 
-  test("binary plist decodes identically to XML (incl. <data> socket payload)", () => {
+  // The three tests below validate against bytes only Apple's plutil can produce.
+  test.skipIf(!HAS_PLUTIL)("binary plist decodes identically to XML (incl. <data> socket payload)", () => {
     const bin = toBinaryPlist(SAMPLE_XML)
     expect(isBinaryPlist(bin)).toBe(true)
     const v = decodeBinaryPlist(bin) as any
@@ -50,13 +52,13 @@ describe("webinspector plist codec", () => {
     expect((v.__argument.WIRSocketDataKey as Buffer).toString()).toBe("hello-socket-bytes")
   })
 
-  test("decodePlist sniffs binary vs XML", () => {
+  test.skipIf(!HAS_PLUTIL)("decodePlist sniffs binary vs XML", () => {
     const bin = toBinaryPlist(SAMPLE_XML)
     expect((decodePlist(bin) as any).__selector).toBe("_rpc_applicationSentListing:")
     expect((decodePlist(Buffer.from(SAMPLE_XML)) as any).__selector).toBe("_rpc_applicationSentListing:")
   })
 
-  test("integers, reals, booleans, nested arrays survive binary encode", () => {
+  test.skipIf(!HAS_PLUTIL)("integers, reals, booleans, nested arrays survive binary encode", () => {
     const obj: PlistValue = { n: 42, big: 70000, neg: -5, f: 1.5, t: true, f2: false, arr: [1, "two", Buffer.from("x")] }
     const bin = toBinaryPlist(encodeXmlPlist(obj))
     const v = decodeBinaryPlist(bin) as any

--- a/test/nmh-locations.test.ts
+++ b/test/nmh-locations.test.ts
@@ -1,0 +1,101 @@
+/**
+ * test/nmh-locations.test.ts
+ *
+ * Where each browser's native-messaging host manifest lives, per platform.
+ *
+ * This is the table `interceptor diagnose` uses to catch a binary mismatch (the
+ * daemon the CLI talks to vs the one the browser would spawn), so a wrong or
+ * missing entry makes the diagnostic silently blind for that browser rather
+ * than noisy. Three shapes have to stay right at once:
+ *
+ *   macOS   ~/Library/Application Support/<vendor>/NativeMessagingHosts
+ *   Linux   $XDG_CONFIG_HOME/<product>/NativeMessagingHosts   (Chromium family)
+ *   Linux   ~/.mozilla/native-messaging-hosts                 (Gecko — NOT XDG,
+ *                                                              and one dir for
+ *                                                              every profile)
+ *
+ * The platform and env are injected, so every case runs on any host.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { installedNmhManifests } from "../cli/lib/status-renderer"
+
+let home: string
+beforeEach(() => { home = mkdtempSync(join(tmpdir(), "interceptor-nmh-")) })
+afterEach(() => { rmSync(home, { recursive: true, force: true }) })
+
+function writeManifest(relativeDir: string): void {
+  const dir = join(home, relativeDir)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "com.interceptor.host.json"), JSON.stringify({ path: "/opt/interceptor/daemon/interceptor-daemon" }), "utf-8")
+}
+
+const linuxEnv = () => ({ HOME: home })
+
+describe("installedNmhManifests — Linux", () => {
+  test("finds the Chromium-family browsers under the XDG config home", () => {
+    writeManifest(".config/google-chrome/NativeMessagingHosts")
+    writeManifest(".config/chromium/NativeMessagingHosts")
+    writeManifest(".config/BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    const found = installedNmhManifests("linux", linuxEnv()).map(m => m.browser).sort()
+    expect(found).toEqual(["brave", "chrome", "chromium"])
+  })
+
+  test("finds Firefox under ~/.mozilla, which is not an XDG path", () => {
+    writeManifest(".mozilla/native-messaging-hosts")
+    const found = installedNmhManifests("linux", linuxEnv())
+    expect(found).toEqual([
+      { browser: "firefox", manifestFile: join(home, ".mozilla/native-messaging-hosts/com.interceptor.host.json") },
+    ])
+  })
+
+  test("honors XDG_CONFIG_HOME for the Chromium family but not for Firefox", () => {
+    const xdg = join(home, "custom-config")
+    mkdirSync(join(xdg, "chromium", "NativeMessagingHosts"), { recursive: true })
+    writeFileSync(join(xdg, "chromium", "NativeMessagingHosts", "com.interceptor.host.json"), "{}", "utf-8")
+    writeManifest(".mozilla/native-messaging-hosts")
+    // A manifest at the DEFAULT ~/.config location must not be found once
+    // XDG_CONFIG_HOME points elsewhere — that would be a false positive.
+    writeManifest(".config/google-chrome/NativeMessagingHosts")
+
+    const found = installedNmhManifests("linux", { HOME: home, XDG_CONFIG_HOME: xdg }).map(m => m.browser).sort()
+    expect(found).toEqual(["chromium", "firefox"])
+  })
+
+  test("no manifests installed → empty, not a throw", () => {
+    expect(installedNmhManifests("linux", linuxEnv())).toEqual([])
+  })
+})
+
+describe("installedNmhManifests — macOS", () => {
+  test("uses the Application Support layout and the macOS browser set", () => {
+    writeManifest("Library/Application Support/Google/Chrome/NativeMessagingHosts")
+    writeManifest("Library/Application Support/Google/Chrome Canary/NativeMessagingHosts")
+    writeManifest("Library/Application Support/Vivaldi/NativeMessagingHosts")
+    const found = installedNmhManifests("darwin", { HOME: home }).map(m => m.browser).sort()
+    expect(found).toEqual(["chrome", "chrome-canary", "vivaldi"])
+  })
+
+  test("the Linux layout is not consulted on darwin", () => {
+    writeManifest(".config/google-chrome/NativeMessagingHosts")
+    writeManifest(".mozilla/native-messaging-hosts")
+    expect(installedNmhManifests("darwin", { HOME: home })).toEqual([])
+  })
+})
+
+describe("installedNmhManifests — Windows", () => {
+  test("returns nothing: Windows registers native hosts in the registry", () => {
+    writeManifest(".config/google-chrome/NativeMessagingHosts")
+    expect(installedNmhManifests("win32", { HOME: home })).toEqual([])
+  })
+})
+
+describe("installedNmhManifests — no HOME", () => {
+  test("returns empty rather than scanning from the filesystem root", () => {
+    expect(installedNmhManifests("linux", {})).toEqual([])
+    expect(installedNmhManifests("darwin", {})).toEqual([])
+  })
+})

--- a/test/process-liveness.test.ts
+++ b/test/process-liveness.test.ts
@@ -1,0 +1,53 @@
+/**
+ * test/process-liveness.test.ts
+ *
+ * isProcessAlive must not count a zombie as running.
+ *
+ * The daemon is spawned detached and reparented to PID 1. On Linux that PID 1 is
+ * frequently not an init that reaps (a container started without --init, most CI
+ * images, many Kubernetes pods), so an exited daemon lingers as a zombie and keeps
+ * answering `kill(pid, 0)`. `interceptor daemon stop` then waits out its full
+ * timeout and exits non-zero on a daemon it successfully stopped, and a stale pid
+ * file makes `status` report a daemon nothing can reach.
+ *
+ * The /proc parsing is exercised through the injectable stat reader, so these
+ * cases run identically on macOS and Linux.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { isProcessAlive } from "../shared/platform"
+
+const IS_LINUX = process.platform === "linux"
+
+describe("isProcessAlive", () => {
+  test("a pid that does not exist is dead on every platform", () => {
+    // 2^22 is above the default pid_max on Linux and unused on macOS.
+    expect(isProcessAlive(4_194_304)).toBe(false)
+  })
+
+  test("the current process is alive", () => {
+    expect(isProcessAlive(process.pid)).toBe(true)
+  })
+
+  test.skipIf(!IS_LINUX)("a zombie /proc state reads as dead", () => {
+    const zombie = () => `${process.pid} (interceptor-dae) Z 1 ${process.pid} 0 -1 4194304 0 0`
+    expect(isProcessAlive(process.pid, zombie)).toBe(false)
+  })
+
+  test.skipIf(!IS_LINUX)("a sleeping /proc state reads as alive", () => {
+    const sleeping = () => `${process.pid} (interceptor-dae) S 1 ${process.pid} 0 -1 4194304 0 0`
+    expect(isProcessAlive(process.pid, sleeping)).toBe(true)
+  })
+
+  test.skipIf(!IS_LINUX)("a comm containing spaces and parens does not shift the state field", () => {
+    // /proc/<pid>/stat quotes comm in parens but does NOT escape parens or
+    // spaces inside it, so the state token is only findable after the LAST ')'.
+    const tricky = () => `${process.pid} (weird ) name (x) Z 1 ${process.pid} 0 -1 4194304 0 0`
+    expect(isProcessAlive(process.pid, tricky)).toBe(false)
+  })
+
+  test.skipIf(!IS_LINUX)("an unreadable /proc entry falls back to the signal probe", () => {
+    const missing = () => { throw new Error("ENOENT") }
+    expect(isProcessAlive(process.pid, missing)).toBe(true)
+  })
+})

--- a/test/secrets-vault.test.ts
+++ b/test/secrets-vault.test.ts
@@ -26,6 +26,20 @@ afterAll(async () => {
   rmSync(dir, { recursive: true, force: true })
 })
 
+// O bloco de round-trip usa o keychain REAL do SO (Bun.secrets → Keychain no macOS, libsecret/
+// Secret Service no Linux). Num container/CI headless não há Secret Service, então `set` lança e o
+// bloco é PULADO (mesma postura env-dependente do ios-keychain no port Linux) em vez de falhar.
+// `delete` engole o erro (retorna false), então a sonda usa `set`, que lança sem backend.
+const KEYCHAIN_OK: boolean = await (async () => {
+  try {
+    await vault.set("__probe__", "x")
+    await vault.delete("__probe__")
+    return true
+  } catch {
+    return false
+  }
+})()
+
 describe("names, gates, targets, durations", () => {
   test("names are bounded and safe", () => {
     expect(assertName("admin")).toBe("admin")
@@ -97,7 +111,7 @@ describe("unlock windows", () => {
   })
 })
 
-describe("store, list, resolve, remove (real keychain, throwaway service)", () => {
+describe.skipIf(!KEYCHAIN_OK)("store, list, resolve, remove (real keychain, throwaway service)", () => {
   test("round trip with metadata and release accounting", async () => {
     const meta = await storeSecret(vault, "roundtrip", "hunter2-value", { targets: "sudo,browser:example.com", metaPath })
     expect(meta.gate).toBe("none")


### PR DESCRIPTION
Ajustar Interceptor para funcionar em Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux support for Chromium, Brave, Chrome, and Firefox, including installation, native messaging, packaging, and CLI PATH linking.
  * Added Firefox extension support and browser-specific setup guidance.
  * Added Linux packages in tar.gz, DEB, and RPM formats where supported.
  * Status and diagnostics now report the detected system browser and configured browsers across macOS and Linux.
  * Capability reporting now reflects OS-level input availability.

* **Bug Fixes**
  * Improved daemon detection for exited or zombie processes.
  * Made browser mismatch warnings browser-neutral.
  * Added clearer handling for unavailable browser APIs and bookmark failures.

* **Documentation**
  * Added Linux installation instructions and a Linux port report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->