### PR TITLE
status/diagnose: keep the Allow User Scripts hint when chrome.userScripts is absent

### DIFF
--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -92,10 +92,9 @@ export function describeEvalMain(
   if (!us.manifest_permission) {
     return { available: false, hint: `this extension copy has no userScripts permission; install the current extension` }
   }
-  if (us.api_present === false) {
-    // No toggle can restore an API the browser does not expose.
-    return { available: false, hint: "chrome.userScripts is not available in this browser (Chrome 120+ exposes it); structured reads (read, find, text, html) do not need it" }
-  }
+  // `api_present: false` is the toggle-off state, not an unsupported browser:
+  // Chrome removes the chrome.userScripts namespace entirely while "Allow User
+  // Scripts" (Developer mode before 138) is off, so the toggle hint applies.
   return {
     available: false,
     hint: `enable "Allow User Scripts" on ${page} (Chrome 138+; on older Chrome turn on Developer mode), then run 'interceptor reload'. Structured reads (read, find, text, html) do not need it.${us.error ? ` Chrome said: ${us.error}` : ""}`,

--- a/test/eval-availability.test.ts
+++ b/test/eval-availability.test.ts
@@ -13,11 +13,12 @@ describe("describeEvalMain", () => {
     expect(s.hint).toContain("chrome://extensions/?id=abcdefghijklmnopabcdefghijklmnop")
     expect(s.hint).toContain("Allow User Scripts")
   })
-  test("an API the browser does not expose is not a toggle problem", () => {
+  test("a missing chrome.userScripts namespace is the toggle-off state, so the toggle hint applies", () => {
+    // Chrome removes the namespace entirely while Allow User Scripts is off;
+    // `api_present: false` is what a working Chrome reports in that state.
     const s = describeEvalMain({ userScripts: { manifest_permission: true, api_present: false, enabled: false } })
     expect(s.available).toBe(false)
-    expect(s.hint).not.toContain("Allow User Scripts")
-    expect(s.hint).toContain("not available in this browser")
+    expect(s.hint).toContain("Allow User Scripts")
   })
   test("no userScripts block means an older extension copy", () => {
     expect(describeEvalMain({}).hint).toContain("older extension copy")


### PR DESCRIPTION
## What

`describeEvalMain` treated `api_present: false` as an unsupported browser. It is the toggle-off state: `api_present` is `!!chrome.userScripts`, and Chrome removes that namespace entirely while "Allow User Scripts" (Developer mode before 138) is off. A normal Chromium profile with the toggle off was told the browser lacks the API. The toggle hint is restored for that case and the test asserts it.

## Verified

- `bun run typecheck` 0; `bun test` for the status renderer suites 10 pass / 0 fail; full suite unchanged otherwise.
- Live on the installed 0.26.1 build the misdiagnosis reproduced on the main profile before the change.

Follow-up to #261.